### PR TITLE
Switch to mongocxx v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
               glibmm24-devel \
               gtkmm30-devel \
               make \
-              mongodb-devel \
+              mongo-cxx-driver-devel \
               ncurses-devel \
               openssh-clients \
               openssl-devel \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             dnf install -y --nodocs freeopcua-devel
       - checkout
       - run: make quick-check
-      - run: make all FAIL_ON_WARNING=0
+      - run: make all FAIL_ON_WARNING=1
   build_ubuntu:
     docker:
       - image: ubuntu:bionic

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #   (at your option) any later version.
 #
 
-FROM fedora:29 as buildenv
+FROM fedora:30 as buildenv
 RUN dnf install -y --nodocs \
       avahi-devel \
       boost-devel \
@@ -19,7 +19,8 @@ RUN dnf install -y --nodocs \
       git \
       glibmm24-devel \
       gtkmm30-devel \
-      mongodb-devel \
+      make \
+      mongo-cxx-driver-devel \
       ncurses-devel \
       openssh-clients \
       openssl-devel \
@@ -44,7 +45,7 @@ RUN shopt -s globstar; \
     /usr/lib/rpm/rpmdeps -P lib/** bin/** > provides.txt && \
     /usr/lib/rpm/rpmdeps -R lib/** bin/** | grep -v -f provides.txt > requires.txt
 
-FROM fedora:29
+FROM fedora:30
 COPY --from=buildenv /buildenv/bin/* /usr/local/bin/
 COPY --from=buildenv /buildenv/lib/* /usr/local/lib64/
 COPY --from=buildenv /buildenv/src/games /usr/local/share/rcll-refbox/games

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -151,9 +151,9 @@ llsfrb:
     enable: false
     hostport: localhost
     collections:
-      text-log: llsfrb.log
-      clips-log: llsfrb.clipslog
-      protobuf: llsfrb.protobuf
+      text-log: log
+      clips-log: clipslog
+      protobuf: protobuf
 
   game:
     teams: [Carologistics]

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -112,11 +112,11 @@
      (bson-append ?o-doc "activate-at" ?o:activate-at)
      (bson-array-append ?o-arr ?o-doc)
   )
-  (bson-array-finish ?o-arr)
+  (bson-array-finish ?doc "orders" ?o-arr)
 
   ;(printout t "Storing game report" crlf (bson-tostring ?doc) crlf)
 
-  (mongodb-upsert "llsfrb.game_report" ?doc
+  (mongodb-upsert "game_report" ?doc
   		  (str-cat "{\"start-timestamp\": [" (nth$ 1 ?stime) ", " (nth$ 2 ?stime) "]}"))
   (bson-destroy ?doc)
 )
@@ -174,7 +174,7 @@
   (bson-append ?client-doc "client-id" ?client-id)
   (bson-append ?client-doc "host" ?host)
   (bson-append ?client-doc "port" ?port)
-  (mongodb-insert "llsfrb.clients" ?client-doc)
+  (mongodb-insert "clients" ?client-doc)
   (bson-destroy ?client-doc)
 )
 
@@ -189,7 +189,7 @@
   (bson-append-time ?update-query "session" ?*START-TIME*)
   (bson-append ?update-query "client-id" ?client-id)
 
-  (mongodb-update "llsfrb.clients" ?client-update-doc ?update-query)
+  (mongodb-update "clients" ?client-update-doc ?update-query)
   (bson-destroy ?client-update-doc)
   (bson-destroy ?update-query)
 )
@@ -212,7 +212,7 @@
   )
 
 	(bson-array-finish ?doc "machines" ?m-arr)
-  (mongodb-upsert "llsfrb.machine_zones" ?doc
+  (mongodb-upsert "machine_zones" ?doc
   		  (str-cat "{\"timestamp\": [" (nth$ 1 ?time) ", " (nth$ 2 ?time) "]}"))
   (bson-destroy ?doc)
 
@@ -223,7 +223,7 @@
   ;(bind ?t-query (bson-parse "{\"end-time\": { \"$exists\": 1 }}"))
   (bind ?t-query (bson-parse "{}"))
   (bind ?t-sort  (bson-parse "{\"start-timestamp\": -1}"))
-	(bind ?t-cursor (mongodb-query-sort "llsfrb.game_report" ?t-query ?t-sort))
+	(bind ?t-cursor (mongodb-query-sort "game_report" ?t-query ?t-sort))
   (bind ?t-doc (mongodb-cursor-next ?t-cursor))
   (if (neq ?t-doc FALSE) then
 	  (bind ?stime (bson-get-time ?t-doc "start-time"))
@@ -239,7 +239,7 @@
 		(bind ?qs (str-cat "{}"))
 		(bind ?query (bson-parse ?qs))
 		(bind ?sort  (bson-parse "{time: -1}"))
-		(bind ?cursor (mongodb-query-sort "llsfrb.machine_zones" ?query ?sort))
+		(bind ?cursor (mongodb-query-sort "machine_zones" ?query ?sort))
 		(bind ?doc (mongodb-cursor-next ?cursor))
 		(if (neq ?doc FALSE) then
 		 then
@@ -256,14 +256,14 @@
 				(bson-destroy ?m-p)
       )
      else
-	    (printout error "Empty result in mongoDB from llsfrb.machine_zones" crlf)
+	    (printout error "Empty result in mongoDB from machine_zones" crlf)
     )
     (bson-destroy ?doc)
     (mongodb-cursor-destroy ?cursor)
 	  (bson-destroy ?query)
 	  (bson-destroy ?sort)
    else
-	  (printout error "Empty result in mongoDB from llsfrb.game_report" crlf)
+	  (printout error "Empty result in mongoDB from game_report" crlf)
     
   )
   (mongodb-cursor-destroy ?t-cursor)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -238,7 +238,7 @@
 		;(bind ?qs (str-cat "{\"time\": ISODate(\"" (mongodb-time-as-ms ?stime) "\"}"))
 		(bind ?qs (str-cat "{}"))
 		(bind ?query (bson-parse ?qs))
-		(bind ?sort  (bson-parse "{time: -1}"))
+		(bind ?sort  (bson-parse "{\"time\": -1}"))
 		(bind ?cursor (mongodb-query-sort "machine_zones" ?query ?sort))
 		(bind ?doc (mongodb-cursor-next ?cursor))
 		(if (neq ?doc FALSE) then

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -62,7 +62,7 @@
         else (bind ?phase-points-magenta (+ ?phase-points-magenta ?p:points))
       )
       (bson-array-append ?points-arr ?point-doc)
-      (bson-destroy ?point-doc)
+      (bson-builder-destroy ?point-doc)
     )
     (bson-append ?phase-points-doc-cyan ?phase ?phase-points-cyan)
     (bson-append ?phase-points-doc-magenta ?phase ?phase-points-magenta)
@@ -74,8 +74,8 @@
   (bson-append ?doc "phase-points-cyan" ?phase-points-doc-cyan)
   (bson-append ?doc "phase-points-magenta" ?phase-points-doc-magenta)
   (bson-append-array ?doc "total-points" (create$ ?points-cyan ?points-magenta))
-  (bson-destroy ?phase-points-doc-cyan)
-  (bson-destroy ?phase-points-doc-magenta)
+  (bson-builder-destroy ?phase-points-doc-cyan)
+  (bson-builder-destroy ?phase-points-doc-magenta)
 
   (bind ?m-arr (bson-array-start))
   (do-for-all-facts ((?m machine)) TRUE
@@ -118,7 +118,7 @@
 
   (mongodb-upsert "game_report" ?doc
   		  (str-cat "{\"start-timestamp\": [" (nth$ 1 ?stime) ", " (nth$ 2 ?stime) "]}"))
-  (bson-destroy ?doc)
+  (bson-builder-destroy ?doc)
 )
 
 (defrule mongodb-game-report-begin
@@ -175,7 +175,7 @@
   (bson-append ?client-doc "host" ?host)
   (bson-append ?client-doc "port" ?port)
   (mongodb-insert "clients" ?client-doc)
-  (bson-destroy ?client-doc)
+  (bson-builder-destroy ?client-doc)
 )
 
 (defrule mongodb-net-client-disconnected
@@ -190,8 +190,8 @@
   (bson-append ?update-query "client-id" ?client-id)
 
   (mongodb-update "clients" ?client-update-doc ?update-query)
-  (bson-destroy ?client-update-doc)
-  (bson-destroy ?update-query)
+  (bson-builder-destroy ?client-update-doc)
+  (bson-builder-destroy ?update-query)
 )
 
 
@@ -208,13 +208,13 @@
 		(bson-append ?m-doc "zone" ?m:zone)
 		(bson-append ?m-doc "rotation" ?m:rotation)
 		(bson-array-append ?m-arr ?m-doc)
-		(bson-destroy ?m-doc)
+		(bson-builder-destroy ?m-doc)
   )
 
 	(bson-array-finish ?doc "machines" ?m-arr)
   (mongodb-upsert "machine_zones" ?doc
   		  (str-cat "{\"timestamp\": [" (nth$ 1 ?time) ", " (nth$ 2 ?time) "]}"))
-  (bson-destroy ?doc)
+  (bson-builder-destroy ?doc)
 
 )
 
@@ -260,15 +260,15 @@
     )
     (bson-destroy ?doc)
     (mongodb-cursor-destroy ?cursor)
-	  (bson-destroy ?query)
-	  (bson-destroy ?sort)
+	  (bson-builder-destroy ?query)
+	  (bson-builder-destroy ?sort)
    else
 	  (printout error "Empty result in mongoDB from game_report" crlf)
     
   )
   (mongodb-cursor-destroy ?t-cursor)
-	(bson-destroy ?t-query)
-	(bson-destroy ?t-sort)
+	(bson-builder-destroy ?t-query)
+	(bson-builder-destroy ?t-sort)
 )
 
 (defrule mongodb-store-machine-zones

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -224,12 +224,11 @@
   (bind ?t-query (bson-parse "{}"))
   (bind ?t-sort  (bson-parse "{\"start-timestamp\": -1}"))
 	(bind ?t-cursor (mongodb-query-sort "llsfrb.game_report" ?t-query ?t-sort))
-	(if (mongodb-cursor-more ?t-cursor)
-   then
-    (bind ?t-doc (mongodb-cursor-next ?t-cursor))
+  (bind ?t-doc (mongodb-cursor-next ?t-cursor))
+  (if (neq ?t-doc FALSE) then
 	  (bind ?stime (bson-get-time ?t-doc "start-time"))
+    (bson-destroy ?t-doc)
 ;	  (bind ?etime (bson-get-time ?t-doc "end-time"))
-		(bson-destroy ?t-doc)
 
 	  ; retrieve machine config
 ;		(bind ?qs (str-cat "{\"$and\": [{time: { \"$gte\": { \"$date\": "
@@ -241,9 +240,9 @@
 		(bind ?query (bson-parse ?qs))
 		(bind ?sort  (bson-parse "{time: -1}"))
 		(bind ?cursor (mongodb-query-sort "llsfrb.machine_zones" ?query ?sort))
-		(if (mongodb-cursor-more ?cursor)
+		(bind ?doc (mongodb-cursor-next ?cursor))
+		(if (neq ?doc FALSE) then
 		 then
-		  (bind ?doc (mongodb-cursor-next ?cursor))
 			(bind ?fn (bson-field-names ?doc))
 			(bind ?m-arr (bson-get-array ?doc "machines"))
 			(foreach ?m-p ?m-arr
@@ -256,10 +255,10 @@
 			  )
 				(bson-destroy ?m-p)
       )
-		  (bson-destroy ?doc)
      else
 	    (printout error "Empty result in mongoDB from llsfrb.machine_zones" crlf)
     )
+    (bson-destroy ?doc)
     (mongodb-cursor-destroy ?cursor)
 	  (bson-destroy ?query)
 	  (bson-destroy ?sort)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -254,11 +254,11 @@
 					(modify ?m (zone ?m-zone) (rotation (integer (eval ?m-rotation))))
 			  )
 				(bson-destroy ?m-p)
-      )
+			)
+			(bson-destroy ?doc)
      else
 	    (printout error "Empty result in mongoDB from machine_zones" crlf)
     )
-    (bson-destroy ?doc)
     (mongodb-cursor-destroy ?cursor)
 	  (bson-builder-destroy ?query)
 	  (bson-builder-destroy ?sort)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -42,7 +42,7 @@
     (bson-append-time ?doc "end-time" ?etime)
   )
 
-  (bind ?points-arr (bson-array-start ?doc "points"))
+  (bind ?points-arr (bson-array-start))
   (bind ?phase-points-doc-cyan (bson-create))
   (bind ?phase-points-doc-magenta (bson-create))
 
@@ -70,14 +70,14 @@
     (bind ?points-magenta (+ ?points-magenta ?phase-points-magenta))
   )
 
-  (bson-array-finish ?points-arr)
+  (bson-array-finish ?doc "points" ?points-arr)
   (bson-append ?doc "phase-points-cyan" ?phase-points-doc-cyan)
   (bson-append ?doc "phase-points-magenta" ?phase-points-doc-magenta)
   (bson-append-array ?doc "total-points" (create$ ?points-cyan ?points-magenta))
   (bson-destroy ?phase-points-doc-cyan)
   (bson-destroy ?phase-points-doc-magenta)
 
-  (bind ?m-arr (bson-array-start ?doc "machines"))
+  (bind ?m-arr (bson-array-start))
   (do-for-all-facts ((?m machine)) TRUE
      (bind ?m-doc (bson-create))
      (bson-append ?m-doc "name" ?m:name)
@@ -95,9 +95,9 @@
      )
      (bson-array-append ?m-arr ?m-doc)
   )
-  (bson-array-finish ?m-arr)
+  (bson-array-finish ?doc "machines" ?m-arr)
 
-  (bind ?o-arr (bson-array-start ?doc "orders"))
+  (bind ?o-arr (bson-array-start))
   (do-for-all-facts ((?o order)) TRUE
      (bind ?o-doc (bson-create))
      (bson-append ?o-doc "id" ?o:id)
@@ -200,7 +200,7 @@
 
   (bson-append-array ?doc "timestamp" ?time)
   (bson-append-time  ?doc "time" ?time)
-  (bind ?m-arr (bson-array-start ?doc "machines"))
+  (bind ?m-arr (bson-array-start))
 	
 	(do-for-all-facts ((?m machine)) TRUE
     (bind ?m-doc (bson-create))
@@ -211,7 +211,7 @@
 		(bson-destroy ?m-doc)
   )
 
-	(bson-array-finish ?m-arr)
+	(bson-array-finish ?doc "machines" ?m-arr)
   (mongodb-upsert "llsfrb.machine_zones" ?doc
   		  (str-cat "{\"timestamp\": [" (nth$ 1 ?time) ", " (nth$ 2 ?time) "]}"))
   (bson-destroy ?doc)

--- a/src/libs/mongodb_log/Makefile
+++ b/src/libs/mongodb_log/Makefile
@@ -32,7 +32,7 @@ OBJS_all = $(OBJS_libllsf_mongodb_log)
 
 ifeq ($(HAVE_PROTOBUF)$(HAVE_MONGODB)$(HAVE_BOOST_LIBS),111)
   CFLAGS  += $(CFLAGS_PROTOBUF)  $(CFLAGS_MONGODB)  $(call boost-libs-cflags,$(REQ_BOOST_LIBS))
-  LDFLAGS += $(LDFLAGS_PROTOBUF) -lmongoclient $(LDFLAGS_MONGODB) $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
+  LDFLAGS += $(LDFLAGS_PROTOBUF) $(LDFLAGS_MONGODB) $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
 
   LIBS_all  = $(LIBDIR)/libllsf_mongodb_log.$(SOEXT)
 else

--- a/src/libs/mongodb_log/mongodb.mk
+++ b/src/libs/mongodb_log/mongodb.mk
@@ -17,7 +17,7 @@
 ifneq ($(PKGCONFIG),)
 	ifeq ($(HAVE_CPP11),1)
     HAVE_MONGODB = $(if $(shell $(PKGCONFIG) --exists --atleast-version=3 'libmongocxx'; echo $${?/1/}),1,0)
-    CFLAGS_MONGODB = $(shell $(PKGCONFIG) --cflags 'libmongocxx')
+    CFLAGS_MONGODB = $(shell $(PKGCONFIG) --cflags 'libmongocxx') -DHAVE_MONGODB
     LDFLAGS_MONGODB = $(shell $(PKGCONFIG) --libs 'libmongocxx')
   endif
 endif

--- a/src/libs/mongodb_log/mongodb.mk
+++ b/src/libs/mongodb_log/mongodb.mk
@@ -3,6 +3,7 @@
 #                            -------------------
 #   Created on Sun Dec 05 23:03:18 2010 (Steelers vs. Baltimore)
 #   Copyright (C) 2006-2010 by Tim Niemueller, AllemaniACs RoboCup Team
+#                 2019      by Till Hofmann
 #
 #*****************************************************************************
 #
@@ -13,30 +14,10 @@
 #
 #*****************************************************************************
 
-include $(BUILDSYSDIR)/boost.mk
-
 ifneq ($(PKGCONFIG),)
-  HAVE_LIBSSL := $(if $(shell $(PKGCONFIG) --exists 'openssl'; echo $${?/1/}),1,0)
-endif
-ifeq ($(HAVE_LIBSSL),1)
-  CFLAGS_LIBSSL  += -DHAVE_LIBSSL $(shell $(PKGCONFIG) --cflags 'openssl')
-  LDFLAGS_LIBSSL += $(shell $(PKGCONFIG) --libs 'openssl')
-endif
-
-ifneq ($(wildcard /usr/include/mongo/client/dbclient.h /usr/local/include/mongo/client/dbclient.h),)
-  ifeq ($(call boost-have-libs,thread system filesystem)$(HAVE_LIBSSL),11)
-    HAVE_MONGODB = 1
-    CFLAGS_MONGODB  = -DHAVE_MONGODB $(CFLAGS_LIBSSL)
-    LDFLAGS_MONGODB = -lm -lpthread \
-		      $(call boost-libs-ldflags,thread system filesystem) \
-		      $(LDFLAGS_LIBSSL)
-    ifneq ($(wildcard $(SYSROOT)/usr/lib/libmongoclient.so $(SYSROOT)/usr/lib64/libmongoclient.so $(SYSROOT)/usr/local/lib/libmongoclient.so $(SYSROOT)/usr/local/lib64/libmongoclient.so $(SYSROOT)/usr/lib/x86_64-linux-gnu/libmongoclient.so $(SYSROOT)/usr/local/lib/x86_64-linux-gnu/libmongoclient.so),)
-      # we are linking against a shared library, add to link flags
-      LDFLAGS_MONGODB += -lmongoclient
-    endif
-    ifneq ($(wildcard /usr/include/mongo/version.h /usr/local/include/mongo/version.h),)
-      CFLAGS_MONGODB += -DHAVE_MONGODB_VERSION_H
-    endif
+	ifeq ($(HAVE_CPP11),1)
+    HAVE_MONGODB = $(if $(shell $(PKGCONFIG) --exists --atleast-version=3 'libmongocxx'; echo $${?/1/}),1,0)
+    CFLAGS_MONGODB = $(shell $(PKGCONFIG) --cflags 'libmongocxx')
+    LDFLAGS_MONGODB = $(shell $(PKGCONFIG) --libs 'libmongocxx')
   endif
 endif
-

--- a/src/libs/mongodb_log/mongodb_log_logger.cpp
+++ b/src/libs/mongodb_log/mongodb_log_logger.cpp
@@ -25,6 +25,7 @@
 #include <mongodb_log/mongodb_log_logger.h>
 
 #include <bsoncxx/builder/basic/document.hpp>
+#include <chrono>
 #include <mongocxx/client.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/uri.hpp>
@@ -75,6 +76,7 @@ MongoDBLogLogger::insert_message(LogLevel ll, const char *component, const char 
 		}
 
 		document doc{};
+		doc.append(kvp("time", bsoncxx::types::b_date(std::chrono::system_clock::now())));
 		switch (ll) {
 		case LL_DEBUG: doc.append(kvp("level", "DEBUG")); break;
 		case LL_INFO: doc.append(kvp("level", "INFO")); break;
@@ -83,12 +85,9 @@ MongoDBLogLogger::insert_message(LogLevel ll, const char *component, const char 
 		default: doc.append(kvp("level", "UNKN")); break;
 		}
 		doc.append(kvp("component", component));
-		doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
 		doc.append(kvp("message", msg));
-
-		free(msg);
-
 		collection_.insert_one(doc.view());
+		free(msg);
 	}
 }
 
@@ -107,9 +106,8 @@ MongoDBLogLogger::insert_message(LogLevel ll, const char *component, Exception &
 			case LL_ERROR: doc.append(kvp("level", "ERROR")); break;
 			default: doc.append(kvp("level", "UNKN")); break;
 			}
+			doc.append(kvp("time", bsoncxx::types::b_date(std::chrono::system_clock::now())));
 			doc.append(kvp("component", component));
-			doc.append(
-			  kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
 			doc.append(kvp("message", std::string("[EXCEPTION] ") + *i));
 			try {
 				collection_.insert_one(doc.view());
@@ -225,8 +223,7 @@ MongoDBLogLogger::tlog_insert_message(LogLevel        ll,
 		default: doc.append(kvp("level", "UNKN")); break;
 		}
 		doc.append(kvp("component", component));
-
-		doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
+		doc.append(kvp("time", bsoncxx::types::b_date(std::chrono::system_clock::now())));
 		doc.append(kvp("message", msg));
 		try {
 			collection_.insert_one(doc.view());
@@ -257,8 +254,7 @@ MongoDBLogLogger::tlog_insert_message(LogLevel        ll,
 			default: doc.append(kvp("level", "UNKN")); break;
 			}
 			doc.append(kvp("component", component));
-			doc.append(
-			  kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
+			doc.append(kvp("time", bsoncxx::types::b_date(std::chrono::system_clock::now())));
 			doc.append(kvp("message", std::string("[EXCEPTION] ") + *i));
 			try {
 				collection_.insert_one(doc.view());

--- a/src/libs/mongodb_log/mongodb_log_logger.cpp
+++ b/src/libs/mongodb_log/mongodb_log_logger.cpp
@@ -24,11 +24,18 @@
 #include <core/threading/mutex_locker.h>
 #include <mongodb_log/mongodb_log_logger.h>
 
-// from MongoDB
-#include <mongo/client/dbclient.h>
+#include <bsoncxx/builder/basic/document.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/operation_exception.hpp>
+#include <mongocxx/uri.hpp>
+#include <string>
 
 using namespace mongo;
 using namespace fawkes;
+
+using bsoncxx::builder::basic::document;
+using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::sub_document;
 
 /** @class MongoDBLogLogger <mongodb_log/mongodb_log_logger.h>
  * Thread that provides a logger writing to MongoDB.
@@ -41,15 +48,9 @@ using namespace fawkes;
 MongoDBLogLogger::MongoDBLogLogger(std::string host_port, std::string collection)
 {
 	mutex_ = new Mutex();
-
-	collection_ = collection;
-
-	DBClientConnection *conn = new DBClientConnection(/* auto reconnect */ true);
-	mongodb_                 = conn;
-	std::string errmsg;
-	if (!conn->connect(host_port, errmsg)) {
-		throw Exception("Could not connect to MongoDB at %s: %s", host_port.c_str(), errmsg.c_str());
-	}
+	std::string uri{"mongodb://" + host_port};
+	auto        client = mongocxx::client{mongocxx::uri{"mongodb://" + host_port}};
+	collection_        = client["rcll"][collection];
 }
 
 /** Destructor. */
