### PR TITLE
Remove gate from DS prepare msg

### DIFF
--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -299,7 +299,7 @@
 )
 
 (defrule prod-proc-state-processing-ds-start
-  "BS must be instructed to dispense base for processing"
+  "Instruct DS to start processing"
   (declare (salience ?*PRIORITY_HIGHER*))
   (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt))
   (order (id ?order) (delivery-gate ?gate))

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -101,12 +101,16 @@
 	      (if (pb-has-field ?p "instruction_ds")
 	       then
 	        (bind ?prepmsg (pb-field-value ?p "instruction_ds"))
-		(bind ?gate (pb-field-value ?prepmsg "gate"))
-		(bind ?order (pb-field-value ?prepmsg "order_id"))
-		(printout t "Prepared " ?mname " (gate: " ?gate ", order: " ?order ")" crlf)
-	        (modify ?m (state PREPARED) (ds-gate ?gate) (ds-order ?order)
+		(bind ?order-id (pb-field-value ?prepmsg "order_id"))
+		(if (any-factp ((?order order)) (eq ?order:id ?order-id))
+		 then
+			(printout t "Prepared " ?mname " (order: " ?order-id ")" crlf)
+			(modify ?m (state PREPARED) (ds-order ?order-id)
                            (mps-state AVAILABLE) (wait-for-product-since ?gt))
-                           ;(wait-for-product-since ?gt))
+		else
+			(modify ?m (state BROKEN) (prev-state ?m:state)
+			  (broken-reason (str-cat "Prepare received for " ?mname " with invalid order ID")))
+		)
                else
 		(modify ?m (state BROKEN) (prev-state ?m:state)
 			(broken-reason (str-cat "Prepare received for " ?mname " without data")))
@@ -298,13 +302,13 @@
   "BS must be instructed to dispense base for processing"
   (declare (salience ?*PRIORITY_HIGHER*))
   (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt))
-  ?m <- (machine (name ?n) (mtype DS) (state PREPARED) (proc-state ~PREPARED)
-		 (ds-gate ?gate))
+  (order (id ?order) (delivery-gate ?gate))
+  ?m <- (machine (name ?n) (mtype DS) (state PREPARED) (proc-state ~PREPARED))
   =>
   (printout t "Machine " ?n " of type DS switching to PREPARED state" crlf)
   (modify ?m (proc-state PREPARED) (desired-lights GREEN-BLINK)
              (prep-blink-start ?gt))
-  (printout t "Machine " ?n " processing to gate " ?gate crlf)
+  (printout t "Machine " ?n " processing to gate " ?gate " for order " ?order crlf)
   (mps-ds-process (str-cat ?n) ?gate)
 )
 

--- a/src/msgs/MachineInstructions.proto
+++ b/src/msgs/MachineInstructions.proto
@@ -61,7 +61,8 @@ message PrepareInstructionBS {
 }
 
 message PrepareInstructionDS {
-  required uint32 gate = 1;
+  reserved "gate";
+  reserved 1;
   required uint32 order_id = 2;
 }
 

--- a/src/shell/machine.cpp
+++ b/src/shell/machine.cpp
@@ -321,7 +321,7 @@ LLSFRefBoxShellMachine::refresh()
     if (minfo_ && minfo_->has_instruction_ds()) {
       attron(' '|COLOR_PAIR(COLOR_BLACK_ON_BACK));
       addstr(0, 26, (boost::str(boost::format("%u")
-				% minfo_->instruction_ds().gate())).c_str());
+				% minfo_->instruction_ds().order_id())).c_str());
     } else {
       attron(' '|COLOR_PAIR(COLOR_BLACK_ON_BACK));
       addstr(0, 26, "  ");

--- a/src/tools/rcll-prepare-machine.cpp
+++ b/src/tools/rcll-prepare-machine.cpp
@@ -57,7 +57,6 @@ std::string machine_name_;
 std::string machine_type_;
 llsf_msgs::MachineSide bs_side_;
 llsf_msgs::BaseColor   bs_color_;
-int ds_gate_;
 int ds_order_id_;
 llsf_msgs::SSOp ss_op_;
 int ss_slot_x_;
@@ -171,7 +170,6 @@ handle_message(boost::asio::ip::udp::endpoint &sender,
 	       llsf_msgs::BaseColor_Name(bs_color_).c_str());
       } else if (machine_type_ == "DS") {
 	llsf_msgs::PrepareInstructionDS *prep_ds = prep.mutable_instruction_ds();
-	prep_ds->set_gate(ds_gate_);
 	prep_ds->set_order_id(ds_order_id_);
       } else if (machine_type_ == "SS") {
 	llsf_msgs::PrepareInstructionSS *prep_ss = prep.mutable_instruction_ss();
@@ -202,7 +200,7 @@ usage(const char *progname)
 	 "\n"
 	 "instructions are specific for the machine type:\n"
 	 "BS:  (INPUT|OUTPUT) (BASE_RED|BASE_BLACK|BASE_SILVER)\n"
-	 "DS:  <order_id> <gate number>\n"
+	 "DS:  <order_id>\n"
 	 "SS:  (RETRIEVE|STORE) <slot-x> <slot-y> <slot-z>\n"
 	 "RS:  (RING_BLUE|RING_GREEN|RING_ORANGE|RING_YELLOW)\n"
 	 "CS:  (RETRIEVE_CAP|MOUNT_CAP)\n",
@@ -237,13 +235,12 @@ main(int argc, char **argv)
       printf("Invalid base color\n"); exit(-2);
     }
   } else if (machine_type_ == "DS") {
-    if (argp.num_items() != 4) {
-      printf("Wrong number of arguments. Expected 4, got %zu\n", argp.num_items());
+    if (argp.num_items() != 3) {
+      printf("Wrong number of arguments. Expected 3, got %zu\n", argp.num_items());
       usage(argv[0]);
       exit(-1);
     }
     ds_order_id_ = argp.parse_item_int(2);
-    ds_gate_  = argp.parse_item_int(3);
   } else if (machine_type_ == "SS") {
     if (argp.num_items() < 6) {
       printf("SS machine requires operation and x, y, z arguments %zu\n", argp.num_items());


### PR DESCRIPTION
Remove the gate from the prepare message of the delivery station. When processing the message, get the correct gate from the respective order fact instead. If no order exists for the order ID given in the prepare message, set the DS to broken.

In the shell, display the order ID instead of the gate, which is more useful information anyway.

Also adapt the `rcll-prepare-machine` tool accordingly.

This implements robocup-logistics/rcll-rulebook#21.