### PR TITLE
Adapt mps_comm to use correct c++11 build flags, do not require c++14

### DIFF
--- a/etc/buildsys/gcc.mk
+++ b/etc/buildsys/gcc.mk
@@ -35,13 +35,57 @@ gcc_atleast_version = $(strip $(if $(call gt,$(GCC_VERSION_MAJOR),$1),1,	\
                          $(if $(call eq,$(GCC_VERSION_MAJOR),$1),		\
                            $(if $(call gte,$(GCC_VERSION_MINOR),$2),1))))
 
-# Check für C++0x/C++11 availability
+gcc_lessthan_version = $(strip $(if $(call lt,$(GCC_VERSION_MAJOR),$1),1,	\
+                         $(if $(call eq,$(GCC_VERSION_MAJOR),$1),		\
+                           $(if $(call lt,$(GCC_VERSION_MINOR),$2),1))))
+
+# Check für newer C++ standards availability
+# According to https://gcc.gnu.org/projects/cxx-status.html
 ifeq ($(call gcc_atleast_version,4,3),1)
   HAVE_CPP11=1
   CFLAGS_CPP11=-std=c++0x
-  ifeq ($(call gcc_atleast_version,4,7),1)
-    CFLAGS_CPP11=-std=c++11
+endif
+ifeq ($(call gcc_atleast_version,4,7),1)
+  CFLAGS_CPP11=-std=c++11
+endif
+ifeq ($(call gcc_atleast_version,4,8),1)
+  HAVE_CPP14=1
+  CFLAGS_CPP14=-std=c++1y
+endif
+ifeq ($(call gcc_atleast_version,5,0),1)
+  HAVE_CPP17=1
+  CFLAGS_CPP14=-std=c++14
+  CFLAGS_CPP17=-std=c++1z
+endif
+ifeq ($(call gcc_atleast_version,6,0),1)
+  # The default for GCC 6 is C++14
+  # Reset flags, also CPP11 to avoid downgrade to C++11.
+  CFLAGS_CPP11=
+  CFLAGS_CPP14=
+endif
+
+ifeq ($(call gcc_lessthan_version,4,7),1)
+  # Older GCC version can screw up CPU identification when running in QEMU KVM
+  IS_QEMU=
+  ifeq ($(OS),FreeBSD)
+    ifneq ($(findstring QEMU,$(shell sysctl hw.model)),)
+      IS_QEMU=1
+    endif
   endif
+  ifeq ($(OS),Linux)
+    ifneq ($(findstring QEMU,$(shell grep "^model name" /proc/cpuinfo)),)
+      IS_QEMU=1
+    endif
+  endif
+
+  ifeq ($(IS_QEMU),1)
+    CFLAGS_MTUNE_NATIVE=$(shell gcc -march=native -E -v - </dev/null 2>&1 | sed -n 's/.* -v - //p' | sed -e 's/-march=[^ ]*//g' -e 's/-mbmi//g') \
+			-mno-sse3 -mno-ssse3 -mno-sse4.1 -mno-sse4.2 -mno-avx
+  else
+    CFLAGS_MTUNE_NATIVE=-march=native -mtune=native
+  endif
+else
+  CFLAGS_MTUNE_NATIVE=-march=native -mtune=native
 endif
 
 OPENMP_LIBRARY = gomp
@@ -58,4 +102,11 @@ ifeq ($(ARCH),armv6l)
   CFLAGS_MINIMUM += -Wno-psabi
 endif
 
+CFLAG_W_NO_UNUSED_LOCAL_TYPEDEFS=-Wno-unused-local-typedefs
+
+ifeq ($(call gcc_atleast_version,4,6),1)
+  HAVE_CPP11_RANGE_FOR=1
+endif
+
 endif # __buildsys_gcc_mk_
+

--- a/src/libs/mps_comm/machine.cpp
+++ b/src/libs/mps_comm/machine.cpp
@@ -54,8 +54,7 @@ void Machine::dispatch_command_queue()
 			command_queue_.pop();
 			lock.unlock();
 			command();
-			using namespace std::chrono_literals;
-			std::this_thread::sleep_for(40ms);
+			std::this_thread::sleep_for(std::chrono::milliseconds(40));
 			lock.lock();
     }
 	}
@@ -64,10 +63,9 @@ void Machine::dispatch_command_queue()
 void Machine::heartbeat()
 {
   heartbeat_active_ = true;
-  using namespace std::chrono_literals;
   while (!shutdown_) {
     send_command(COMMAND_NOTHING, 0, 0, 1);
-    std::this_thread::sleep_for(1s);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   heartbeat_active_ = false;
 }

--- a/src/libs/mps_comm/mps_comm.mk
+++ b/src/libs/mps_comm/mps_comm.mk
@@ -19,7 +19,7 @@ ifneq ($(PKGCONFIG),)
 endif
 
 ifeq ($(HAVE_FREEOPCUA),1)
-	HAVE_MPS_COMM = 1
-  CFLAGS_MPS_COMM  = $(shell $(PKGCONFIG) --cflags $(FREEOPCUA_COMPONENTS))
+  HAVE_MPS_COMM    = 1
+  CFLAGS_MPS_COMM  = $(shell $(PKGCONFIG) --cflags $(FREEOPCUA_COMPONENTS)) $(CFLAGS_CPP11)
   LDFLAGS_MPS_COMM = $(shell $(PKGCONFIG) --libs $(FREEOPCUA_COMPONENTS)) -lmbedtls
 endif


### PR DESCRIPTION
* Correctly detect the currently supported C++11 standard and set `CFLAGS_CPP11` and `CFLAGS_CPP14` accordingly
* Build `libmps_comm` with `CFLAGS_CPP11`, which is required by freeopcua
* Do not use `std::chrono_literals` as those require C++14

This fixes build errors on older systems, in particular Ubuntu 16.04. While we do not support such old distributions, these fixes are straight forward and make sense generally.