@@ -65,7 +66,7 @@ MongoDBLogLogger::insert_message(LogLevel ll, const char *component, const char 
 		MutexLocker    lock(mutex_);
 		struct timeval now;
 		gettimeofday(&now, NULL);
-		Date_t nowd = now.tv_sec * 1000 + now.tv_usec / 1000;
+		//Date_t nowd = now.tv_sec * 1000 + now.tv_usec / 1000;
 
 		char *msg;
 		if (vasprintf(&msg, format, va) == -1) {
@@ -73,24 +74,21 @@ MongoDBLogLogger::insert_message(LogLevel ll, const char *component, const char 
 			return;
 		}
 
-		BSONObjBuilder b;
+		document doc{};
 		switch (ll) {
-		case LL_DEBUG: b.append("level", "DEBUG"); break;
-		case LL_INFO: b.append("level", "INFO"); break;
-		case LL_WARN: b.append("level", "WARN"); break;
-		case LL_ERROR: b.append("level", "ERROR"); break;
-		default: b.append("level", "UNKN"); break;
+		case LL_DEBUG: doc.append(kvp("level", "DEBUG")); break;
+		case LL_INFO: doc.append(kvp("level", "INFO")); break;
+		case LL_WARN: doc.append(kvp("level", "WARN")); break;
+		case LL_ERROR: doc.append(kvp("level", "ERROR")); break;
+		default: doc.append(kvp("level", "UNKN")); break;
 		}
-		b.append("component", component);
-		b.appendDate("time", nowd);
-		b.append("message", msg);
+		doc.append(kvp("component", component));
+		doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
+		doc.append(kvp("message", msg));
 
 		free(msg);
 
-		try {
-			mongodb_->insert(collection_, b.obj());
-		} catch (mongo::DBException &e) {
-		} // ignored
+		collection_.insert_one(doc.view());
 	}
 }
 
