### PR TITLE
Only set MPS to READY-AT-OUTPUT if workpiece has been seen

### DIFF
--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -443,6 +443,8 @@
 	(gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt))
 	?m <- (machine (name ?n) (mtype BS|CS|RS|SS) (state PROCESSED) (task MOVE-OUT)
 	               (mps-busy FALSE) (mps-ready TRUE))
+	(or (workpiece-tracking (enabled FALSE))
+	    (workpiece (at-machine ?n) (state AVAILABLE)))
 	=>
 	(modify ?m (state READY-AT-OUTPUT) (task nil))
 )


### PR DESCRIPTION
We sometimes miss workpieces and then disable the tracking completely
for the whole game. Instead of doing this, do not set the machine to
READY-AT-OUTPUT if it did not see a workpiece and the tracking is
enabled. This allows the referee and or the machine to recover, either
by manually moving the workpiece into the barcode scanner, or by moving
the belt.