### PR TITLE
rcll: always give intermediate points even if done late

### DIFF
--- a/src/games/rcll/orders.clp
+++ b/src/games/rcll/orders.clp
@@ -478,7 +478,7 @@
   (order (id ?o-id)
          (complexity ?complexity)
          (quantity-requested ?q-req)
-         (delivery-period $?dp &:(<= ?g-time (nth$ 2 ?dp)))
+         (delivery-period $?dp)
          (base-color ?base-color)
          (ring-colors $?r-colors&:(eq ?wp-r-colors
                                       (subseq$ ?r-colors 1 (length$ ?wp-r-colors)))))
@@ -536,7 +536,7 @@
     (order (id ?o-id)
            (complexity ?complexity)
            (quantity-requested ?q-req)
-           (delivery-period $?dp &:(<= ?g-time (nth$ 2 ?dp)))
+           (delivery-period $?dp)
            (base-color ?base-color)
            (ring-colors $?ring-colors)
            (cap-color ?cap-color))


### PR DESCRIPTION
Points for ring and cap mounting should always be awarded regardless if
they were performed later than the order delivery window.
This restores the old behavior of giving full points for production
steps, even if the delivery is late.

This is an alternative implementation to extend the solution implemented
at PR #44.

This fixes issue #42.