@@ -98,26 +96,24 @@ void
 MongoDBLogLogger::insert_message(LogLevel ll, const char *component, Exception &e)
 {
 	if (log_level <= ll) {
-		MutexLocker    lock(mutex_);
-		struct timeval now;
-		gettimeofday(&now, NULL);
-		Date_t nowd = now.tv_sec * 1000 + now.tv_usec / 1000;
+		MutexLocker lock(mutex_);
 
 		for (Exception::iterator i = e.begin(); i != e.end(); ++i) {
-			BSONObjBuilder b;
+			document doc{};
 			switch (ll) {
-			case LL_DEBUG: b.append("level", "DEBUG"); break;
-			case LL_INFO: b.append("level", "INFO"); break;
-			case LL_WARN: b.append("level", "WARN"); break;
-			case LL_ERROR: b.append("level", "ERROR"); break;
-			default: b.append("level", "UNKN"); break;
+			case LL_DEBUG: doc.append(kvp("level", "DEBUG")); break;
+			case LL_INFO: doc.append(kvp("level", "INFO")); break;
+			case LL_WARN: doc.append(kvp("level", "WARN")); break;
+			case LL_ERROR: doc.append(kvp("level", "ERROR")); break;
+			default: doc.append(kvp("level", "UNKN")); break;
 			}
-			b.append("component", component);
-			b.appendDate("time", nowd);
-			b.append("message", std::string("[EXCEPTION] ") + *i);
+			doc.append(kvp("component", component));
+			doc.append(
+			  kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
+			doc.append(kvp("message", std::string("[EXCEPTION] ") + *i));
 			try {
-				mongodb_->insert(collection_, b.obj());
-			} catch (mongo::DBException &e) {
+				collection_.insert_one(doc.view());
+			} catch (mongocxx::operation_exception &) {
 			} // ignored
 		}
 	}
@@ -220,23 +216,21 @@ MongoDBLogLogger::tlog_insert_message(LogLevel        ll,
 		if (vasprintf(&msg, format, va) == -1) {
 			return;
 		}
-
-		Date_t nowd = t->tv_sec * 1000 + t->tv_usec / 1000;
-
-		BSONObjBuilder b;
+		document doc{};
 		switch (ll) {
-		case LL_DEBUG: b.append("level", "DEBUG"); break;
-		case LL_INFO: b.append("level", "INFO"); break;
-		case LL_WARN: b.append("level", "WARN"); break;
-		case LL_ERROR: b.append("level", "ERROR"); break;
-		default: b.append("level", "UNKN"); break;
+		case LL_DEBUG: doc.append(kvp("level", "DEBUG")); break;
+		case LL_INFO: doc.append(kvp("level", "INFO")); break;
+		case LL_WARN: doc.append(kvp("level", "WARN")); break;
+		case LL_ERROR: doc.append(kvp("level", "ERROR")); break;
+		default: doc.append(kvp("level", "UNKN")); break;
 		}
-		b.append("component", component);
-		b.appendDate("time", nowd);
-		b.append("message", msg);
+		doc.append(kvp("component", component));
+
+		doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
+		doc.append(kvp("message", msg));
 		try {
-			mongodb_->insert(collection_, b.obj());
-		} catch (mongo::DBException &e) {
+			collection_.insert_one(doc.view());
+		} catch (mongocxx::operation_exception &) {
 		} // ignored
 
 		free(msg);
@@ -253,22 +247,22 @@ MongoDBLogLogger::tlog_insert_message(LogLevel        ll,
 {
 	if (log_level <= ll) {
 		MutexLocker lock(mutex_);
-		Date_t      nowd = t->tv_sec * 1000 + t->tv_usec / 1000;
 		for (Exception::iterator i = e.begin(); i != e.end(); ++i) {
-			BSONObjBuilder b;
+			document doc{};
 			switch (ll) {
-			case LL_DEBUG: b.append("level", "DEBUG"); break;
-			case LL_INFO: b.append("level", "INFO"); break;
-			case LL_WARN: b.append("level", "WARN"); break;
-			case LL_ERROR: b.append("level", "ERROR"); break;
-			default: b.append("level", "UNKN"); break;
+			case LL_DEBUG: doc.append(kvp("level", "DEBUG")); break;
+			case LL_INFO: doc.append(kvp("level", "INFO")); break;
+			case LL_WARN: doc.append(kvp("level", "WARN")); break;
+			case LL_ERROR: doc.append(kvp("level", "ERROR")); break;
+			default: doc.append(kvp("level", "UNKN")); break;
 			}
-			b.append("component", component);
-			b.appendDate("time", nowd);
-			b.append("message", std::string("[EXCEPTION] ") + *i);
+			doc.append(kvp("component", component));
+			doc.append(
+			  kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("time", true)); }));
+			doc.append(kvp("message", std::string("[EXCEPTION] ") + *i));
 			try {
-				mongodb_->insert(collection_, b.obj());
-			} catch (mongo::DBException &e) {
+				collection_.insert_one(doc.view());
+			} catch (mongocxx::operation_exception &) {
 			} // ignored
 		}
 	}

--- a/src/libs/mongodb_log/mongodb_log_logger.cpp
+++ b/src/libs/mongodb_log/mongodb_log_logger.cpp
@@ -50,8 +50,8 @@ MongoDBLogLogger::MongoDBLogLogger(std::string host_port, std::string collection
 {
 	mutex_ = new Mutex();
 	std::string uri{"mongodb://" + host_port};
-	auto        client = mongocxx::client{mongocxx::uri{"mongodb://" + host_port}};
-	collection_        = client["rcll"][collection];
+	client_     = mongocxx::client{mongocxx::uri{"mongodb://" + host_port}};
+	collection_ = client_["rcll"][collection];
 }
 
 /** Destructor. */

--- a/src/libs/mongodb_log/mongodb_log_logger.h
+++ b/src/libs/mongodb_log/mongodb_log_logger.h
@@ -89,6 +89,7 @@ private:
 
 private:
 	fawkes::Mutex *      mutex_;
+	mongocxx::client     client_;
 	mongocxx::collection collection_;
 };
 

--- a/src/libs/mongodb_log/mongodb_log_logger.h
+++ b/src/libs/mongodb_log/mongodb_log_logger.h
@@ -27,7 +27,6 @@
 #include <logging/logger.h>
 
 #include <mongocxx/client.hpp>
-#include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
 #include <string>
 
@@ -91,7 +90,6 @@ private:
 private:
 	fawkes::Mutex *      mutex_;
 	mongocxx::collection collection_;
-	mongocxx::instance   mongodb_instance_;
 };
 
 #endif

--- a/src/libs/mongodb_log/mongodb_log_logger.h
+++ b/src/libs/mongodb_log/mongodb_log_logger.h
@@ -26,6 +26,9 @@
 #include <core/exception.h>
 #include <logging/logger.h>
 
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
 #include <string>
 
 namespace fawkes {
@@ -86,9 +89,9 @@ private:
 	tlog_insert_message(LogLevel ll, struct timeval *t, const char *component, fawkes::Exception &);
 
 private:
-	std::string          collection_;
 	fawkes::Mutex *      mutex_;
-	mongo::DBClientBase *mongodb_;
+	mongocxx::collection collection_;
+	mongocxx::instance   mongodb_instance_;
 };
 
 #endif

--- a/src/libs/mongodb_log/mongodb_log_protobuf.cpp
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.cpp
@@ -48,8 +48,8 @@ MongoDBLogProtobuf::MongoDBLogProtobuf(std::string host_port, std::string collec
 	mutex_ = new fawkes::Mutex();
 
 	std::string uri{"mongodb://" + host_port};
-	auto        client = mongocxx::client{mongocxx::uri{"mongodb://" + host_port}};
-	collection_        = client["rcll"][collection];
+	client_     = mongocxx::client{mongocxx::uri{"mongodb://" + host_port}};
+	collection_ = client_["rcll"][collection];
 }
 
 /** Destructor. */

--- a/src/libs/mongodb_log/mongodb_log_protobuf.cpp
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.cpp
@@ -24,11 +24,16 @@
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
 #include <google/protobuf/descriptor.h>
-#include <mongo/client/dbclient.h>
 #include <mongodb_log/mongodb_log_protobuf.h>
 
-using namespace mongo;
+#include <mongocxx/exception/operation_exception.hpp>
+
 using namespace google::protobuf;
+
+using bsoncxx::builder::basic::document;
+using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::sub_document;
+using bsoncxx::document::view_or_value;
 
 /** @class MongoDBLogProtobuf <mongodb_log/mongodb_log_logger.h>
  * Thread that provides a logger writing to MongoDB.
@@ -42,16 +47,9 @@ MongoDBLogProtobuf::MongoDBLogProtobuf(std::string host_port, std::string collec
 {
 	mutex_ = new fawkes::Mutex();
 
-	collection_ = collection;
-
-	DBClientConnection *conn = new DBClientConnection(/* auto reconnect */ true);
-	mongodb_                 = conn;
-	std::string errmsg;
-	if (!conn->connect(host_port, errmsg)) {
-		throw fawkes::Exception("Could not connect to MongoDB at %s: %s",
-		                        host_port.c_str(),
-		                        errmsg.c_str());
-	}
+	std::string uri{"mongodb://" + host_port};
+	auto        client = mongocxx::client{mongocxx::uri{"mongodb://" + host_port}};
+	collection_        = client["rcll"][collection];
 }
 
 /** Destructor. */
