### PR TITLE
Load ring colors from mongodb

### DIFF
--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -143,6 +143,18 @@
 				(modify ?m-magenta (zone ?z-cyan) (rotation ?r-cyan))
 			)
 	  )
+
+    ; Randomize ring colors per machine
+    (do-for-fact ((?m-cyan machine) (?m-magenta machine))
+                 (and (eq ?m-cyan:name C-RS1) (eq ?m-magenta:name M-RS1))
+      (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 1 2)))
+      (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 1 2)))
+    )
+    (do-for-fact ((?m-cyan machine) (?m-magenta machine))
+                 (and (eq ?m-cyan:name C-RS2) (eq ?m-magenta:name M-RS2))
+      (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+      (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+    )
   )
 
   ; assign random down times
@@ -168,20 +180,6 @@
 
       (modify ?c (down-period ?start-time ?end-time))
     )
-  )
-
-  ; Randomize ring colors per machine
-  (do-for-fact ((?m-cyan machine) (?m-magenta machine))
-    (and (eq ?m-cyan:name C-RS1) (eq ?m-magenta:name M-RS1))
-
-    (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 1 2)))
-    (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 1 2)))
-  )
-  (do-for-fact ((?m-cyan machine) (?m-magenta machine))
-    (and (eq ?m-cyan:name C-RS2) (eq ?m-magenta:name M-RS2))
-
-    (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 3 4)))
-    (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 3 4)))
   )
 
   (assert (machines-initialized))

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -207,6 +207,9 @@
 		(bson-append ?m-doc "name" ?m:name)
 		(bson-append ?m-doc "zone" ?m:zone)
 		(bson-append ?m-doc "rotation" ?m:rotation)
+		(if (eq ?m:mtype RS) then
+			(bson-append-array ?m-doc "rs-ring-colors" ?m:rs-ring-colors)
+		)
 		(bson-array-append ?m-arr ?m-doc)
 		(bson-builder-destroy ?m-doc)
   )

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -254,7 +254,11 @@
 				(bind ?m-rotation (sym-cat (bson-get ?m-p "rotation")))
 				;(printout t "Machine " ?m-name " is in zone " ?m-zone " with rotation " ?m-rotation crlf)
 				(do-for-fact ((?m machine)) (eq ?m:name ?m-name)
-					(modify ?m (zone ?m-zone) (rotation (integer (eval ?m-rotation))))
+					(bind ?ring-colors (create$))
+					(if (eq ?m:mtype RS) then
+						(bind ?ring-colors (bson-get-array ?m-p "rs-ring-colors"))
+					)
+					(modify ?m (zone ?m-zone) (rs-ring-colors ?ring-colors) (rotation (integer (eval ?m-rotation))))
 			  )
 				(bson-destroy ?m-p)
 			)


### PR DESCRIPTION
When loading a game configuration from the database, also load the assignment of the ring colors to the ring stations.

Fixes #47.