### PR TITLE
Warn if an MPS is waiting for workpiece tracking

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -168,7 +168,7 @@ llsfrb:
     refbox-port: 4444
 
   workpiece-tracking:
-   enable: true
+   enable: false
    fail-safe: true
    broadcast: false
 

--- a/src/games/rcll/workpieces.clp
+++ b/src/games/rcll/workpieces.clp
@@ -179,6 +179,15 @@
     )
 )
 
+(defrule workpiece-mps-waiting-in-processed
+  "Print a message if the MPS is in state PROCESSED but has not seen a workpiece yet."
+	(machine (name ?n) (state PROCESSED))
+  (workpiece-tracking (enabled TRUE))
+  (not (workpiece (at-machine ?n) (state AVAILABLE)))
+  =>
+  (printout warn "Machine " ?n " is waiting to detect a workpiece" crlf)
+)
+
 ;-----------------------------Order assignment---------------------------------
 (defrule workpiece-assign-order
    "Assign order to workpiece.


### PR DESCRIPTION
If tracking is enabled and the MPS already processed the workpiece but has not seen a barcode yet, print a warning, as this is usually either a problem with the barcode scanner or a misconfiguration.

Also disable tracking by default, as the default config is supposed to work in simulation.