@@ -63,7 +61,7 @@ MongoDBLogProtobuf::~MongoDBLogProtobuf()
 void
 MongoDBLogProtobuf::add_field(const FieldDescriptor *            field,
                               const ::google::protobuf::Message &m,
-                              BSONObjBuilder *                   b)
+                              document *                         doc)
 {
 	const Reflection *refl = m.GetReflection();
 
@@ -80,21 +78,21 @@ MongoDBLogProtobuf::add_field(const FieldDescriptor *            field,
 	case FieldDescriptor::TYPE_##TYPE: {                                                          \
 		const CPPTYPE value = field->is_repeated() ? refl->GetRepeated##CPPTYPE_METHOD(m, field, j) \
 		                                           : refl->Get##CPPTYPE_METHOD(m, field);           \
-		b->append(field->name(), value);                                                            \
+		doc->append(kvp(field->name(), value));                                                     \
 		break;                                                                                      \
 	}
 
 			HANDLE_PRIMITIVE_TYPE(INT32, int, Int32);
-			HANDLE_PRIMITIVE_TYPE(INT64, long long int, Int64);
+			HANDLE_PRIMITIVE_TYPE(INT64, long int, Int64);
 			HANDLE_PRIMITIVE_TYPE(SINT32, int, Int32);
-			HANDLE_PRIMITIVE_TYPE(SINT64, long long int, Int64);
-			HANDLE_PRIMITIVE_TYPE(UINT32, unsigned int, UInt32);
-			HANDLE_PRIMITIVE_TYPE(UINT64, long long int, UInt64);
+			HANDLE_PRIMITIVE_TYPE(SINT64, long int, Int64);
+			HANDLE_PRIMITIVE_TYPE(UINT32, long int, UInt32);
+			HANDLE_PRIMITIVE_TYPE(UINT64, long int, UInt64);
 
-			HANDLE_PRIMITIVE_TYPE(FIXED32, unsigned int, UInt32);
-			HANDLE_PRIMITIVE_TYPE(FIXED64, long long int, UInt64);
+			HANDLE_PRIMITIVE_TYPE(FIXED32, int, UInt32);
+			HANDLE_PRIMITIVE_TYPE(FIXED64, long int, UInt64);
 			HANDLE_PRIMITIVE_TYPE(SFIXED32, int, Int32);
-			HANDLE_PRIMITIVE_TYPE(SFIXED64, long long int, Int64);
+			HANDLE_PRIMITIVE_TYPE(SFIXED64, long int, Int64);
 
 			HANDLE_PRIMITIVE_TYPE(FLOAT, float, Float);
 			HANDLE_PRIMITIVE_TYPE(DOUBLE, double, Double);
@@ -105,10 +103,7 @@ MongoDBLogProtobuf::add_field(const FieldDescriptor *            field,
 		case FieldDescriptor::TYPE_MESSAGE: {
 			const google::protobuf::Message &sub_m =
 			  field->is_repeated() ? refl->GetRepeatedMessage(m, field, j) : refl->GetMessage(m, field);
-
-			BSONObjBuilder sub(b->subobjStart(field->name()));
-			add_message(sub_m, &sub);
-			sub.done();
+			doc->append(kvp(field->name(), add_message(sub_m)));
 			break;
 		}
 
@@ -117,7 +112,7 @@ MongoDBLogProtobuf::add_field(const FieldDescriptor *            field,
 		case FieldDescriptor::TYPE_ENUM: {
 			const EnumValueDescriptor *value =
 			  field->is_repeated() ? refl->GetRepeatedEnum(m, field, j) : refl->GetEnum(m, field);
-			b->append(field->name(), value->name());
+			doc->append(kvp(field->name(), value->name()));
 			break;
 		}
 
@@ -129,7 +124,7 @@ MongoDBLogProtobuf::add_field(const FieldDescriptor *            field,
 			                        ? refl->GetRepeatedStringReference(m, field, j, &scratch)
 			                        : refl->GetStringReference(m, field, &scratch);
 			//VerifyUTF8String(value.data(), value.length(), SERIALIZE);
-			b->append(field->name(), value);
+			doc->append(kvp(field->name(), value));
 			break;
 		}
 
@@ -138,21 +133,22 @@ MongoDBLogProtobuf::add_field(const FieldDescriptor *            field,
 			const string &value = field->is_repeated()
 			                        ? refl->GetRepeatedStringReference(m, field, j, &scratch)
 			                        : refl->GetStringReference(m, field, &scratch);
-			b->appendBinData(field->name(), value.size(), BinDataGeneral, value.c_str());
+			doc->append(kvp(field->name(), value));
 			break;
 		}
 		}
 	}
 }
 
