### PR TITLE
rcll: give full production steps in failsafe for late delivery

### DIFF
--- a/src/games/rcll/workpieces.clp
+++ b/src/games/rcll/workpieces.clp
@@ -57,7 +57,7 @@
                                     (confirmed TRUE)
                                     (at-machine ?m:name)
                                     (workpiece ?workpiece-id)
-                                    (game-time ?delivery-time)
+                                    (game-time 0.1)
                                     (base-color ?order:base-color))))
       ;Simulate Ring mouting processes
       (foreach ?r ?order:ring-colors
@@ -68,7 +68,7 @@
                                       (confirmed TRUE)
                                       (at-machine ?m:name)
                                       (workpiece ?workpiece-id)
-                                      (game-time ?delivery-time)
+                                      (game-time 0.1)
                                       (ring-color ?r)))))
       ;Simulate Cap mounting process on a random cap station
       (do-for-fact ((?m machine)) (and (eq ?m:mtype CS) (eq ?m:team ?team))
@@ -77,7 +77,7 @@
                                     (confirmed TRUE)
                                     (at-machine ?m:name)
                                     (workpiece ?workpiece-id)
-                                    (game-time ?delivery-time)
+                                    (game-time 0.1)
                                     (cap-color ?order:cap-color))))
      ; (do-for-fact ((?m machine)) (and (eq ?m:mtype DS) (eq ?m:team ?team))
      ;    (assert (product-processed (mtype DS)


### PR DESCRIPTION
We should not assume that the individual production steps happened at
the same time as the delivery, as this results in no points given if the
delivery is late. Instead, if we are not tracking, simply assume that
all steps happened at time 0.1 to guarantee that they are before the
delivery deadline. This restores the old behavior of giving full points
for production steps, even if the delivery is late.