### PR TITLE
circleci: fail if a warning occurs during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
               which \
               yaml-cpp-devel
       - checkout
-      - run: make all
+      - run: make all FAIL_ON_WARNING=1
   build_ubuntu:
     docker:
       - image: ubuntu:bionic
@@ -61,7 +61,7 @@ jobs:
               libyaml-cpp-dev \
               protobuf-compiler
       - checkout
-      - run: make all
+      - run: make all FAIL_ON_WARNING=1
 workflows:
   version: 2
   build:

--- a/etc/buildsys/base.mk
+++ b/etc/buildsys/base.mk
@@ -28,14 +28,3 @@ ifneq ($(OBJDIR),$(notdir $(CURDIR)))
 else
   include $(BUILDSYSDIR)/rules.mk
 endif
-
-ifeq ($(FAIL_ON_WARNING),1)
-  ifneq ($(WARN_TARGETS),)
-all: fail_on_warning
-  endif
-endif
-
-.PHONY: fail_on_warning
-fail_on_warning:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)A warning occurred and all warnings are considered to be errors!$(TNORMAL) Build with FAIL_ON_WARNING=0 to disable."
-	$(SILENT)exit 1

--- a/etc/buildsys/base.mk
+++ b/etc/buildsys/base.mk
@@ -29,3 +29,13 @@ else
   include $(BUILDSYSDIR)/rules.mk
 endif
 
+ifeq ($(FAIL_ON_WARNING),1)
+  ifneq ($(WARN_TARGETS),)
+all: $(WARN_TARGETS) fail_on_warning
+  endif
+endif
+
+.PHONY: fail_on_warning
+fail_on_warning:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)A warning occurred and all warnings are considered to be errors!$(TNORMAL) Build with FAIL_ON_WARNING=0 to disable."
+	$(SILENT)exit 1

--- a/etc/buildsys/base.mk
+++ b/etc/buildsys/base.mk
@@ -31,7 +31,7 @@ endif
 
 ifeq ($(FAIL_ON_WARNING),1)
   ifneq ($(WARN_TARGETS),)
-all: $(WARN_TARGETS) fail_on_warning
+all: fail_on_warning
   endif
 endif
 

--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -69,15 +69,27 @@ endif
 # Dependencies
 -include $(DEPDIR)/*.d
 
+ifeq ($(FAIL_ON_WARNING),1)
+  ifneq ($(WARN_TARGETS),)
+    WARN_FAIL_TARGET=fail_on_warning
+  endif
+endif
+
 # One to build 'em all
 .PHONY: all gui
 ifeq ($(MAKELEVEL),1)
   EXTRA_ALL = $(LIBS_gui) $(PLUGINS_gui) $(BINS_gui) $(TARGETS_gui) $(MANPAGES_gui)
 endif
-all: presubdirs $(LIBS_all:%.so=%.$(SOEXT)) $(PLUGINS_all:%.so=%.$(SOEXT)) $(BINS_all) $(MANPAGES_all) $(TARGETS_all) $(EXTRA_ALL) subdirs
-gui: presubdirs $(LIBS_gui:%.so=%.$(SOEXT)) $(PLUGINS_gui:%.so=%.$(SOEXT)) $(BINS_gui) $(MANPAGES_gui) $(TARGETS_gui) subdirs
+all: presubdirs $(WARN_FAIL_TARGET) $(LIBS_all:%.so=%.$(SOEXT)) $(PLUGINS_all:%.so=%.$(SOEXT)) $(BINS_all) $(MANPAGES_all) $(TARGETS_all) $(EXTRA_ALL) subdirs
+gui: presubdirs $(WARN_FAIL_TARGET) $(LIBS_gui:%.so=%.$(SOEXT)) $(PLUGINS_gui:%.so=%.$(SOEXT)) $(BINS_gui) $(MANPAGES_gui) $(TARGETS_gui) subdirs
 uncolored-all: all
 uncolored-gui: gui
+
+.PHONY: fail_on_warning
+fail_on_warning:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Warnings are considered to be errors!$(TNORMAL)" \
+	                 "Build with FAIL_ON_WARNING=0 to disable."
+	$(SILENT)exit 1
 
 ifdef OBJS_all
 ifneq ($(OBJS_all),)

--- a/src/refbox/Makefile
+++ b/src/refbox/Makefile
@@ -71,9 +71,11 @@ endif
 
 ifeq ($(OBJSSUBMAKE),1)
 all: $(WARN_TARGETS) $(WARN_TARGETS_BOOST)
-.PHONY: warning_libmodbus warning_clips
+.PHONY: warning_libmodbus warning_protobuf warning_clips warning_mongodb $(WARN_TARGETS_BOOST)
 warning_libmodbus:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build LLSF RefBox$(TNORMAL) (libmodbus not found)"
+warning_protobuf:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build LLSF RefBox$(TNORMAL) (protobuf not found)"
 warning_clips:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build LLSF RefBox$(TNORMAL) (clipsmm not found)"
 warning_mongodb:


### PR DESCRIPTION
This adds an option to fail if any warning occurred, which is enabled by calling `make FAIL_ON_WARNING=1`.

Enable the option in all circleci build to avoid silent regressions.