-void
-MongoDBLogProtobuf::add_message(const google::protobuf::Message &m, BSONObjBuilder *b)
+document
+MongoDBLogProtobuf::add_message(const google::protobuf::Message &m)
 {
-	b->append("_type", m.GetTypeName());
+	document doc{};
+	doc.append(kvp("_type", m.GetTypeName()));
 
 	std::string data;
 	m.SerializeToString(&data);
-	b->appendBinData("_protobuf", data.size(), BinDataGeneral, data.c_str());
+	doc.append(kvp("_protobuf", data));
 
 	const Reflection *refl = m.GetReflection();
 
@@ -160,46 +156,31 @@ MongoDBLogProtobuf::add_message(const google::protobuf::Message &m, BSONObjBuild
 	refl->ListFields(m, &fields);
 
 	for (size_t i = 0; i < fields.size(); ++i) {
-		add_field(fields[i], m, b);
+		add_field(fields[i], m, &doc);
 	}
+	return doc;
 }
 
 void
 MongoDBLogProtobuf::write(google::protobuf::Message &m)
 {
 	fawkes::MutexLocker lock(mutex_);
-	struct timeval      now;
-	gettimeofday(&now, NULL);
-	Date_t nowd = now.tv_sec * 1000 + now.tv_usec / 1000;
-
-	BSONObjBuilder b;
-	b.appendDate("_time", nowd);
-
-	add_message(m, &b);
-
+	document            doc{add_message(m)};
+	doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("_time", true)); }));
 	try {
-		mongodb_->insert(collection_, b.obj());
-	} catch (mongo::DBException &e) {
+		collection_.insert_one(doc.view());
+	} catch (mongocxx::operation_exception &) {
 	} // ignored
 }
 
 void
-MongoDBLogProtobuf::write(google::protobuf::Message &m, mongo::BSONObj &meta_data)
+MongoDBLogProtobuf::write(google::protobuf::Message &m, view_or_value &meta_data)
 {
 	fawkes::MutexLocker lock(mutex_);
-	struct timeval      now;
-	gettimeofday(&now, NULL);
-	Date_t nowd = now.tv_sec * 1000 + now.tv_usec / 1000;
-
-	BSONObjBuilder b;
-	b.appendDate("_time", nowd);
-
-	add_message(m, &b);
-
-	b.append("_meta", meta_data);
-
+	document            doc{add_message(m)};
+	doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("_time", true)); }));
 	try {
-		mongodb_->insert(collection_, b.obj());
-	} catch (mongo::DBException &e) {
+		collection_.insert_one(doc.view());
+	} catch (mongocxx::operation_exception &) {
 	} // ignored
 }

