### PR TITLE
Provide a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,4 @@ RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && /sbin/ldconfig
 RUN dnf install -y --nodocs 'dnf-command(copr)' && \
     dnf -y copr enable thofmann/freeopcua && \
     dnf install -y --nodocs $(cat /requires.txt) && dnf clean all && rm /requires.txt
+CMD ["llsf-refbox"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Dockerfile
+# Copyright (C) 2019 Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#
+# Distributed under terms of the MIT license.
+#
+FROM fedora:29 as buildenv
+RUN dnf install -y --nodocs \
+      avahi-devel \
+      boost-devel \
+      clips-devel \
+      clipsmm-devel \
+      gcc-c++ \
+      gecode-devel \
+      git \
+      glibmm24-devel \
+      gtkmm30-devel \
+      mongodb-devel \
+      ncurses-devel \
+      openssh-clients \
+      openssl-devel \
+      protobuf-compiler \
+      protobuf-devel \
+      which \
+      yaml-cpp-devel \
+    && \
+    dnf install -y --nodocs 'dnf-command(copr)' && \
+    dnf -y copr enable thofmann/freeopcua && \
+    dnf install -y --nodocs freeopcua-devel && \
+    dnf install -y --nodocs rpm-build && \
+    dnf clean all
+COPY . /buildenv/
+SHELL ["/usr/bin/bash", "-c"]
+WORKDIR /buildenv
+RUN make -j`nproc` -l`nproc` FAIL_ON_WARNING=1 \
+    EXEC_CONFDIR=/etc/rcll-refbox EXEC_BINDIR=/usr/local/bin EXEC_LIBDIR=/usr/local/lib64
+# Compute the dependencies and store them in requires.txt
+RUN shopt -s globstar; \
+    /usr/lib/rpm/rpmdeps -P lib/** bin/** > provides.txt && \
+    /usr/lib/rpm/rpmdeps -R lib/** bin/** | grep -v -f provides.txt > requires.txt
+
+FROM fedora:29
+COPY --from=buildenv /buildenv/bin/* /usr/local/bin/
+COPY --from=buildenv /buildenv/lib/* /usr/local/lib64/
+COPY --from=buildenv /buildenv/cfg/* /etc/rcll-refbox/
+COPY --from=buildenv /buildenv/requires.txt /
+RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && /sbin/ldconfig
+RUN dnf install -y --nodocs 'dnf-command(copr)' && \
+    dnf -y copr enable thofmann/freeopcua && \
+    dnf install -y --nodocs $(cat /requires.txt) && dnf clean all && rm /requires.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-# Dockerfile
-# Copyright (C) 2019 Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#   Dockerfile for the RCLL Refbox
+#   Created on Wed Jun 05 15:12:42 2019
+#   Copyright (C) 2019 Till Hofmann <hofmann@kbsg.rwth-aachen.de>
 #
-# Distributed under terms of the MIT license.
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
 #
+
 FROM fedora:29 as buildenv
 RUN dnf install -y --nodocs \
       avahi-devel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y --nodocs \
 COPY . /buildenv/
 SHELL ["/usr/bin/bash", "-c"]
 WORKDIR /buildenv
-RUN make -j`nproc` -l`nproc` FAIL_ON_WARNING=1 \
+RUN make -j`nproc` -l`nproc` USE_AVAHI=0 FAIL_ON_WARNING=1 \
     EXEC_CONFDIR=/etc/rcll-refbox EXEC_BINDIR=/usr/local/bin EXEC_LIBDIR=/usr/local/lib64 \
     EXEC_SHAREDIR=/usr/local/share/rcll-refbox
 # Compute the dependencies and store them in requires.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ COPY . /buildenv/
 SHELL ["/usr/bin/bash", "-c"]
 WORKDIR /buildenv
 RUN make -j`nproc` -l`nproc` FAIL_ON_WARNING=1 \
-    EXEC_CONFDIR=/etc/rcll-refbox EXEC_BINDIR=/usr/local/bin EXEC_LIBDIR=/usr/local/lib64
+    EXEC_CONFDIR=/etc/rcll-refbox EXEC_BINDIR=/usr/local/bin EXEC_LIBDIR=/usr/local/lib64 \
+    EXEC_SHAREDIR=/usr/local/share/rcll-refbox
 # Compute the dependencies and store them in requires.txt
 RUN shopt -s globstar; \
     /usr/lib/rpm/rpmdeps -P lib/** bin/** > provides.txt && \
@@ -41,6 +42,8 @@ RUN shopt -s globstar; \
 FROM fedora:29
 COPY --from=buildenv /buildenv/bin/* /usr/local/bin/
 COPY --from=buildenv /buildenv/lib/* /usr/local/lib64/
+COPY --from=buildenv /buildenv/src/games /usr/local/share/rcll-refbox/games
+COPY --from=buildenv /buildenv/src/msgs /usr/local/share/rcll-refbox/msgs
 COPY --from=buildenv /buildenv/cfg/* /etc/rcll-refbox/
 COPY --from=buildenv /buildenv/requires.txt /
 RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && /sbin/ldconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ FROM fedora:29
 COPY --from=buildenv /buildenv/bin/* /usr/local/bin/
 COPY --from=buildenv /buildenv/lib/* /usr/local/lib64/
 COPY --from=buildenv /buildenv/src/games /usr/local/share/rcll-refbox/games
-COPY --from=buildenv /buildenv/src/msgs /usr/local/share/rcll-refbox/msgs
+COPY --from=buildenv /buildenv/src/msgs/*.proto /usr/local/share/rcll-refbox/msgs/
 COPY --from=buildenv /buildenv/cfg/* /etc/rcll-refbox/
 COPY --from=buildenv /buildenv/requires.txt /
 RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && /sbin/ldconfig

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -111,7 +111,7 @@ llsfrb:
                     net-send-VersionInfo]
 
   comm:
-    protobuf-dirs: ["@BASEDIR@/src/msgs"]
+    protobuf-dirs: ["@SHAREDIR@/msgs"]
 
     server-port: !tcp-port 4444
     

--- a/etc/buildsys/config.mk
+++ b/etc/buildsys/config.mk
@@ -113,6 +113,7 @@ EXEC_LOGDIR    = $(abspath $(EXEC_BASEDIR)/log)
 EXEC_DOCDIR    = $(abspath $(EXEC_BASEDIR)/doc)
 EXEC_TMPDIR    = /tmp
 EXEC_MANDIR    = $(abspath $(EXEX_DOCDIR)/man)
+EXEC_SHAREDIR  = $(TOP_BASEDIR)/src
 
 # Some paths divert in submodule configuration
 ifeq ($(SUBMODULE_INTERN),1)
@@ -175,6 +176,7 @@ CFLAGS_DEFS      = -DBASEDIR=\"$(abspath $(TOP_BASEDIR))\" \
 		   -DCONFDIR=\"$(EXEC_CONFDIR)\" -DUSERDIR=\"$(EXEC_USERDIR)\" \
 		   -DLOGDIR=\"$(EXEC_LOGDIR)\" -DRESDIR=\"$(EXEC_RESDIR)\" \
 		   -DTMPDIR=\"$(EXEC_TMPDIR)\" -DSRCDIR=\"$(abspath $(SRCDIR))\" \
+		   -DSHAREDIR=\"$(abspath $(EXEC_SHAREDIR))\" \
 		   -DBUILDTYPE=\"$(BUILD_TYPE)\" -DSOEXT=\"$(SOEXT)\"
 
 CFLAGS_MINIMUM   = -fPIC -pthread $(DEFAULT_INCLUDES) $(CFLAGS_DEFS)

--- a/src/libs/core/threading/thread.cpp
+++ b/src/libs/core/threading/thread.cpp
@@ -1295,7 +1295,7 @@ Thread *
 Thread::current_thread()
 {
   if ( THREAD_KEY == PTHREAD_KEYS_MAX ) {
-    throw Exception("No thread has been initialized");
+    return NULL;
   }
   return (Thread *)pthread_getspecific(THREAD_KEY);
 }

--- a/src/libs/netcomm/Makefile
+++ b/src/libs/netcomm/Makefile
@@ -16,8 +16,10 @@
 BASEDIR = ../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 
-ifneq ($(HAVE_AVAHI),1)
-  WARN_TARGETS += warn_avahi
+ifneq ($(USE_AVAHI)$(HAVE_AVAHI),11)
+  ifeq ($(USE_AVAHI),1)
+    WARN_TARGETS += warn_avahi
+  endif
   OMIT_OBJECTS += dns-sd/%
 else
   CFLAGS += $(CFLAGS_AVAHI)

--- a/src/libs/netcomm/netcomm.mk
+++ b/src/libs/netcomm/netcomm.mk
@@ -13,20 +13,23 @@
 #
 #*****************************************************************************
 
-ifneq ($(PKGCONFIG),)
-  HAVE_AVAHI     := $(if $(shell $(PKGCONFIG) --exists 'avahi-client'; echo $${?/1/}),1,0)
-  HAVE_LIBCRYPTO := $(if $(shell $(PKGCONFIG) --exists 'libcrypto'; echo $${?/1/}),1,0)
-  LIBCRYPTO_PKG  := libcrypto
-  ifneq ($(HAVE_LIBCRYPTO),1)
-    HAVE_LIBCRYPTO := $(if $(shell $(PKGCONFIG) --exists 'openssl'; echo $${?/1/}),1,0)
-    LIBCRYPTO_PKG  := openssl
+USE_AVAHI ?= 1
+
+ifeq ($(USE_AVAHI),1)
+  ifneq ($(PKGCONFIG),)
+    HAVE_AVAHI     := $(if $(shell $(PKGCONFIG) --exists 'avahi-client'; echo $${?/1/}),1,0)
+    HAVE_LIBCRYPTO := $(if $(shell $(PKGCONFIG) --exists 'libcrypto'; echo $${?/1/}),1,0)
+    LIBCRYPTO_PKG  := libcrypto
+    ifneq ($(HAVE_LIBCRYPTO),1)
+      HAVE_LIBCRYPTO := $(if $(shell $(PKGCONFIG) --exists 'openssl'; echo $${?/1/}),1,0)
+      LIBCRYPTO_PKG  := openssl
+    endif
+  endif
+  ifeq ($(HAVE_AVAHI),1)
+    CFLAGS_AVAHI  = -DHAVE_AVAHI $(shell $(PKGCONFIG) --cflags avahi-client)
+    LDFLAGS_AVAHI = $(shell $(PKGCONFIG) --libs avahi-client)
+  endif
+  ifeq ($(HAVE_LIBCRYPTO),1)
+    CFLAGS += -DHAVE_LIBCRYPTO
   endif
 endif
-ifeq ($(HAVE_AVAHI),1)
-  CFLAGS_AVAHI  = -DHAVE_AVAHI $(shell $(PKGCONFIG) --cflags avahi-client)
-  LDFLAGS_AVAHI = $(shell $(PKGCONFIG) --libs avahi-client)
-endif
-ifeq ($(HAVE_LIBCRYPTO),1)
-  CFLAGS += -DHAVE_LIBCRYPTO
-endif
-

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -106,7 +106,7 @@ LLSFRefBox::LLSFRefBox(int argc, char **argv)
   config_ = new YamlConfiguration(CONFDIR);
   config_->load("config.yaml");
 
-  cfg_clips_dir_ = std::string(BASEDIR) + "/src/games/rcll/";
+  cfg_clips_dir_ = std::string(SHAREDIR) + "/games/rcll/";
 
   try {
     cfg_timer_interval_ = config_->get_uint("/llsfrb/clips/timer-interval");
@@ -386,6 +386,9 @@ LLSFRefBox::setup_protobuf_comm()
 	  }
 	  if ((pos = proto_dirs[i].find("@CONFDIR@")) != std::string::npos) {
 	    proto_dirs[i].replace(pos, 9, CONFDIR);
+	  }
+	  if ((pos = proto_dirs[i].find("@SHAREDIR@")) != std::string::npos) {
+	    proto_dirs[i].replace(pos, 10, SHAREDIR);
 	  }
 	
 	  if (proto_dirs[i][proto_dirs.size()-1] != '/') {


### PR DESCRIPTION
Create a docker image that contains the refbox. In particular:
* Use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to make the image as minimal as possible.
* Compute the dependencies from the built libraries and binaries to
  1. Avoid duplication of the list of packages to be installed
  1. Only install those dependencies that are actually needed.

  This reduces the size of the image considerably.
* Add a build flag to disable avahi support. Avahi currently does not work in a container, at least not in the way that we use it (it results in 100% CPU load). Build the docker image without avahi, the rest with avahi.
* Allow a different location for CLIPS and protobuf msgs files. These are installed in `/usr/local/share` in the resulting image, but they were expected in the `SRCDIR`.
* Also build the image in CircleCI. Note that this image is not pushed, the build is for testing purposes only.
* A Docker Hub repository for the refbox is available [here](https://cloud.docker.com/u/robocuplogistics/repository/docker/robocuplogistics/rcll-refbox/general). You can pull it with `docker pull robocuplogistics/rcll-refbox` (after this is merged). For testing purposes, I created the tag `branch-docker`, which contains the image of this PR. Builds are triggered automatically on pushes to `master` and for every tag.

I will update the Wiki documentation after this has been merged.

For testing:

    $ docker --pull run -ti --net=host robocuplogistics/rcll-refbox:branch-docker

You should be able to connect with your local refbox shell. Alternatively, you can also run the shell in a container:

    $ docker run -ti --net=host -e TERM robocuplogistics/rcll-refbox:branch-docker llsf-refbox-shell
