### PR TITLE
circleci: switch from Fedora 28 to Fedora 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_fedora:
     docker:
-      - image: fedora:28
+      - image: fedora:29
     steps:
       - run:
           name: Install dependencies


### PR DESCRIPTION
Fedora 29 is the latest Fedora release, we should use that for CircleCI.