--- a/src/libs/mongodb_log/mongodb_log_protobuf.cpp
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.cpp
@@ -166,7 +166,7 @@ MongoDBLogProtobuf::write(const google::protobuf::Message &m)
 {
 	fawkes::MutexLocker lock(mutex_);
 	document            doc{add_message(m)};
-	doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("_time", true)); }));
+	doc.append(kvp("_time", bsoncxx::types::b_date(std::chrono::system_clock::now())));
 	try {
 		collection_.insert_one(doc.view());
 	} catch (mongocxx::operation_exception &) {
@@ -178,7 +178,7 @@ MongoDBLogProtobuf::write(const google::protobuf::Message &m, const view_or_valu
 {
 	fawkes::MutexLocker lock(mutex_);
 	document            doc{add_message(m)};
-	doc.append(kvp("$currentDate", [](sub_document subdoc) { subdoc.append(kvp("_time", true)); }));
+	doc.append(kvp("_time", bsoncxx::types::b_date(std::chrono::system_clock::now())));
 	try {
 		collection_.insert_one(doc.view());
 	} catch (mongocxx::operation_exception &) {

--- a/src/libs/mongodb_log/mongodb_log_protobuf.cpp
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.cpp
@@ -162,7 +162,7 @@ MongoDBLogProtobuf::add_message(const google::protobuf::Message &m)
 }
 
 void
-MongoDBLogProtobuf::write(google::protobuf::Message &m)
+MongoDBLogProtobuf::write(const google::protobuf::Message &m)
 {
 	fawkes::MutexLocker lock(mutex_);
 	document            doc{add_message(m)};
@@ -174,7 +174,7 @@ MongoDBLogProtobuf::write(google::protobuf::Message &m)
 }
 
 void
-MongoDBLogProtobuf::write(google::protobuf::Message &m, view_or_value &meta_data)
+MongoDBLogProtobuf::write(const google::protobuf::Message &m, const view_or_value &meta_data)
 {
 	fawkes::MutexLocker lock(mutex_);
 	document            doc{add_message(m)};

--- a/src/libs/mongodb_log/mongodb_log_protobuf.h
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.h
@@ -50,6 +50,7 @@ private:
 
 private:
 	fawkes::Mutex *      mutex_;
+	mongocxx::client     client_;
 	mongocxx::collection collection_;
 };
 

--- a/src/libs/mongodb_log/mongodb_log_protobuf.h
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.h
@@ -23,16 +23,14 @@
 #define __LIBS_MONGODB_LOG_MONGODB_LOG_PROTOBUF_H_
 
 #include <google/protobuf/message.h>
-#include <mongo/bson/bson.h>
 
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/document/view_or_value.hpp>
+#include <mongocxx/client.hpp>
 #include <string>
 
 namespace fawkes {
 class Mutex;
-}
-
-namespace mongo {
-class DBClientBase;
 }
 
 class MongoDBLogProtobuf
@@ -42,18 +40,17 @@ public:
 	virtual ~MongoDBLogProtobuf();
 
 	void write(google::protobuf::Message &m);
-	void write(google::protobuf::Message &m, mongo::BSONObj &meta_data);
+	void write(google::protobuf::Message &m, bsoncxx::document::view_or_value &meta_data);
 
 private:
-	void add_field(const ::google::protobuf::FieldDescriptor *field,
-	               const ::google::protobuf::Message &        m,
-	               mongo::BSONObjBuilder *                    b);
-	void add_message(const google::protobuf::Message &m, mongo::BSONObjBuilder *b);
+	void                              add_field(const ::google::protobuf::FieldDescriptor *field,
+	                                            const ::google::protobuf::Message &        m,
+	                                            bsoncxx::builder::basic::document *        doc);
+	bsoncxx::builder::basic::document add_message(const google::protobuf::Message &m);
 
 private:
-	std::string          collection_;
 	fawkes::Mutex *      mutex_;
-	mongo::DBClientBase *mongodb_;
+	mongocxx::collection collection_;
 };
 
 #endif

--- a/src/libs/mongodb_log/mongodb_log_protobuf.h
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.h
@@ -39,8 +39,8 @@ public:
 	MongoDBLogProtobuf(std::string host_port, std::string collection);
 	virtual ~MongoDBLogProtobuf();
 
-	void write(google::protobuf::Message &m);
-	void write(google::protobuf::Message &m, bsoncxx::document::view_or_value &meta_data);
+	void write(const google::protobuf::Message &m);
+	void write(const google::protobuf::Message &m, const bsoncxx::document::view_or_value &meta_data);
 
 private:
 	void                              add_field(const ::google::protobuf::FieldDescriptor *field,

--- a/src/refbox/Makefile
+++ b/src/refbox/Makefile
@@ -49,6 +49,8 @@ ifeq ($(HAVE_PROTOBUF)$(HAVE_MPS_COMM)$(HAVE_CLIPS)$(HAVE_BOOST_LIBS),1111)
 
   ifeq ($(HAVE_MONGODB),1)
     LIBS_llsf_refbox += llsf_mongodb_log
+  else
+    WARN_TARGETS += warning_mongodb
   endif
 else
   ifneq ($(HAVE_PROTOBUF),1)
@@ -71,7 +73,7 @@ endif
 
 ifeq ($(OBJSSUBMAKE),1)
 all: $(WARN_TARGETS) $(WARN_TARGETS_BOOST)
-.PHONY: warning_libmps_comm warning_protobuf warning_clips warning_mongodb $(WARN_TARGETS_BOOST)
+.PHONY: $(WARN_TARGETS)
 warning_libmps_comm:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build RCLL RefBox$(TNORMAL) (libmps_comm not available)"
 warning_protobuf:

--- a/src/refbox/main.cpp
+++ b/src/refbox/main.cpp
@@ -37,10 +37,8 @@
 #include "refbox.h"
 
 #include <clipsmm.h>
+#include <mongocxx/instance.hpp>
 #include <termios.h>
-#ifdef HAVE_MONGODB_VERSION_H
-#	include <mongo/client/init.h>
-#endif
 
 using namespace llsfrb;
 
@@ -54,8 +52,8 @@ main(int argc, char **argv)
 	tcsetattr(0, TCSANOW, &term);
 
 	CLIPS::init();
-#ifdef HAVE_MONGODB_VERSION_H
-	mongo::client::initialize();
+#ifdef HAVE_MONGODB
+	mongocxx::instance mongodb_instance{};
 #endif
 	LLSFRefBox llsfrb(argc, argv);
 	int        rv = llsfrb.run();

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -1456,10 +1456,7 @@ LLSFRefBox::clips_mongodb_update(std::string collection, void *bson, CLIPS::Valu
 		return;
 	}
 
-	document update_doc{};
-	update_doc.append(kvp("$set", doc->view()));
-
-	mongodb_update(collection, update_doc.view(), query, false);
+	mongodb_update(collection, doc->view(), query, false);
 }
 
 void

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -1533,9 +1533,9 @@ LLSFRefBox::clips_mongodb_cursor_next(void *cursor)
 	if (it == (*c)->end()) {
 		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
 	}
-	auto doc = new document();
-	doc->append(bsoncxx::builder::concatenate(*it));
-	return CLIPS::Value(doc);
+	document doc{};
+	doc.append(bsoncxx::builder::concatenate(*it));
+	return CLIPS::Value(new bsoncxx::document::value(doc.extract()));
 }
 
 CLIPS::Values

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -4,6 +4,7 @@
  *
  *  Created: Thu Feb 07 11:04:17 2013
  *  Copyright  2013  Tim Niemueller [www.niemueller.de]
+ *             2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
  ****************************************************************************/
 
 /*  Redistribution and use in source and binary forms, with or without
@@ -1585,9 +1586,7 @@ LLSFRefBox::clips_bson_get(void *bson, std::string field_name)
 	case bsoncxx::type::k_int32: return CLIPS::Value(element->get_int32());
 	case bsoncxx::type::k_int64: return CLIPS::Value(element->get_int64());
 	case bsoncxx::type::k_document: {
-		auto obj_doc = new document();
-		obj_doc->append(bsoncxx::builder::concatenate(element->get_document().view()));
-		return CLIPS::Value(obj_doc);
+		return CLIPS::Value(new bsoncxx::document::value(element->get_document().view()));
 	}
 	default: return CLIPS::Value("INVALID_VALUE_TYPE", CLIPS::TYPE_SYMBOL);
 	}
@@ -1628,16 +1627,18 @@ LLSFRefBox::clips_bson_get_array(void *bson, std::string field_name)
 
 	for (auto element = array_view.begin(); element != array_view.end(); element++) {
 		switch (element->type()) {
-		case bsoncxx::type::k_double: rv.push_back(CLIPS::Value(element->get_double()));
-		case bsoncxx::type::k_utf8: rv.push_back(CLIPS::Value(element->get_utf8().value.to_string()));
+		case bsoncxx::type::k_double: rv.push_back(CLIPS::Value(element->get_double())); break;
+		case bsoncxx::type::k_utf8:
+			rv.push_back(CLIPS::Value(element->get_utf8().value.to_string()));
+			break;
 		case bsoncxx::type::k_bool:
 			CLIPS::Value(element->get_bool() ? "TRUE" : "FALSE", CLIPS::TYPE_SYMBOL);
-		case bsoncxx::type::k_int32: rv.push_back(CLIPS::Value(element->get_int32()));
-		case bsoncxx::type::k_int64: rv.push_back(CLIPS::Value(element->get_int64()));
+			break;
+		case bsoncxx::type::k_int32: rv.push_back(CLIPS::Value(element->get_int32())); break;
+		case bsoncxx::type::k_int64: rv.push_back(CLIPS::Value(element->get_int64())); break;
 		case bsoncxx::type::k_document: {
-			auto obj_doc = new document();
-			obj_doc->append(bsoncxx::builder::concatenate(element->get_document().view()));
-			rv.push_back(CLIPS::Value(obj_doc));
+			rv.push_back(CLIPS::Value(new bsoncxx::document::value(element->get_document().view())));
+			break;
 		}
 		default:
 			rv.clear();

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -285,8 +285,8 @@ LLSFRefBox::LLSFRefBox(int argc, char **argv)
 
 		mongodb_protobuf_ = new MongoDBLogProtobuf(cfg_mongodb_hostport_, mdb_protobuf);
 
-		auto client = mongocxx::client{mongocxx::uri{"mongodb://" + cfg_mongodb_hostport_}};
-		database_   = client["rcll"];
+		client_   = mongocxx::client{mongocxx::uri{"mongodb://" + cfg_mongodb_hostport_}};
+		database_ = client_["rcll"];
 
 		setup_clips_mongodb();
 

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -1570,7 +1570,10 @@ LLSFRefBox::clips_bson_get(void *bson, std::string field_name)
 
 	auto element = doc->view().find(field_name);
 	if (element == doc->view().end()) {
-		logger_->log_error("MongoDB", "mongodb-bson-get: has no field %s", field_name.c_str());
+		logger_->log_error("MongoDB",
+		                   "mongodb-bson-get: cannot get field '%s' from document: %s",
+		                   field_name.c_str(),
+		                   bsoncxx::to_json(doc->view()).c_str());
 		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
 	}
 
@@ -1605,7 +1608,10 @@ LLSFRefBox::clips_bson_get_array(void *bson, std::string field_name)
 
 	auto element = doc->view().find(field_name);
 	if (element == doc->view().end()) {
-		logger_->log_error("MongoDB", "mongodb-bson-get-array: has no field %s", field_name.c_str());
+		logger_->log_error("MongoDB",
+		                   "mongodb-bson-get-array: cannot get field '%s' from document: %s",
+		                   field_name.c_str(),
+		                   bsoncxx::to_json(doc->view()).c_str());
 		rv.push_back(CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL));
 		return rv;
 	}
@@ -1657,7 +1663,10 @@ LLSFRefBox::clips_bson_get_time(void *bson, std::string field_name)
 
 	auto element = doc->view().find(field_name);
 	if (element == doc->view().end()) {
-		logger_->log_error("MongoDB", "mongodb-bson-get-time: has no field %s", field_name.c_str());
+		logger_->log_error("MongoDB",
+		                   "mongodb-bson-get-time: cannot get field '%s' from document: %s",
+		                   field_name.c_str(),
+		                   bsoncxx::to_json(doc->view()).c_str());
 		rv.push_back(CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL));
 		return rv;
 	}

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -1131,10 +1131,10 @@ LLSFRefBox::setup_clips_mongodb()
 	                     sigc::slot<void, void *, std::string, CLIPS::Values>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_bson_append_array)));
 	clips_->add_function("bson-array-start",
-	                     sigc::slot<CLIPS::Value, void *, std::string>(
+	                     sigc::slot<CLIPS::Value>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_bson_array_start)));
 	clips_->add_function("bson-array-finish",
-	                     sigc::slot<void, void *>(
+	                     sigc::slot<void, void *, std::string, void *>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_bson_array_finish)));
 	clips_->add_function("bson-array-append",
 	                     sigc::slot<void, void *, CLIPS::Value>(
@@ -1308,27 +1308,42 @@ LLSFRefBox::clips_bson_append_array(void *bson, std::string field_name, CLIPS::V
 }
 
 CLIPS::Value
-LLSFRefBox::clips_bson_array_start(void *bson, std::string field_name)
+LLSFRefBox::clips_bson_array_start()
 {
-	// With the new libmongocxx, we can no longer create an open array as
-	// sub-field of another document.
-	throw Exception("Not implemented");
+	return CLIPS::Value(new bsoncxx::builder::basic::array{});
 }
 
 void
-LLSFRefBox::clips_bson_array_finish(void *barr)
+LLSFRefBox::clips_bson_array_finish(void *bson, std::string field_name, void *array)
 {
-	// With the new libmongocxx, we can no longer create an open array as
-	// sub-field of another document.
-	throw Exception("Not implemented");
+	auto doc       = static_cast<document *>(bson);
+	auto array_doc = static_cast<bsoncxx::builder::basic::array *>(array);
+	doc->append(kvp(field_name, array_doc->view()));
+	delete array_doc;
 }
 
 void
-LLSFRefBox::clips_bson_array_append(void *barr, CLIPS::Value value)
+LLSFRefBox::clips_bson_array_append(void *array, CLIPS::Value value)
 {
-	// With the new libmongocxx, we can no longer create an open array as
-	// sub-field of another document.
-	throw Exception("Not implemented");
+	auto array_doc = static_cast<bsoncxx::builder::basic::array *>(array);
+	switch (value.type()) {
+	case CLIPS::TYPE_FLOAT: array_doc->append(value.as_float()); break;
+
+	case CLIPS::TYPE_INTEGER: array_doc->append(static_cast<int64_t>(value.as_integer())); break;
+
+	case CLIPS::TYPE_SYMBOL:
+	case CLIPS::TYPE_STRING:
+	case CLIPS::TYPE_INSTANCE_NAME: array_doc->append(value.as_string()); break;
+
+	case CLIPS::TYPE_EXTERNAL_ADDRESS: {
+		auto subb = static_cast<document *>(value.as_address());
+		array_doc->append(subb->view());
+	} break;
+	default:
+		logger_->log_warn("MongoDB",
+		                  "bson-array-append: tried to add unknown type to BSON array field");
+		break;
+	}
 }
 
 void

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -1164,17 +1164,17 @@ LLSFRefBox::setup_clips_mongodb()
 	clips_->add_function("mongodb-query-sort",
 	                     sigc::slot<CLIPS::Value, std::string, void *, void *>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_mongodb_query_sort)));
-	/*
 	clips_->add_function("mongodb-cursor-destroy",
 	                     sigc::slot<void, void *>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_mongodb_cursor_destroy)));
+	/*
 	clips_->add_function("mongodb-cursor-more",
 	                     sigc::slot<CLIPS::Value, void *>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_mongodb_cursor_more)));
+  */
 	clips_->add_function("mongodb-cursor-next",
 	                     sigc::slot<CLIPS::Value, void *>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_mongodb_cursor_next)));
