### PR TITLE
Register callback to read the barcode from the MPS

### DIFF
--- a/src/libs/mps_comm/machine.cpp
+++ b/src/libs/mps_comm/machine.cpp
@@ -127,7 +127,6 @@ void Machine::send_command(unsigned short command, unsigned short payload1, unsi
 				setNodeValue(registerNodes[reg], statusBit, reg);
 				reg = registerOffset + OpcUtils::MPSRegister::ERROR_IN;
 				setNodeValue(registerNodes[reg], (uint8_t)error, reg);
-				logger->info("Finished command: {} {} {} {}", command, payload1, payload2, status);
 				success = true;
 			} catch (std::runtime_error &e) {
 				logger->warn("Failed to send command to {}, reconnecting", name_);

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -516,6 +516,14 @@ LLSFRefBox::setup_clips()
 			  },
 			  OpcUtils::MPSRegister::STATUS_BUSY_IN,
 			  nullptr);
+			mps.second->addCallback(
+			  [this, mps](OpcUtils::ReturnValue *ret) {
+				  fawkes::MutexLocker clips_lock(&clips_mutex_);
+				  clips_->assert_fact_f("(mps-status-feedback %s BARCODE %i)",
+				                        mps.first.c_str(),
+				                        ret->int32_s);
+			  },
+			  OpcUtils::MPSRegister::BARCODE_IN);
 			// TODO proper MPS type check
 			if (mps.first == "C-RS1" || mps.first == "C-RS2" || mps.first == "M-RS1"
 			    || mps.first == "M-RS2") {


### PR DESCRIPTION
In preparation for #15 and #30, register a callback for the barcode and assert a CLIPS fact.

This assumes the barcode to be a `int32`, which may need to be fixed in the PLC code, where it's handled inconsistently (as string and int).