### PR TITLE
Update to Ubuntu Bionic, fix mongodb support on Ubuntu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
               libgtkmm-3.0-dev \
               libmodbus-dev \
               libmodbus-dev \
+              libmongoclient-dev \
               libncurses5-dev \
               libncursesw5-dev \
               libprotobuf-dev \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: make all
   build_ubuntu:
     docker:
-      - image: ubuntu:xenial
+      - image: ubuntu:bionic
     steps:
       - run:
           name: Install dependencies

--- a/src/libs/mongodb_log/mongodb.mk
+++ b/src/libs/mongodb_log/mongodb.mk
@@ -30,7 +30,7 @@ ifneq ($(wildcard /usr/include/mongo/client/dbclient.h /usr/local/include/mongo/
     LDFLAGS_MONGODB = -lm -lpthread \
 		      $(call boost-libs-ldflags,thread system filesystem) \
 		      $(LDFLAGS_LIBSSL)
-    ifneq ($(wildcard $(SYSROOT)/usr/lib/libmongoclient.so $(SYSROOT)/usr/lib64/libmongoclient.so $(SYSROOT)/usr/local/lib/libmongoclient.so $(SYSROOT)/usr/local/lib64/libmongoclient.so),)
+    ifneq ($(wildcard $(SYSROOT)/usr/lib/libmongoclient.so $(SYSROOT)/usr/lib64/libmongoclient.so $(SYSROOT)/usr/local/lib/libmongoclient.so $(SYSROOT)/usr/local/lib64/libmongoclient.so $(SYSROOT)/usr/lib/x86_64-linux-gnu/libmongoclient.so $(SYSROOT)/usr/local/lib/x86_64-linux-gnu/libmongoclient.so),)
       # we are linking against a shared library, add to link flags
       LDFLAGS_MONGODB += -lmongoclient
     endif


### PR DESCRIPTION
Update to the latest Ubuntu LTS, install the missing package `libmongoclient-dev` into the Ubuntu environment, and fix an error that caused underlinking on Ubuntu.

This fixes #11.