-  */
 	clips_->add_function("bson-field-names",
 	                     sigc::slot<CLIPS::Values, void *>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_bson_field_names)));
@@ -1475,7 +1475,6 @@ LLSFRefBox::clips_mongodb_query(std::string collection, void *bson)
 	return clips_mongodb_query_sort(collection, bson, NULL);
 }
 
-/*
 void
 LLSFRefBox::clips_mongodb_cursor_destroy(void *cursor)
 {
@@ -1489,6 +1488,7 @@ LLSFRefBox::clips_mongodb_cursor_destroy(void *cursor)
 	delete c;
 }
 
+/*
 CLIPS::Value
 LLSFRefBox::clips_mongodb_cursor_more(void *cursor)
 {
@@ -1501,6 +1501,7 @@ LLSFRefBox::clips_mongodb_cursor_more(void *cursor)
 
 	return CLIPS::Value((*c)->more() ? "TRUE" : "FALSE", CLIPS::TYPE_SYMBOL);
 }
+*/
 
 CLIPS::Value
 LLSFRefBox::clips_mongodb_cursor_next(void *cursor)
@@ -1512,11 +1513,14 @@ LLSFRefBox::clips_mongodb_cursor_next(void *cursor)
 		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
 	}
 
-  auto doc = new document();
-  doc->append(bsoncxx::builder::concatenate((*c)->next());
+	auto it = (*c)->begin();
+	if (it == (*c)->end()) {
+		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
+	}
+	auto doc = new document();
+	doc->append(bsoncxx::builder::concatenate(*it));
 	return CLIPS::Value(doc);
 }
-*/
 
 CLIPS::Values
 LLSFRefBox::clips_bson_field_names(void *bson)

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -1122,6 +1122,9 @@ LLSFRefBox::setup_clips_mongodb()
 	clips_->add_function("bson-parse",
 	                     sigc::slot<CLIPS::Value, std::string>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_bson_parse)));
+	clips_->add_function("bson-builder-destroy",
+	                     sigc::slot<void, void *>(
+	                       sigc::mem_fun(*this, &LLSFRefBox::clips_bson_builder_destroy)));
 	clips_->add_function("bson-destroy",
 	                     sigc::slot<void, void *>(
 	                       sigc::mem_fun(*this, &LLSFRefBox::clips_bson_destroy)));
@@ -1225,9 +1228,16 @@ LLSFRefBox::clips_bson_parse(std::string document)
 }
 
 void
-LLSFRefBox::clips_bson_destroy(void *bson)
+LLSFRefBox::clips_bson_builder_destroy(void *bson)
 {
 	auto b = static_cast<bsoncxx::builder::basic::document *>(bson);
+	delete b;
+}
+
+void
+LLSFRefBox::clips_bson_destroy(void *bson)
+{
+	auto b = static_cast<bsoncxx::document::value *>(bson);
 	delete b;
 }
 

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -67,6 +67,7 @@ class ServicePublisher;
 
 #ifdef HAVE_MONGODB
 #	include <mongocxx/database.hpp>
+#	include <mongocxx/client.hpp>
 class MongoDBLogProtobuf;
 #endif
 
@@ -215,6 +216,7 @@ private: // members
 	bool                cfg_mongodb_enabled_;
 	std::string         cfg_mongodb_hostport_;
 	MongoDBLogProtobuf *mongodb_protobuf_;
+	mongocxx::client    client_;
 	mongocxx::database  database_;
 #endif
 

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -4,6 +4,7 @@
  *
  *  Created: Thu Feb 07 11:02:51 2013
  *  Copyright  2013  Tim Niemueller [www.niemueller.de]
+ *             2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
  ****************************************************************************/
 
 /*  Redistribution and use in source and binary forms, with or without
@@ -111,6 +112,7 @@ private: // methods
 #ifdef HAVE_MONGODB
 	CLIPS::Value clips_bson_create();
 	CLIPS::Value clips_bson_parse(std::string document);
+	void         clips_bson_builder_destroy(void *bson);
 	void         clips_bson_destroy(void *bson);
 	void         clips_bson_append(void *bson, std::string field_name, CLIPS::Value value);
 	void         clips_bson_append_array(void *bson, std::string field_name, CLIPS::Values values);

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -129,8 +129,8 @@ private: // methods
 	CLIPS::Value clips_mongodb_query_sort(std::string collection, void *bson, void *bson_sort);
 	CLIPS::Value clips_mongodb_query(std::string collection, void *bson);
 	//	CLIPS::Value  clips_mongodb_cursor_more(void *cursor);
-	//	CLIPS::Value  clips_mongodb_cursor_next(void *cursor);
-	//	void          clips_mongodb_cursor_destroy(void *cursor);
+	CLIPS::Value  clips_mongodb_cursor_next(void *cursor);
+	void          clips_mongodb_cursor_destroy(void *cursor);
 	CLIPS::Values clips_bson_field_names(void *bson);
 	CLIPS::Value  clips_bson_get(void *bson, std::string field_name);
 	CLIPS::Values clips_bson_get_array(void *bson, std::string field_name);

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -49,9 +49,6 @@
 #include <boost/asio.hpp>
 #include <clipsmm.h>
 #include <future>
-#ifdef HAVE_MONGODB
-#	include <mongo/bson/bson.h>
-#endif
 
 namespace mps_placing_clips {
 class MPSPlacingGenerator;
@@ -69,12 +66,8 @@ class ServicePublisher;
 #endif
 
 #ifdef HAVE_MONGODB
+#	include <mongocxx/database.hpp>
 class MongoDBLogProtobuf;
-namespace mongo {
-class BSONObjBuilder;
-class DBClientBase;
-class BSONObj;
-} // namespace mongo
 #endif
 
 namespace llsfrb {
@@ -129,13 +122,15 @@ private: // methods
 	void         clips_mongodb_update(std::string collection, void *bson, CLIPS::Value query);
 	void         clips_mongodb_replace(std::string collection, void *bson, CLIPS::Value query);
 	void         clips_mongodb_insert(std::string collection, void *bson);
-	void
-	              mongodb_update(std::string &collection, mongo::BSONObj obj, CLIPS::Value &query, bool upsert);
-	CLIPS::Value  clips_mongodb_query_sort(std::string collection, void *bson, void *bson_sort);
-	CLIPS::Value  clips_mongodb_query(std::string collection, void *bson);
-	CLIPS::Value  clips_mongodb_cursor_more(void *cursor);
-	CLIPS::Value  clips_mongodb_cursor_next(void *cursor);
-	void          clips_mongodb_cursor_destroy(void *cursor);
+	void         mongodb_update(std::string &                  collection,
+	                            const bsoncxx::document::view &doc,
+	                            CLIPS::Value &                 query,
+	                            bool                           upsert);
+	CLIPS::Value clips_mongodb_query_sort(std::string collection, void *bson, void *bson_sort);
+	CLIPS::Value clips_mongodb_query(std::string collection, void *bson);
+	//	CLIPS::Value  clips_mongodb_cursor_more(void *cursor);
+	//	CLIPS::Value  clips_mongodb_cursor_next(void *cursor);
+	//	void          clips_mongodb_cursor_destroy(void *cursor);
 	CLIPS::Values clips_bson_field_names(void *bson);
 	CLIPS::Value  clips_bson_get(void *bson, std::string field_name);
 	CLIPS::Values clips_bson_get_array(void *bson, std::string field_name);
@@ -185,7 +180,7 @@ private: // methods
 	                            std::shared_ptr<google::protobuf::Message> msg);
 
 #ifdef HAVE_MONGODB
-	void add_comp_type(google::protobuf::Message &m, mongo::BSONObjBuilder *b);
+	void add_comp_type(google::protobuf::Message &m, bsoncxx::builder::basic::document *doc);
 #endif
 
 private: // members
@@ -217,10 +212,10 @@ private: // members
 #endif
 
 #ifdef HAVE_MONGODB
-	bool                 cfg_mongodb_enabled_;
-	std::string          cfg_mongodb_hostport_;
-	MongoDBLogProtobuf * mongodb_protobuf_;
-	mongo::DBClientBase *mongodb_;
+	bool                cfg_mongodb_enabled_;
+	std::string         cfg_mongodb_hostport_;
+	MongoDBLogProtobuf *mongodb_protobuf_;
+	mongocxx::database  database_;
 #endif
 
 	MPSRefboxInterface *mps_;

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -115,8 +115,8 @@ private: // methods
 	void         clips_bson_append(void *bson, std::string field_name, CLIPS::Value value);
 	void         clips_bson_append_array(void *bson, std::string field_name, CLIPS::Values values);
 	void         clips_bson_append_time(void *bson, std::string field_name, CLIPS::Values time);
-	CLIPS::Value clips_bson_array_start(void *bson, std::string field_name);
-	void         clips_bson_array_finish(void *barr);
+	CLIPS::Value clips_bson_array_start();
+	void         clips_bson_array_finish(void *bson, std::string field_name, void *array);
 	void         clips_bson_array_append(void *barr, CLIPS::Value value);
 	std::string  clips_bson_tostring(void *bson);
 	void         clips_mongodb_upsert(std::string collection, void *bson, CLIPS::Value query);


### PR DESCRIPTION
Switch from the legacy mongocxx driver to the most recent mongocxx-v3. In particular:
* Adapt the mongodb logger
* Adapt the provided CLIPS functions to use mongocxx-v3

There are some changes that were necessary because the new mongocxx provides a different API:
* We need to distinguish `bsoncxx::document::value` (among others, the result of a query) and `bsoncxx::builder::basic::document` (used to create new documents). Thus, there are now two separate functions in CLIPS to delete a document: `bson-builder-destroy` to destroy a `bsoncxx::builder::basic::document` and `bson-destroy` to destroy a `bsoncxx::document::value`.
* Array building is slightly different. Instead of directly attaching the array to a document, create the array, then add it as a sub-document of an existing doc.