### PR TITLE
update config parser lib according to changes in the fawkes repo

### DIFF
--- a/src/libs/config/config.cpp
+++ b/src/libs/config/config.cpp
@@ -593,7 +593,6 @@ CouldNotOpenConfigException::CouldNotOpenConfigException(const char *format, ...
  *
  */
 
-
 float
 Configuration::get_float_or_default(const char *path, const float &default_val)
 {

--- a/src/libs/config/config.cpp
+++ b/src/libs/config/config.cpp
@@ -45,10 +45,10 @@ namespace llsfrb {
  * 
  *
  * @fn void Configuration::copy(Configuration *copyconf)
- * Copy all values from the given configuration.
+ * Copies all values from the given configuration.
  * All values from the given configuration are copied. Old values are not erased
  * so that the copied values will overwrite existing values, new values are
- * created, but values existent in current config but not in the copie config
+ * created, but values existent in current config but not in the copied config
  * will remain unchanged.
  * @param copyconf configuration to copy
  * 
@@ -140,6 +140,76 @@ namespace llsfrb {
  * @fn std::vector<std::string> Configuration::get_strings(const char *path)
  * Get list of values from configuration which is of type string
  * @param path path to value
+ * @return value
+ *
+ * @fn float Configuration::get_float_or_default(const char *path, const float &default_val)
+ * Get value from configuration which is of type float, or the given default if
+ * the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn unsigned int Configuration::get_uint_or_default(const char *path, const unsigned int &default_val)
+ * Get value from configuration which is of type unsigned int, or the given
+ * default if the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn int Configuration::get_int_or_default(const char *path, const int &default_val)
+ * Get value from configuration which is of type int, or the given default if
+ * the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn bool Configuration::get_bool_or_default(const char *path, const bool &default_val)
+ * Get value from configuration which is of type bool, or the given default if
+ * the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn string Configuration::get_string_or_default(const char *path, const string &default_val)
+ * Get value from configuration which is of type string, or the given default if
+ * the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn std::vector<float> Configuration::get_floats_or_defaults(const char *path, const std::vector<float> &default_val)
+ * Get list of values from configuration which is of type float, or the given
+ * default if the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn std::vector<unsigned int> Configuration::get_uints_or_defaults(const char *path, const std::vector<unsigned int> &default_val)
+ * Get list of values from configuration which is of type unsigned int, or the given
+ * default if the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn std::vector<int> Configuration::get_ints_or_defaults(const char *path, const std::vector<int> &default_val)
+ * Get list of values from configuration which is of type int, or the given
+ * default if the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn std::vector<bool> Configuration::get_bools_or_defaults(const char *path, const std::vector<bool> &default_val)
+ * Get list of values from configuration which is of type bool, or the given
+ * default if the path does not exist
+ * @param path path to value
+ * @param default_val the default value
+ * @return value
+ *
+ * @fn std::vector<string> Configuration::get_strings_or_defaults(const char *path, const std::vector<string> &default_val)
+ * Get list of values from configuration which is of type string, or the given
+ * default if the path does not exist
+ * @param path path to value
+ * @param default_val the default value
  * @return value
  *
  * @fn Configuration::ValueIterator * Configuration::get_value(const char *path)
@@ -522,5 +592,107 @@ CouldNotOpenConfigException::CouldNotOpenConfigException(const char *format, ...
  * @return value as string
  *
  */
+
+
+float
+Configuration::get_float_or_default(const char *path, const float &default_val)
+{
+	try {
+		return get_float(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+unsigned int
+Configuration::get_uint_or_default(const char *path, const unsigned int &default_val)
+{
+	try {
+		return get_uint(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+int
+Configuration::get_int_or_default(const char *path, const int &default_val)
+{
+	try {
+		return get_int(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+bool
+Configuration::get_bool_or_default(const char *path, const bool &default_val)
+{
+	try {
+		return get_bool(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+std::string
+Configuration::get_string_or_default(const char *path, const std::string &default_val)
+{
+	try {
+		return get_string(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+std::vector<float>
+Configuration::get_floats_or_defaults(const char *path, const std::vector<float> &default_val)
+{
+	try {
+		return get_floats(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+std::vector<unsigned int>
+Configuration::get_uints_or_defaults(const char *path, const std::vector<unsigned int> &default_val)
+{
+	try {
+		return get_uints(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+std::vector<int>
+Configuration::get_ints_or_defaults(const char *path, const std::vector<int> &default_val)
+{
+	try {
+		return get_ints(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+std::vector<bool>
+Configuration::get_bools_or_defaults(const char *path, const std::vector<bool> &default_val)
+{
+	try {
+		return get_bools(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
+
+std::vector<std::string>
+Configuration::get_strings_or_defaults(const char *                    path,
+                                       const std::vector<std::string> &default_val)
+{
+	try {
+		return get_strings(path);
+	} catch (ConfigEntryNotFoundException &e) {
+		return default_val;
+	}
+}
 
 } // end namespace llsfrb

--- a/src/libs/config/config.h
+++ b/src/libs/config/config.h
@@ -117,20 +117,35 @@ public:
 
 	virtual bool is_default(const char *path) = 0;
 
-	virtual float                     get_float(const char *path)           = 0;
-	virtual unsigned int              get_uint(const char *path)            = 0;
-	virtual int                       get_int(const char *path)             = 0;
-	virtual bool                      get_bool(const char *path)            = 0;
-	virtual std::string               get_string(const char *path)          = 0;
-	virtual std::vector<float>        get_floats(const char *path)          = 0;
-	virtual std::vector<unsigned int> get_uints(const char *path)           = 0;
-	virtual std::vector<int>          get_ints(const char *path)            = 0;
-	virtual std::vector<bool>         get_bools(const char *path)           = 0;
-	virtual std::vector<std::string>  get_strings(const char *path)         = 0;
-	virtual ValueIterator *           get_value(const char *path)           = 0;
-	virtual std::string               get_type(const char *path)            = 0;
-	virtual std::string               get_comment(const char *path)         = 0;
-	virtual std::string               get_default_comment(const char *path) = 0;
+	virtual float        get_float(const char *path)  = 0;
+	virtual unsigned int get_uint(const char *path)   = 0;
+	virtual int          get_int(const char *path)    = 0;
+	virtual bool         get_bool(const char *path)   = 0;
+	virtual std::string  get_string(const char *path) = 0;
+	virtual float        get_float_or_default(const char *path, const float &default_val);
+	virtual unsigned int get_uint_or_default(const char *path, const unsigned int &default_val);
+	virtual int          get_int_or_default(const char *path, const int &default_val);
+	virtual bool         get_bool_or_default(const char *path, const bool &default_val);
+	virtual std::string  get_string_or_default(const char *path, const std::string &default_val);
+	virtual std::vector<float>        get_floats(const char *path)  = 0;
+	virtual std::vector<unsigned int> get_uints(const char *path)   = 0;
+	virtual std::vector<int>          get_ints(const char *path)    = 0;
+	virtual std::vector<bool>         get_bools(const char *path)   = 0;
+	virtual std::vector<std::string>  get_strings(const char *path) = 0;
+	virtual std::vector<float>        get_floats_or_defaults(const char *              path,
+	                                                         const std::vector<float> &default_val);
+	virtual std::vector<unsigned int>
+	                          get_uints_or_defaults(const char *path, const std::vector<unsigned int> &default_val);
+	virtual std::vector<int>  get_ints_or_defaults(const char *            path,
+	                                               const std::vector<int> &default_val);
+	virtual std::vector<bool> get_bools_or_defaults(const char *             path,
+	                                                const std::vector<bool> &default_val);
+	virtual std::vector<std::string>
+	                       get_strings_or_defaults(const char *path, const std::vector<std::string> &default_val);
+	virtual ValueIterator *get_value(const char *path)           = 0;
+	virtual std::string    get_type(const char *path)            = 0;
+	virtual std::string    get_comment(const char *path)         = 0;
+	virtual std::string    get_default_comment(const char *path) = 0;
 
 	virtual void set_float(const char *path, float f)                         = 0;
 	virtual void set_uint(const char *path, unsigned int uint)                = 0;
@@ -170,6 +185,253 @@ public:
 	virtual void unlock()   = 0;
 
 	virtual void try_dump() = 0;
+
+	/// @cond CONVENIENCE_METHODS
+	virtual bool
+	exists(const std::string &path)
+	{
+		return exists(path.c_str());
+	}
+
+	virtual bool
+	is_float(const std::string &path)
+	{
+		return is_float(path.c_str());
+	}
+	virtual bool
+	is_uint(const std::string &path)
+	{
+		return is_uint(path.c_str());
+	}
+	virtual bool
+	is_int(const std::string &path)
+	{
+		return is_int(path.c_str());
+	}
+	virtual bool
+	is_bool(const std::string &path)
+	{
+		return is_bool(path.c_str());
+	}
+	virtual bool
+	is_string(const std::string &path)
+	{
+		return is_string(path.c_str());
+	}
+	virtual bool
+	is_list(const std::string &path)
+	{
+		return is_list(path.c_str());
+	}
+
+	virtual bool
+	is_default(const std::string &path)
+	{
+		return is_default(path.c_str());
+	}
+
+	virtual float
+	get_float(const std::string &path)
+	{
+		return get_float(path.c_str());
+	}
+	virtual unsigned int
+	get_uint(const std::string &path)
+	{
+		return get_uint(path.c_str());
+	}
+	virtual int
+	get_int(const std::string &path)
+	{
+		return get_int(path.c_str());
+	}
+	virtual bool
+	get_bool(const std::string &path)
+	{
+		return get_bool(path.c_str());
+	}
+	virtual std::string
+	get_string(const std::string &path)
+	{
+		return get_string(path.c_str());
+	}
+	virtual std::vector<float>
+	get_floats(const std::string &path)
+	{
+		return get_floats(path.c_str());
+	}
+	virtual std::vector<unsigned int>
+	get_uints(const std::string &path)
+	{
+		return get_uints(path.c_str());
+	}
+	virtual std::vector<int>
+	get_ints(const std::string &path)
+	{
+		return get_ints(path.c_str());
+	}
+	virtual std::vector<bool>
+	get_bools(const std::string &path)
+	{
+		return get_bools(path.c_str());
+	}
+	virtual std::vector<std::string>
+	get_strings(const std::string &path)
+	{
+		return get_strings(path.c_str());
+	}
+	virtual ValueIterator *
+	get_value(const std::string &path)
+	{
+		return get_value(path.c_str());
+	}
+	virtual std::string
+	get_type(const std::string &path)
+	{
+		return get_type(path.c_str());
+	}
+	virtual std::string
+	get_comment(const std::string &path)
+	{
+		return get_comment(path.c_str());
+	}
+	virtual std::string
+	get_default_comment(const std::string &path)
+	{
+		return get_default_comment(path.c_str());
+	}
+
+	virtual void
+	set_float(const std::string &path, float f)
+	{
+		set_float(path.c_str(), f);
+	}
+	virtual void
+	set_uint(const std::string &path, unsigned int uint)
+	{
+		set_uint(path.c_str(), uint);
+	}
+	virtual void
+	set_int(const std::string &path, int i)
+	{
+		set_int(path.c_str(), i);
+	}
+	virtual void
+	set_bool(const std::string &path, bool b)
+	{
+		set_bool(path.c_str(), b);
+	}
+	virtual void
+	set_string(const std::string &path, std::string &s)
+	{
+		set_string(path.c_str(), s);
+	}
+	virtual void
+	set_string(const std::string &path, const char *s)
+	{
+		set_string(path.c_str(), s);
+	}
+	virtual void
+	set_floats(const std::string &path, std::vector<float> &f)
+	{
+		set_floats(path.c_str(), f);
+	}
+	virtual void
+	set_uints(const std::string &path, std::vector<unsigned int> &uint)
+	{
+		set_uints(path.c_str(), uint);
+	}
+	virtual void
+	set_ints(const std::string &path, std::vector<int> &i)
+	{
+		set_ints(path.c_str(), i);
+	}
+	virtual void
+	set_bools(const std::string &path, std::vector<bool> &b)
+	{
+		set_bools(path.c_str(), b);
+	}
+	virtual void
+	set_strings(const std::string &path, std::vector<std::string> &s)
+	{
+		set_strings(path.c_str(), s);
+	}
+	virtual void
+	set_strings(const std::string &path, std::vector<const char *> &s)
+	{
+		set_strings(path.c_str(), s);
+	}
+	virtual void
+	set_comment(const std::string &path, const char *comment)
+	{
+		set_comment(path.c_str(), comment);
+	}
+	virtual void
+	set_comment(const std::string &path, std::string &comment)
+	{
+		set_comment(path.c_str(), comment);
+	}
+
+	virtual void
+	erase(const std::string &path)
+	{
+		erase(path.c_str());
+	}
+
+	virtual void
+	set_default_float(const std::string &path, float f)
+	{
+		set_default_float(path.c_str(), f);
+	}
+	virtual void
+	set_default_uint(const std::string &path, unsigned int uint)
+	{
+		set_default_uint(path.c_str(), uint);
+	}
+	virtual void
+	set_default_int(const std::string &path, int i)
+	{
+		set_default_int(path.c_str(), i);
+	}
+	virtual void
+	set_default_bool(const std::string &path, bool b)
+	{
+		set_default_bool(path.c_str(), b);
+	}
+	virtual void
+	set_default_string(const std::string &path, std::string &s)
+	{
+		set_default_string(path.c_str(), s);
+	}
+	virtual void
+	set_default_string(const std::string &path, const char *s)
+	{
+		set_default_string(path.c_str(), s);
+	}
+
+	virtual void
+	set_default_comment(const std::string &path, const char *comment)
+	{
+		set_default_comment(path.c_str(), comment);
+	}
+	virtual void
+	set_default_comment(const std::string &path, std::string &comment)
+	{
+		set_default_comment(path.c_str(), comment);
+	}
+
+	virtual void
+	erase_default(const std::string &path)
+	{
+		erase_default(path.c_str());
+	}
+
+	virtual ValueIterator *
+	search(const std::string &path)
+	{
+		return search(path.c_str());
+	}
+	/// @endcond
 };
 
 } // end namespace llsfrb

--- a/src/libs/config/config.mk
+++ b/src/libs/config/config.mk
@@ -15,7 +15,7 @@
 
 ifneq ($(PKGCONFIG),)
   HAVE_SQLITE    = $(if $(shell $(PKGCONFIG) --exists 'sqlite3'; echo $${?/1/}),1,0)
-  HAVE_YAMLCPP   = $(if $(shell $(PKGCONFIG) --exists 'yaml-cpp'; echo $${?/1/}),1,0)
+  HAVE_YAMLCPP   = $(if $(shell $(PKGCONFIG) --exists 'yaml-cpp' --atleast-version='0.5'; echo $${?/1/}),1,0)
 endif
 ifeq ($(HAVE_SQLITE),1)
   CFLAGS_SQLITE  = -DHAVE_SQLITE $(shell $(PKGCONFIG) --cflags 'sqlite3')
@@ -24,10 +24,8 @@ endif
 ifeq ($(HAVE_YAMLCPP),1)
   CFLAGS_YAMLCPP  = -DHAVE_YAMLCPP $(shell $(PKGCONFIG) --cflags 'yaml-cpp')
   LDFLAGS_YAMLCPP = $(shell $(PKGCONFIG) --libs 'yaml-cpp')
-
-  HAVE_YAMLCPP_0_5 = $(if $(shell $(PKGCONFIG) --atleast-version='0.5' 'yaml-cpp'; echo $${?/1/}),1,0)
-  ifeq ($(HAVE_YAMLCPP_0_5),1)
-    CFLAGS_YAMLCPP += -DHAVE_YAMLCPP_0_5
+  ifeq ($(if $(shell $(PKGCONFIG) --atleast-version 0.5.3 'yaml-cpp'; echo $${?/1/}),1,0),1)
+    CFLAGS_YAMLCPP += -DHAVE_YAMLCPP_NODE_MARK
   endif
 endif
 

--- a/src/libs/config/yaml.cpp
+++ b/src/libs/config/yaml.cpp
@@ -351,7 +351,6 @@ YamlConfiguration::~YamlConfiguration()
 		write_host_file();
 	}
 
-
 	if (sysconfdir_)
 		free(sysconfdir_);
 	if (userconfdir_)
@@ -387,10 +386,10 @@ YamlConfiguration::load(const char *file_path)
 		}
 		if (filename == "") {
 			throw fawkes::Exception("YamlConfig: cannot find configuration file %s/%s or %s/%s",
-			                userconfdir_,
-			                file_path,
-			                sysconfdir_,
-			                file_path);
+			                        userconfdir_,
+			                        file_path,
+			                        sysconfdir_,
+			                        file_path);
 		}
 	}
 
@@ -504,7 +503,6 @@ YamlConfiguration::read_yaml_config(std::string                             file
 	}
 }
 
-
 /** Create absolute config path.
  * If the @p path starts with / it is considered to be absolute. Otherwise
  * it is prefixed with the config directory.
@@ -576,7 +574,9 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 				if ((stat(dirname.c_str(), &dir_stat) != 0)) {
 					if (ignore_missing)
 						continue;
-					throw fawkes::Exception(errno, "YamlConfig: Failed to stat directory %s", dirname.c_str());
+					throw fawkes::Exception(errno,
+					                        "YamlConfig: Failed to stat directory %s",
+					                        dirname.c_str());
 				}
 
 				if (!S_ISDIR(dir_stat.st_mode)) {
@@ -585,7 +585,9 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 
 				DIR *d = opendir(dirname.c_str());
 				if (!d) {
-					throw fawkes::Exception(errno, "YamlConfig: failed to open directory %s", dirname.c_str());
+					throw fawkes::Exception(errno,
+					                        "YamlConfig: failed to open directory %s",
+					                        dirname.c_str());
 				}
 
 				load_queue.push(LoadQueueEntry(dirname, ignore_missing, true));

--- a/src/libs/config/yaml.cpp
+++ b/src/libs/config/yaml.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include <sys/stat.h>
+#include <utils/misc/string_split.h>
 #include <yaml-cpp/exceptions.h>
 
 #include <cerrno>
@@ -42,17 +43,14 @@
 #include <dirent.h>
 #include <fstream>
 #include <queue>
-
+#include <regex>
+#include <unistd.h>
 namespace llsfrb {
 #if 0 /* just to make Emacs auto-indent happy */
 }
 #endif
 
-#define PATH_REGEX "^[a-zA-Z0-9_-]+$"
-#define YAML_REGEX "^[a-zA-Z0-9_-]+\\.yaml$"
-// from https://www.ietf.org/rfc/rfc3986.txt
-#define URL_REGEX "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
-#define FRAME_REGEX "^(/[a-zA-Z_][a-zA-Z0-9_-]*)+$"
+#define YAML_FILE_REGEX "^[a-zA-Z0-9_-]+\\.yaml$"
 
 /** @class YamlConfiguration::YamlValueIterator <config/yaml.h>
  * Iterator for YAML config trees.
@@ -74,18 +72,17 @@ YamlConfiguration::YamlValueIterator::YamlValueIterator() : first_(true)
  * @param nodes nodes to iterate over
  */
 YamlConfiguration::YamlValueIterator::YamlValueIterator(
-  std::map<std::string, YamlConfigurationNode *> &nodes)
+  std::map<std::string, std::shared_ptr<YamlConfigurationNode>> &nodes)
 : first_(true), nodes_(nodes)
 {
-	current_ = nodes_.end();
+	current_ = nodes_.begin();
 }
 
 bool
 YamlConfiguration::YamlValueIterator::next()
 {
 	if (first_) {
-		first_   = false;
-		current_ = nodes_.begin();
+		first_ = false;
 	} else {
 		++current_;
 	}
@@ -308,30 +305,12 @@ YamlConfiguration::YamlValueIterator::is_default() const
 /** Constructor. */
 YamlConfiguration::YamlConfiguration()
 {
-	root_ = host_root_ = NULL;
-#ifdef HAVE_FAM
-	fam_thread_ = NULL;
-#endif
-	mutex = new fawkes::Mutex();
+	mutex                = new fawkes::Mutex();
+	write_pending_       = false;
+	write_pending_mutex_ = new fawkes::Mutex();
 
-	__sysconfdir  = NULL;
-	__userconfdir = NULL;
-
-#ifdef USE_REGEX_CPP
-	__yaml_regex  = std::regex(YAML_REGEX, std::regex_constants::extended);
-	__url_regex   = std::regex(URL_REGEX, std::regex_constants::extended);
-	__frame_regex = std::regex(FRAME_REGEX, std::regex_constants::extended);
-#else
-	if (regcomp(&__yaml_regex, YAML_REGEX, REG_EXTENDED) != 0) {
-		throw fawkes::Exception("Failed to compile YAML regex");
-	}
-	if (regcomp(&__url_regex, URL_REGEX, REG_EXTENDED) != 0) {
-		throw fawkes::Exception("Failed to compile URL regex");
-	}
-	if (regcomp(&__frame_regex, FRAME_REGEX, REG_EXTENDED) != 0) {
-		throw fawkes::Exception("Failed to compile frame regex");
-	}
-#endif
+	sysconfdir_  = NULL;
+	userconfdir_ = NULL;
 }
 
 /** Constructor.
@@ -345,39 +324,21 @@ YamlConfiguration::YamlConfiguration()
  */
 YamlConfiguration::YamlConfiguration(const char *sysconfdir, const char *userconfdir)
 {
-	root_ = host_root_ = NULL;
-#ifdef HAVE_FAM
-	fam_thread_ = NULL;
-#endif
-	mutex = new fawkes::Mutex();
+	mutex                = new fawkes::Mutex();
+	write_pending_       = false;
+	write_pending_mutex_ = new fawkes::Mutex();
 
-	__sysconfdir = strdup(sysconfdir);
-
-#ifdef USE_REGEX_CPP
-	__yaml_regex  = std::regex(YAML_REGEX, std::regex_constants::extended);
-	__url_regex   = std::regex(URL_REGEX, std::regex_constants::extended);
-	__frame_regex = std::regex(FRAME_REGEX, std::regex_constants::extended);
-#else
-	if (regcomp(&__yaml_regex, YAML_REGEX, REG_EXTENDED) != 0) {
-		throw fawkes::Exception("Failed to compile YAML regex");
-	}
-	if (regcomp(&__url_regex, URL_REGEX, REG_EXTENDED) != 0) {
-		throw fawkes::Exception("Failed to compile URL regex");
-	}
-	if (regcomp(&__frame_regex, FRAME_REGEX, REG_EXTENDED) != 0) {
-		throw fawkes::Exception("Failed to compile frame regex");
-	}
-#endif
+	sysconfdir_ = strdup(sysconfdir);
 
 	if (userconfdir != NULL) {
-		__userconfdir = strdup(userconfdir);
+		userconfdir_ = strdup(userconfdir);
 	} else {
 		const char *homedir = getenv("HOME");
 		if (homedir == NULL) {
-			__userconfdir = strdup(sysconfdir);
+			userconfdir_ = strdup(sysconfdir);
 		} else {
-			if (asprintf(&__userconfdir, "%s/%s", homedir, USERDIR) == -1) {
-				__userconfdir = strdup(sysconfdir);
+			if (asprintf(&userconfdir_, "%s/%s", homedir, USERDIR) == -1) {
+				userconfdir_ = strdup(sysconfdir);
 			}
 		}
 	}
@@ -386,28 +347,17 @@ YamlConfiguration::YamlConfiguration(const char *sysconfdir, const char *usercon
 /** Destructor. */
 YamlConfiguration::~YamlConfiguration()
 {
-	delete root_;
-	delete host_root_;
-	root_ = host_root_ = NULL;
-
-#ifdef HAVE_FAM
-	if (fam_thread_) {
-		fam_thread_->cancel();
-		fam_thread_->join();
-		delete fam_thread_;
+	if (write_pending_) {
+		write_host_file();
 	}
-#endif
 
-	if (__sysconfdir)
-		free(__sysconfdir);
-	if (__userconfdir)
-		free(__userconfdir);
-#ifndef USE_REGEX_CPP
-	regfree(&__yaml_regex);
-	regfree(&__url_regex);
-	regfree(&__frame_regex);
-#endif
+
+	if (sysconfdir_)
+		free(sysconfdir_);
+	if (userconfdir_)
+		free(userconfdir_);
 	delete mutex;
+	delete write_pending_mutex_;
 }
 
 void
@@ -421,7 +371,7 @@ YamlConfiguration::load(const char *file_path)
 	if (file_path[0] == '/') {
 		filename = file_path;
 	} else {
-		const char *try_paths[]   = {__userconfdir, __sysconfdir};
+		const char *try_paths[]   = {userconfdir_, sysconfdir_};
 		int         try_paths_len = 2;
 
 		for (int i = 0; i < try_paths_len; ++i) {
@@ -437,10 +387,10 @@ YamlConfiguration::load(const char *file_path)
 		}
 		if (filename == "") {
 			throw fawkes::Exception("YamlConfig: cannot find configuration file %s/%s or %s/%s",
-			                        __userconfdir,
-			                        file_path,
-			                        __sysconfdir,
-			                        file_path);
+			                userconfdir_,
+			                file_path,
+			                sysconfdir_,
+			                file_path);
 		}
 	}
 
@@ -450,27 +400,10 @@ YamlConfiguration::load(const char *file_path)
 	std::list<std::string> files, dirs;
 	read_yaml_config(filename, host_file_, root_, host_root_, files, dirs);
 
-#ifdef HAVE_FAM
-	fam_thread_                       = new FamThread();
-	RefPtr<FileAlterationMonitor> fam = fam_thread_->get_fam();
-	fam->add_filter("^[^.].*\\.yaml$");
-	std::list<std::string>::iterator f;
-	for (f = files.begin(); f != files.end(); ++f) {
-		//LibLogger::log_info("YC", "Watching %s", f->c_str());
-		fam->watch_file(f->c_str());
-	}
-	for (f = dirs.begin(); f != dirs.end(); ++f) {
-		//LibLogger::log_info("YC", "Watching DIR %s", f->c_str());
-		fam->watch_dir(f->c_str());
-	}
-	fam->add_listener(this);
-	fam_thread_->start();
-#endif
-
 	//root_->print();
 }
 
-YamlConfigurationNode *
+std::shared_ptr<YamlConfigurationNode>
 YamlConfiguration::read_yaml_file(std::string                 filename,
                                   bool                        ignore_missing,
                                   std::queue<LoadQueueEntry> &load_queue,
@@ -483,25 +416,13 @@ YamlConfiguration::read_yaml_file(std::string                 filename,
 		throw fawkes::Exception(errno, "YamlConfig: cannot access file %s", filename.c_str());
 	}
 
-#ifdef HAVE_YAMLCPP_0_5
 	std::vector<YAML::Node> docs;
-#else
-	std::ifstream fin(filename.c_str());
-	YAML::Parser  parser;
-	YAML::Node    doc1, doc2;
-#endif
-	bool have_doc1 = false, have_doc2 = false;
+	bool                    have_doc1 = false, have_doc2 = false;
 
 	try {
-#ifdef HAVE_YAMLCPP_0_5
 		docs      = YAML::LoadAllFromFile(filename);
 		have_doc1 = docs.size() > 0;
 		have_doc2 = docs.size() > 1;
-#else
-    parser.Load(fin);
-    have_doc1 = parser.GetNextDocument(doc1);
-    have_doc2 = parser.GetNextDocument(doc2);
-#endif
 	} catch (YAML::ParserException &e) {
 		throw CouldNotOpenConfigException("Failed to parse %s line %i column %i: %s",
 		                                  filename.c_str(),
@@ -510,42 +431,33 @@ YamlConfiguration::read_yaml_file(std::string                 filename,
 		                                  e.msg.c_str());
 	}
 
-	YamlConfigurationNode *sub_root = NULL;
+	std::shared_ptr<YamlConfigurationNode> sub_root;
 
 	if (!have_doc1) {
 		//throw fawkes::Exception("YamlConfig: file %s contains no document", filename.c_str());
 		// empty -> ignore
 	} else if (have_doc1 && have_doc2) {
 		// we have a meta info and a config document
-#ifdef HAVE_YAMLCPP_0_5
 		read_meta_doc(docs[0], load_queue, host_file);
-		read_config_doc(docs[1], sub_root);
-#else
-    read_meta_doc(doc1, load_queue, host_file);
-    read_config_doc(doc2, sub_root);
-#endif
+		sub_root = read_config_doc(docs[1]);
 
 	} else {
 		// only one, assume this to be the config document
-#ifdef HAVE_YAMLCPP_0_5
-		read_config_doc(docs[0], sub_root);
-#else
-    read_config_doc(doc1, sub_root);
-#endif
+		sub_root = read_config_doc(docs[0]);
 	}
 
 	return sub_root;
 }
 
 void
-YamlConfiguration::read_yaml_config(std::string             filename,
-                                    std::string &           host_file,
-                                    YamlConfigurationNode *&root,
-                                    YamlConfigurationNode *&host_root,
-                                    std::list<std::string> &files,
-                                    std::list<std::string> &dirs)
+YamlConfiguration::read_yaml_config(std::string                             filename,
+                                    std::string &                           host_file,
+                                    std::shared_ptr<YamlConfigurationNode> &root,
+                                    std::shared_ptr<YamlConfigurationNode> &host_root,
+                                    std::list<std::string> &                files,
+                                    std::list<std::string> &                dirs)
 {
-	root = new YamlConfigurationNode();
+	root = std::make_shared<YamlConfigurationNode>();
 
 	std::queue<LoadQueueEntry> load_queue;
 	load_queue.push(LoadQueueEntry(filename, false));
@@ -560,13 +472,12 @@ YamlConfiguration::read_yaml_config(std::string             filename,
 			//                     "Reading YAML file '%s' (ignore missing: %s)",
 			//                     qe.filename.c_str(), qe.ignore_missing ? "yes" : "no");
 
-			YamlConfigurationNode *sub_root =
+			std::shared_ptr<YamlConfigurationNode> sub_root =
 			  read_yaml_file(qe.filename, qe.ignore_missing, load_queue, host_file);
 
 			if (sub_root) {
 				files.push_back(qe.filename);
 				*root += sub_root;
-				delete sub_root;
 			}
 		}
 
@@ -575,7 +486,7 @@ YamlConfiguration::read_yaml_config(std::string             filename,
 
 	if (host_file != "") {
 		//LibLogger::log_debug("YamlConfiguration",
-		//		 "Reading Host YAML file '%s'", host_file.c_str());
+		//			 "Reading Host YAML file '%s'", host_file.c_str());
 		std::queue<LoadQueueEntry> host_load_queue;
 		host_root = read_yaml_file(host_file, true, host_load_queue, host_file);
 		if (!host_load_queue.empty()) {
@@ -585,61 +496,14 @@ YamlConfiguration::read_yaml_config(std::string             filename,
 		if (host_root) {
 			*root += host_root;
 			files.push_back(host_file);
-		} else
-			host_root = new YamlConfigurationNode();
+		} else {
+			host_root = std::make_shared<YamlConfigurationNode>();
+		}
 	} else {
-		host_root = new YamlConfigurationNode();
+		host_root = std::make_shared<YamlConfigurationNode>();
 	}
 }
 
-#ifdef HAVE_FAM
-void
-YamlConfiguration::fam_event(const char *filename, unsigned int mask)
-{
-	try {
-		std::string            host_file = "";
-		std::list<std::string> files, dirs;
-		YamlConfigurationNode *root, *host_root;
-		read_yaml_config(config_file_, host_file, root, host_root, files, dirs);
-
-		std::list<std::string> changes = YamlConfigurationNode::diff(root_, root);
-
-		if (!changes.empty()) {
-			YamlConfigurationNode *old_root      = root_;
-			YamlConfigurationNode *old_host_root = host_root_;
-			root_                                = root;
-			host_root_                           = host_root;
-			host_file_                           = host_file;
-			delete old_root;
-			delete old_host_root;
-
-			std::list<std::string>::iterator c;
-			for (c = changes.begin(); c != changes.end(); ++c) {
-				notify_handlers(c->c_str());
-			}
-		}
-
-		// includes might have changed to include a new empty file
-		// so even though no value changes were seen, we might very
-		// well have new files we need to watch (or files we do no
-		// longer have to watch, so always reset and re-add.
-		RefPtr<FileAlterationMonitor> fam = fam_thread_->get_fam();
-		fam->reset();
-		std::list<std::string>::iterator f;
-		for (f = files.begin(); f != files.end(); ++f) {
-			fam->watch_file(f->c_str());
-		}
-		for (f = dirs.begin(); f != dirs.end(); ++f) {
-			fam->watch_dir(f->c_str());
-		}
-
-	} catch (fawkes::Exception &e) {
-		//LibLogger::log_warn("YamlConfiguration",
-		//                    "Failed to reload changed config, exception follows");
-		//LibLogger::log_warn("YamlConfiguration", e);
-	}
-}
-#endif
 
 /** Create absolute config path.
  * If the @p path starts with / it is considered to be absolute. Otherwise
@@ -657,6 +521,27 @@ abs_cfg_path(const std::string &path)
 	}
 }
 
+/** Replace $host in string with hostname
+ * @param prelim preliminary filename (potentially with $host)
+ * @return filename with $host replaced with hostname
+ */
+static std::string
+insert_hostname(std::string prelim)
+{
+	const std::string to_replace = "$host";
+	static char *     hostname   = NULL;
+	if (hostname == NULL) {
+		hostname = new char[256];
+		gethostname(hostname, 256);
+	}
+	size_t repl_position = prelim.find(to_replace);
+	if (repl_position == std::string::npos) {
+		return prelim;
+	} else {
+		return prelim.replace(repl_position, to_replace.length(), std::string(hostname));
+	}
+}
+
 void
 YamlConfiguration::read_meta_doc(YAML::Node &                doc,
                                  std::queue<LoadQueueEntry> &load_queue,
@@ -664,15 +549,9 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 {
 	try {
 		const YAML::Node &includes = doc["include"];
-#ifdef HAVE_YAMLCPP_0_5
 		for (YAML::const_iterator it = includes.begin(); it != includes.end(); ++it) {
-			std::string include = it->as<std::string>();
-#else
-    for (YAML::Iterator it = includes.begin(); it != includes.end(); ++it) {
-      std::string include;
-      *it >> include;
-#endif
-			bool ignore_missing = false;
+			std::string include        = insert_hostname(it->as<std::string>());
+			bool        ignore_missing = false;
 			if (it->Tag() == "tag:fawkesrobotics.org,cfg/ignore-missing") {
 				ignore_missing = true;
 			}
@@ -681,12 +560,8 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 				if (host_file != "") {
 					throw fawkes::Exception("YamlConfig: Only one host-specific file can be specified");
 				}
-#ifdef HAVE_YAMLCPP_0_5
-				host_file = abs_cfg_path(it->Scalar());
-#else
-        it->GetScalar(host_file);
-        host_file = abs_cfg_path(host_file);
-#endif
+
+				host_file = abs_cfg_path(insert_hostname(it->Scalar()));
 				continue;
 			}
 
@@ -701,9 +576,7 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 				if ((stat(dirname.c_str(), &dir_stat) != 0)) {
 					if (ignore_missing)
 						continue;
-					throw fawkes::Exception(errno,
-					                        "YamlConfig: Failed to stat directory %s",
-					                        dirname.c_str());
+					throw fawkes::Exception(errno, "YamlConfig: Failed to stat directory %s", dirname.c_str());
 				}
 
 				if (!S_ISDIR(dir_stat.st_mode)) {
@@ -712,26 +585,18 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 
 				DIR *d = opendir(dirname.c_str());
 				if (!d) {
-					throw fawkes::Exception(errno,
-					                        "YamlConfig: failed to open directory %s",
-					                        dirname.c_str());
+					throw fawkes::Exception(errno, "YamlConfig: failed to open directory %s", dirname.c_str());
 				}
 
 				load_queue.push(LoadQueueEntry(dirname, ignore_missing, true));
 
 				std::list<std::string> files;
 
+				std::regex yaml_regex{YAML_REGEX, std::regex_constants::extended};
+
 				struct dirent *dent;
 				while ((dent = readdir(d)) != NULL) {
-#ifdef USE_REGEX_CPP
-					if (regex_search(dent->d_name, __yaml_regex)) {
-#	if 0
-	    // just for emacs auto-indentation
-	  }
-#	endif
-#else
-          if (regexec(&__yaml_regex, dent->d_name, 0, NULL, 0) != REG_NOMATCH) {
-#endif
+					if (regex_search(dent->d_name, yaml_regex)) {
 						std::string dn = dent->d_name;
 						files.push_back(dirname + dn);
 					}
@@ -752,536 +617,499 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 	}
 }
 
-void
-YamlConfiguration::read_config_doc(const YAML::Node &doc, YamlConfigurationNode *&node)
+std::shared_ptr<YamlConfigurationNode>
+YamlConfiguration::read_config_doc(const YAML::Node &doc)
 {
-	if (!node) {
-		node = new YamlConfigurationNode("root");
+	return YamlConfigurationNode::create(doc);
+}
+
+void
+YamlConfiguration::write_host_file()
+{
+	if (host_file_ == "") {
+		throw fawkes::Exception("YamlConfig: no host config file specified");
+	}
+	if (mutex->try_lock()) {
+		try {
+			host_root_->emit(host_file_);
+			mutex->unlock();
+		} catch (...) {
+			write_pending_mutex_->unlock();
+			mutex->unlock();
+			throw;
+		}
+	} else {
+		write_pending_mutex_->lock();
+		write_pending_ = true;
+		write_pending_mutex_->unlock();
+	}
+}
+
+void
+YamlConfiguration::copy(Configuration *copyconf)
+{
+	throw fawkes::NotImplementedException("YamlConfig does not support copying of a configuration");
+}
+
+bool
+YamlConfiguration::exists(const char *path)
+{
+	try {
+		std::shared_ptr<YamlConfigurationNode> n = root_->find(path);
+		return !n->has_children();
+	} catch (fawkes::Exception &e) {
+		return false;
+	}
+}
+
+std::string
+YamlConfiguration::get_type(const char *path)
+{
+	std::shared_ptr<YamlConfigurationNode> n = root_->find(path);
+	if (n->has_children()) {
+		throw ConfigEntryNotFoundException(path);
 	}
 
-	if (doc.Type() == YAML::NodeType::Map) {
-#ifdef HAVE_YAMLCPP_0_5
-		for (YAML::const_iterator it = doc.begin(); it != doc.end(); ++it) {
-			std::string key = it->first.as<std::string>();
-#else
-    for (YAML::Iterator it = doc.begin(); it != doc.end(); ++it) {
-      std::string key;
-      it.first() >> key;
-#endif
-			YamlConfigurationNode *in = node;
-			if (key.find("/") != std::string::npos) {
-				// we need to split and find the proper insertion node
-				std::vector<std::string> pel = fawkes::str_split(key);
-				for (size_t i = 0; i < pel.size() - 1; ++i) {
-					YamlConfigurationNode *n = (*in)[pel[i]];
-					if (!n) {
-						n = new YamlConfigurationNode(pel[i]);
-						in->add_child(pel[i], n);
-					}
-					in = n;
-				}
+	return YamlConfigurationNode::Type::to_string(n->get_type());
+}
 
-				key = pel.back();
-			}
+std::string
+YamlConfiguration::get_comment(const char *path)
+{
+	return "";
+}
 
-			YamlConfigurationNode *tmp = (*in)[key];
-			if (tmp) {
-#ifdef HAVE_YAMLCPP_0_5
-				if (tmp->is_scalar() && it->second.Type() != YAML::NodeType::Scalar)
-#else
-        if (tmp->is_scalar() && it.second().Type() != YAML::NodeType::Scalar)
-#endif
-				{
-					throw fawkes::Exception("YamlConfig: scalar %s cannot be overwritten by non-scalar",
-					                        tmp->name().c_str());
-				}
-#ifdef HAVE_YAMLCPP_0_5
-				tmp->set_scalar(it->second.Scalar());
-#else
-        std::string s;
-        if (it.second().GetScalar(s)) {
-          tmp->set_scalar(s);
-        }
-#endif
-			} else {
-#ifdef HAVE_YAMLCPP_0_5
-				YamlConfigurationNode *tmp = new YamlConfigurationNode(key, it->second);
-				in->add_child(key, tmp);
-				read_config_doc(it->second, tmp);
-#else
-        YamlConfigurationNode *tmp = new YamlConfigurationNode(key, it.second());
-        in->add_child(key, tmp);
-        read_config_doc(it.second(), tmp);
-#endif
-			}
-		}
-
-	} else if (doc.Type() == YAML::NodeType::Scalar) {
-		if (doc.Tag() == "tag:fawkesrobotics.org,cfg/tcp-port"
-		    || doc.Tag() == "tag:fawkesrobotics.org,cfg/udp-port") {
-			unsigned int p = 0;
-			try {
-				p = node->get_uint();
-			} catch (fawkes::Exception &e) {
-				e.prepend("YamlConfig: Invalid TCP/UDP port number (not an unsigned int)");
-				throw;
-			}
-			if (p <= 0 || p >= 65535) {
-				throw fawkes::Exception("YamlConfig: Invalid TCP/UDP port number "
-				                        "(%u out of allowed range)",
-				                        p);
-			}
-		} else if (doc.Tag() == "tag:fawkesrobotics.org,cfg/url") {
-#ifdef HAVE_YAMLCPP_0_5
-			std::string scalar = doc.Scalar();
-#else
-      std::string scalar;
-      doc.GetScalar(scalar);
-#endif
-#ifdef USE_REGEX_CPP
-			if (regex_search(scalar, __url_regex)) {
-#	if 0
-	// just for emacs auto-indentation
-      }
-#	endif
-#else
-      if (regexec(&__url_regex, scalar.c_str(), 0, NULL, 0) == REG_NOMATCH) {
-        throw fawkes::Exception("YamlConfig: %s is not a valid URL", scalar.c_str());
-      }
-#endif
-			} else if (doc.Tag() == "tag:fawkesrobotics.org,cfg/frame") {
-#ifdef HAVE_YAMLCPP_0_5
-				std::string scalar = doc.Scalar();
-#else
-      std::string scalar;
-      doc.GetScalar(scalar);
-#endif
-#ifdef USE_REGEX_CPP
-				if (regex_search(scalar, __frame_regex)) {
-#	if 0
-	// just for emacs auto-indentation
-      }
-#	endif
-#else
-      if (regexec(&__frame_regex, scalar.c_str(), 0, NULL, 0) == REG_NOMATCH) {
-        throw fawkes::Exception("YamlConfig: %s is not a valid frame ID", scalar.c_str());
-      }
-#endif
-				}
-			}
-		}
-
-		void YamlConfiguration::write_host_file()
-		{
-			if (host_file_ == "") {
-				throw fawkes::Exception("YamlConfig: no host config file specified");
-			}
-			host_root_->emit(host_file_);
-		}
-
-		void YamlConfiguration::copy(Configuration * copyconf)
-		{
-			throw fawkes::NotImplementedException(
-			  "YamlConfig does not support copying of a configuration");
-		}
-
-		bool YamlConfiguration::exists(const char *path)
-		{
-			try {
-				YamlConfigurationNode *n = root_->find(path);
-				return !n->has_children();
-			} catch (fawkes::Exception &e) {
-				return false;
-			}
-		}
-
-		std::string YamlConfiguration::get_type(const char *path)
-		{
-			YamlConfigurationNode *n = root_->find(path);
-			if (n->has_children()) {
-				throw ConfigEntryNotFoundException(path);
-			}
-
-			return YamlConfigurationNode::Type::to_string(n->get_type());
-		}
-
-		std::string YamlConfiguration::get_comment(const char *path)
-		{
-			return "";
-		}
-
-		/** Retrieve value casted to given type T.
+/** Retrieve value casted to given type T.
  * @param root root node of the tree to search
  * @param path path to query
  * @return value casted as desired
  * @throw YAML::ScalarInvalid thrown if value does not exist or is of
  * a different type.
  */
-		template <typename T>
-		static inline T get_value_as(YamlConfigurationNode * root, const char *path)
-		{
-			YamlConfigurationNode *n = root->find(path);
-			if (n->has_children()) {
-				throw ConfigEntryNotFoundException(path);
-			}
-			return n->get_value<T>();
-		}
+template <typename T>
+static inline T
+get_value_as(std::shared_ptr<YamlConfigurationNode> root, const char *path)
+{
+	std::shared_ptr<YamlConfigurationNode> n = root->find(path);
+	if (n->has_children()) {
+		throw ConfigEntryNotFoundException(path);
+	}
+	return n->get_value<T>();
+}
 
-		/** Retrieve value casted to given type T.
+/** Retrieve value casted to given type T.
  * @param root root node of the tree to search
  * @param path path to query
  * @return value casted as desired
  * @throw YAML::ScalarInvalid thrown if value does not exist or is of
  * a different type.
  */
-		template <typename T>
-		static inline std::vector<T> get_list(YamlConfigurationNode * root, const char *path)
-		{
-			YamlConfigurationNode *n = root->find(path);
-			if (n->has_children()) {
-				throw ConfigEntryNotFoundException(path);
-			}
-			return n->get_list<T>();
-		}
+template <typename T>
+static inline std::vector<T>
+get_list(std::shared_ptr<YamlConfigurationNode> root, const char *path)
+{
+	std::shared_ptr<YamlConfigurationNode> n = root->find(path);
+	if (n->has_children()) {
+		throw ConfigEntryNotFoundException(path);
+	}
+	return n->get_list<T>();
+}
 
-		float YamlConfiguration::get_float(const char *path)
-		{
-			return get_value_as<float>(root_, path);
-		}
+float
+YamlConfiguration::get_float(const char *path)
+{
+	return get_value_as<float>(root_, path);
+}
 
-		unsigned int YamlConfiguration::get_uint(const char *path)
-		{
-			return get_value_as<unsigned int>(root_, path);
-		}
+unsigned int
+YamlConfiguration::get_uint(const char *path)
+{
+	return get_value_as<unsigned int>(root_, path);
+}
 
-		int YamlConfiguration::get_int(const char *path)
-		{
-			return get_value_as<int>(root_, path);
-		}
+int
+YamlConfiguration::get_int(const char *path)
+{
+	return get_value_as<int>(root_, path);
+}
 
-		bool YamlConfiguration::get_bool(const char *path)
-		{
-			return get_value_as<bool>(root_, path);
-		}
+bool
+YamlConfiguration::get_bool(const char *path)
+{
+	return get_value_as<bool>(root_, path);
+}
 
-		std::string YamlConfiguration::get_string(const char *path)
-		{
-			return get_value_as<std::string>(root_, path);
-		}
+std::string
+YamlConfiguration::get_string(const char *path)
+{
+	return get_value_as<std::string>(root_, path);
+}
 
-		std::vector<float> YamlConfiguration::get_floats(const char *path)
-		{
-			return get_list<float>(root_, path);
-		}
+std::vector<float>
+YamlConfiguration::get_floats(const char *path)
+{
+	return get_list<float>(root_, path);
+}
 
-		std::vector<unsigned int> YamlConfiguration::get_uints(const char *path)
-		{
-			return get_list<unsigned int>(root_, path);
-		}
+std::vector<unsigned int>
+YamlConfiguration::get_uints(const char *path)
+{
+	return get_list<unsigned int>(root_, path);
+}
 
-		std::vector<int> YamlConfiguration::get_ints(const char *path)
-		{
-			return get_list<int>(root_, path);
-		}
+std::vector<int>
+YamlConfiguration::get_ints(const char *path)
+{
+	return get_list<int>(root_, path);
+}
 
-		std::vector<bool> YamlConfiguration::get_bools(const char *path)
-		{
-			return get_list<bool>(root_, path);
-		}
+std::vector<bool>
+YamlConfiguration::get_bools(const char *path)
+{
+	return get_list<bool>(root_, path);
+}
 
-		std::vector<std::string> YamlConfiguration::get_strings(const char *path)
-		{
-			return get_list<std::string>(root_, path);
-		}
+std::vector<std::string>
+YamlConfiguration::get_strings(const char *path)
+{
+	return get_list<std::string>(root_, path);
+}
 
-		/** Check if value is of given type T.
+/** Check if value is of given type T.
  * @param root root node of the tree to search
  * @param path path to query
  * @return true if value is of desired type, false otherwise
  */
-		template <typename T>
-		static inline bool is_type(YamlConfigurationNode * root, const char *path)
-		{
-			YamlConfigurationNode *n = root->find(path);
-			if (n->has_children()) {
-				throw ConfigEntryNotFoundException(path);
-			}
-			return n->is_type<T>();
+template <typename T>
+static inline bool
+is_type(std::shared_ptr<YamlConfigurationNode> root, const char *path)
+{
+	std::shared_ptr<YamlConfigurationNode> n = root->find(path);
+	if (n->has_children()) {
+		throw ConfigEntryNotFoundException(path);
+	}
+	return n->is_type<T>();
+}
+
+bool
+YamlConfiguration::is_float(const char *path)
+{
+	return is_type<float>(root_, path);
+}
+
+bool
+YamlConfiguration::is_uint(const char *path)
+{
+	std::shared_ptr<YamlConfigurationNode> n = root_->find(path);
+	if (n->has_children()) {
+		throw ConfigEntryNotFoundException(path);
+	}
+
+	if (!n->is_type<unsigned int>())
+		return false;
+
+	int v = n->get_value<int>();
+	return (v >= 0);
+}
+
+bool
+YamlConfiguration::is_int(const char *path)
+{
+	return is_type<int>(root_, path);
+}
+
+bool
+YamlConfiguration::is_bool(const char *path)
+{
+	return is_type<bool>(root_, path);
+}
+
+bool
+YamlConfiguration::is_string(const char *path)
+{
+	return is_type<std::string>(root_, path);
+}
+
+bool
+YamlConfiguration::is_list(const char *path)
+{
+	std::shared_ptr<YamlConfigurationNode> n = root_->find(path);
+	if (n->has_children()) {
+		throw ConfigEntryNotFoundException(path);
+	}
+	return (n->get_type() == YamlConfigurationNode::Type::SEQUENCE);
+}
+
+std::string
+YamlConfiguration::get_default_comment(const char *path)
+{
+	return "";
+}
+
+bool
+YamlConfiguration::is_default(const char *path)
+{
+	return false;
+}
+
+Configuration::ValueIterator *
+YamlConfiguration::get_value(const char *path)
+{
+	try {
+		std::shared_ptr<YamlConfigurationNode> n = root_->find(path);
+		if (n->has_children()) {
+			return new YamlValueIterator();
 		}
+		std::map<std::string, std::shared_ptr<YamlConfigurationNode>> nodes;
+		nodes[path] = n;
+		return new YamlValueIterator(nodes);
+	} catch (ConfigEntryNotFoundException &e) {
+		return new YamlValueIterator();
+	}
+}
 
-		bool YamlConfiguration::is_float(const char *path)
-		{
-			return is_type<float>(root_, path);
-		}
+void
+YamlConfiguration::set_float(const char *path, float f)
+{
+	root_->set_value(path, f);
+	host_root_->set_value(path, f);
+	write_host_file();
+}
 
-		bool YamlConfiguration::is_uint(const char *path)
-		{
-			YamlConfigurationNode *n = root_->find(path);
-			if (n->has_children()) {
-				throw ConfigEntryNotFoundException(path);
-			}
+void
+YamlConfiguration::set_uint(const char *path, unsigned int uint)
+{
+	root_->set_value(path, uint);
+	host_root_->set_value(path, uint);
+	write_host_file();
+}
 
-			if (!n->is_type<unsigned int>())
-				return false;
+void
+YamlConfiguration::set_int(const char *path, int i)
+{
+	root_->set_value(path, i);
+	host_root_->set_value(path, i);
+	write_host_file();
+}
 
-			int v = n->get_value<int>();
-			return (v >= 0);
-		}
+void
+YamlConfiguration::set_bool(const char *path, bool b)
+{
+	root_->set_value(path, b);
+	host_root_->set_value(path, b);
+	write_host_file();
+}
 
-		bool YamlConfiguration::is_int(const char *path)
-		{
-			return is_type<int>(root_, path);
-		}
+void
+YamlConfiguration::set_string(const char *path, const char *s)
+{
+	root_->set_value(path, std::string(s));
+	host_root_->set_value(path, std::string(s));
+	write_host_file();
+}
 
-		bool YamlConfiguration::is_bool(const char *path)
-		{
-			return is_type<bool>(root_, path);
-		}
+void
+YamlConfiguration::set_string(const char *path, std::string &s)
+{
+	set_string(path, s.c_str());
+}
 
-		bool YamlConfiguration::is_string(const char *path)
-		{
-			return is_type<std::string>(root_, path);
-		}
+void
+YamlConfiguration::set_floats(const char *path, std::vector<float> &f)
+{
+	root_->set_list(path, f);
+	host_root_->set_list(path, f);
+	write_host_file();
+}
 
-		bool YamlConfiguration::is_list(const char *path)
-		{
-			YamlConfigurationNode *n = root_->find(path);
-			if (n->has_children()) {
-				throw ConfigEntryNotFoundException(path);
-			}
-			return (n->get_type() == YamlConfigurationNode::Type::SEQUENCE);
-		}
+void
+YamlConfiguration::set_uints(const char *path, std::vector<unsigned int> &u)
+{
+	root_->set_list(path, u);
+	host_root_->set_list(path, u);
+	write_host_file();
+}
 
-		std::string YamlConfiguration::get_default_comment(const char *path)
-		{
-			return "";
-		}
+void
+YamlConfiguration::set_ints(const char *path, std::vector<int> &i)
+{
+	root_->set_list(path, i);
+	host_root_->set_list(path, i);
+	write_host_file();
+}
 
-		bool YamlConfiguration::is_default(const char *path)
-		{
-			return false;
-		}
+void
+YamlConfiguration::set_bools(const char *path, std::vector<bool> &b)
+{
+	root_->set_list(path, b);
+	host_root_->set_list(path, b);
+	write_host_file();
+}
 
-		Configuration::ValueIterator *YamlConfiguration::get_value(const char *path)
-		{
-			try {
-				YamlConfigurationNode *n = root_->find(path);
-				if (n->has_children()) {
-					return new YamlValueIterator();
-				}
-				std::map<std::string, YamlConfigurationNode *> nodes;
-				nodes[path] = n;
-				return new YamlValueIterator(nodes);
-			} catch (ConfigEntryNotFoundException &e) {
-				return new YamlValueIterator();
-			}
-		}
+void
+YamlConfiguration::set_strings(const char *path, std::vector<std::string> &s)
+{
+	root_->set_list(path, s);
+	host_root_->set_list(path, s);
+	write_host_file();
+}
 
-		void YamlConfiguration::set_float(const char *path, float f)
-		{
-			root_->set_value(path, f);
-			host_root_->set_value(path, f);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_strings(const char *path, std::vector<const char *> &s)
+{
+	root_->set_list(path, s);
+	host_root_->set_list(path, s);
+	write_host_file();
+}
 
-		void YamlConfiguration::set_uint(const char *path, unsigned int uint)
-		{
-			root_->set_value(path, uint);
-			host_root_->set_value(path, uint);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_comment(const char *path, const char *comment)
+{
+}
 
-		void YamlConfiguration::set_int(const char *path, int i)
-		{
-			root_->set_value(path, i);
-			host_root_->set_value(path, i);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_comment(const char *path, std::string &comment)
+{
+}
 
-		void YamlConfiguration::set_bool(const char *path, bool b)
-		{
-			root_->set_value(path, b);
-			host_root_->set_value(path, b);
-			write_host_file();
-		}
+void
+YamlConfiguration::erase(const char *path)
+{
+	host_root_->erase(path);
+	root_->erase(path);
+	write_host_file();
+}
 
-		void YamlConfiguration::set_string(const char *path, const char *s)
-		{
-			root_->set_value(path, std::string(s));
-			host_root_->set_value(path, std::string(s));
-			write_host_file();
-		}
+void
+YamlConfiguration::set_default_float(const char *path, float f)
+{
+	throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
+}
 
-		void YamlConfiguration::set_string(const char *path, std::string &s)
-		{
-			set_string(path, s.c_str());
-		}
+void
+YamlConfiguration::set_default_uint(const char *path, unsigned int uint)
+{
+	throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
+}
 
-		void YamlConfiguration::set_floats(const char *path, std::vector<float> &f)
-		{
-			root_->set_list(path, f);
-			host_root_->set_list(path, f);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_default_int(const char *path, int i)
+{
+	throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
+}
 
-		void YamlConfiguration::set_uints(const char *path, std::vector<unsigned int> &u)
-		{
-			root_->set_list(path, u);
-			host_root_->set_list(path, u);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_default_bool(const char *path, bool b)
+{
+	throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
+}
 
-		void YamlConfiguration::set_ints(const char *path, std::vector<int> &i)
-		{
-			root_->set_list(path, i);
-			host_root_->set_list(path, i);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_default_string(const char *path, const char *s)
+{
+	throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
+}
 
-		void YamlConfiguration::set_bools(const char *path, std::vector<bool> &b)
-		{
-			root_->set_list(path, b);
-			host_root_->set_list(path, b);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_default_string(const char *path, std::string &s)
+{
+	set_default_string(path, s.c_str());
+}
 
-		void YamlConfiguration::set_strings(const char *path, std::vector<std::string> &s)
-		{
-			root_->set_list(path, s);
-			host_root_->set_list(path, s);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_default_comment(const char *path, const char *comment)
+{
+	throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
+}
 
-		void YamlConfiguration::set_strings(const char *path, std::vector<const char *> &s)
-		{
-			root_->set_list(path, s);
-			host_root_->set_list(path, s);
-			write_host_file();
-		}
+void
+YamlConfiguration::set_default_comment(const char *path, std::string &comment)
+{
+	set_default_comment(path, comment.c_str());
+}
 
-		void YamlConfiguration::set_comment(const char *path, const char *comment)
-		{
-		}
+void
+YamlConfiguration::erase_default(const char *path)
+{
+	throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
+}
 
-		void YamlConfiguration::set_comment(const char *path, std::string &comment)
-		{
-		}
-
-		void YamlConfiguration::erase(const char *path)
-		{
-			host_root_->erase(path);
-			root_->erase(path);
-			write_host_file();
-		}
-
-		void YamlConfiguration::set_default_float(const char *path, float f)
-		{
-			throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
-		}
-
-		void YamlConfiguration::set_default_uint(const char *path, unsigned int uint)
-		{
-			throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
-		}
-
-		void YamlConfiguration::set_default_int(const char *path, int i)
-		{
-			throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
-		}
-
-		void YamlConfiguration::set_default_bool(const char *path, bool b)
-		{
-			throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
-		}
-
-		void YamlConfiguration::set_default_string(const char *path, const char *s)
-		{
-			throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
-		}
-
-		void YamlConfiguration::set_default_string(const char *path, std::string &s)
-		{
-			set_default_string(path, s.c_str());
-		}
-
-		void YamlConfiguration::set_default_comment(const char *path, const char *comment)
-		{
-			throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
-		}
-
-		void YamlConfiguration::set_default_comment(const char *path, std::string &comment)
-		{
-			set_default_comment(path, comment.c_str());
-		}
-
-		void YamlConfiguration::erase_default(const char *path)
-		{
-			throw fawkes::NotImplementedException("YamlConfiguration does not support default values");
-		}
-
-		/** Lock the config.
+/** Lock the config.
  * No further changes or queries can be executed on the configuration and will block until
  * the config is unlocked.
  */
-		void YamlConfiguration::lock()
-		{
-			mutex->lock();
-		}
+void
+YamlConfiguration::lock()
+{
+	mutex->lock();
+}
 
-		/** Try to lock the config.
+/** Try to lock the config.
  * @see Configuration::lock()
  * @return true, if the lock has been aquired, false otherwise
  */
-		bool YamlConfiguration::try_lock()
-		{
-			return mutex->try_lock();
-		}
+bool
+YamlConfiguration::try_lock()
+{
+	return mutex->try_lock();
+}
 
-		/** Unlock the config.
+/** Unlock the config.
  * Modifications and queries are possible again.
  */
-		void YamlConfiguration::unlock()
-		{
-			mutex->unlock();
-		}
+void
+YamlConfiguration::unlock()
+{
+	write_pending_mutex_->lock();
+	if (write_pending_) {
+		host_root_->emit(host_file_);
+		write_pending_ = false;
+	}
+	write_pending_mutex_->unlock();
+	mutex->unlock();
+}
 
-		void YamlConfiguration::try_dump()
-		{
-		}
+void
+YamlConfiguration::try_dump()
+{
+}
 
-		Configuration::ValueIterator *YamlConfiguration::iterator()
-		{
-			std::map<std::string, YamlConfigurationNode *> nodes;
-			root_->enum_leafs(nodes);
-			return new YamlValueIterator(nodes);
-		}
+Configuration::ValueIterator *
+YamlConfiguration::iterator()
+{
+	std::map<std::string, std::shared_ptr<YamlConfigurationNode>> nodes;
+	root_->enum_leafs(nodes);
+	return new YamlValueIterator(nodes);
+}
 
-		Configuration::ValueIterator *YamlConfiguration::search(const char *path)
-		{
-			std::string            tmp_path = path;
-			std::string::size_type tl       = tmp_path.length();
-			if ((tl > 0) && (tmp_path[tl - 1] == '/')) {
-				tmp_path.resize(tl - 1);
-			}
-			try {
-				YamlConfigurationNode *                        n = root_->find(tmp_path.c_str());
-				std::map<std::string, YamlConfigurationNode *> nodes;
-				n->enum_leafs(nodes, tmp_path);
-				return new YamlValueIterator(nodes);
-			} catch (fawkes::Exception &e) {
-				return new YamlValueIterator();
-			}
-		}
+Configuration::ValueIterator *
+YamlConfiguration::search(const char *path)
+{
+	std::string            tmp_path = path;
+	std::string::size_type tl       = tmp_path.length();
+	if ((tl > 0) && (tmp_path[tl - 1] == '/')) {
+		tmp_path.resize(tl - 1);
+	}
+	try {
+		std::shared_ptr<YamlConfigurationNode>                        n = root_->find(tmp_path.c_str());
+		std::map<std::string, std::shared_ptr<YamlConfigurationNode>> nodes;
+		n->enum_leafs(nodes, tmp_path);
+		return new YamlValueIterator(nodes);
+	} catch (fawkes::Exception &e) {
+		return new YamlValueIterator();
+	}
+}
 
-		/** Query node for a specific path.
+/** Query node for a specific path.
  * @param path path to retrieve node for
  * @return node representing requested path query result, if the path only
  * consists of collection and path name returns the whole document.
  */
-		YamlConfigurationNode *YamlConfiguration::query(const char *path) const
-		{
-			std::queue<std::string> pel_q = fawkes::str_split_to_queue(path);
-			return root_->find(pel_q);
-		}
+std::shared_ptr<YamlConfigurationNode>
+YamlConfiguration::query(const char *path) const
+{
+	std::queue<std::string> pel_q = fawkes::str_split_to_queue(path);
+	return root_->find(pel_q);
+}
 
-	} // end namespace llsfrb
+} // end namespace llsfrb

--- a/src/libs/config/yaml.h
+++ b/src/libs/config/yaml.h
@@ -193,11 +193,11 @@ private:
 	std::shared_ptr<YamlConfigurationNode> root_;
 	std::shared_ptr<YamlConfigurationNode> host_root_;
 
-	bool   write_pending_;
-  fawkes::Mutex *write_pending_mutex_;
+	bool           write_pending_;
+	fawkes::Mutex *write_pending_mutex_;
 
 private:
-  fawkes::Mutex *mutex;
+	fawkes::Mutex *mutex;
 
 	typedef std::map<std::string, YAML::Node *> DocMap;
 	mutable DocMap                              documents_;

--- a/src/libs/config/yaml_node.h
+++ b/src/libs/config/yaml_node.h
@@ -3,8 +3,7 @@
  *  yaml_node.h - Utility class for internal YAML config handling
  *
  *  Created: Thu Aug 09 14:08:18 2012
- *  Copyright  2006-2012  Tim Niemueller [www.niemueller.de]
- *
+ *  Copyright  2006-2018  Tim Niemueller [www.niemueller.de]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -28,32 +27,33 @@
 #	error Do not include yaml_node.h directly
 #endif
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <utils/misc/string_conversions.h>
 #include <utils/misc/string_split.h>
 #include <yaml-cpp/traits.h>
 
 #include <algorithm>
 #include <cerrno>
+#include <climits>
 #include <fstream>
 #include <iostream>
+#include <limits>
+#include <memory>
+#include <regex>
 #include <stack>
 #include <unistd.h>
-
-#ifndef HAVE_YAMLCPP_0_5
-// older versions of yaml-cpp had these functions in the
-// YAML, rather than in the YAML::conversion namespace.
-namespace YAML {
-namespace conversion {
-using YAML::IsInfinity;
-using YAML::IsNaN;
-using YAML::IsNegativeInfinity;
-} // namespace conversion
-} // namespace YAML
-#endif
 
 namespace llsfrb {
 
 /// @cond INTERNALS
+
+#define PATH_REGEX "^[a-zA-Z0-9_-]+$"
+#define YAML_REGEX "^[a-zA-Z0-9_-]+\\.yaml$"
+// from https://www.ietf.org/rfc/rfc3986.txt
+#define URL_REGEX "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+#define FRAME_REGEX "^([a-zA-Z_][a-zA-Z0-9_/-]*)+$"
 
 namespace yaml_utils {
 
@@ -161,15 +161,36 @@ convert(const std::string &input, YAML::_Null &output)
 	return input.empty() || input == "~" || input == "null" || input == "Null" || input == "NULL";
 }
 
+inline bool
+convert(const std::string &input, unsigned int &rhs)
+{
+	errno = 0;
+	char *   endptr;
+	long int l = strtol(input.c_str(), &endptr, 0);
+
+	if ((errno == ERANGE && (l == LONG_MAX || l == LONG_MIN)) || (errno != 0 && l == 0)) {
+		return false;
+	}
+	if (endptr == input.c_str())
+		return false;
+	if (*endptr != 0)
+		return false;
+	if (l < 0)
+		return false;
+
+	rhs = (unsigned int)l;
+
+	return true;
+}
+
 template <typename T>
 inline bool
 convert(const std::string &input, T &rhs, typename YAML::enable_if<YAML::is_numeric<T>>::type * = 0)
 {
 	std::stringstream stream(input);
 	stream.unsetf(std::ios::dec);
-	if ((stream >> rhs) && (stream >> std::ws).eof())
+	if ((stream >> rhs) && (stream >> std::ws).eof()) {
 		return true;
-	else {
 	}
 	if (std::numeric_limits<T>::has_infinity) {
 		if (YAML::conversion::IsInfinity(input) || YAML::conversion::IsNegativeInfinity(input)) {
@@ -185,14 +206,17 @@ convert(const std::string &input, T &rhs, typename YAML::enable_if<YAML::is_nume
 
 	return false;
 }
+
+static std::regex url_regex{URL_REGEX, std::regex_constants::extended};
+static std::regex frame_regex{FRAME_REGEX, std::regex_constants::extended};
 } // namespace yaml_utils
 
-class YamlConfigurationNode
+class YamlConfigurationNode : public std::enable_shared_from_this<YamlConfigurationNode>
 {
 public:
 	struct Type
 	{
-		enum value { NONE, UINT32, INT32, FLOAT, BOOL, STRING, MAP, SEQUENCE, UNKNOWN };
+		enum value { NONE, UINT32, INT32, FLOAT, BOOL, STRING, MAP, SEQUENCE, SEQUENCE_MAP, UNKNOWN };
 		static const char *
 		to_string(value v)
 		{
@@ -205,6 +229,7 @@ public:
 			case STRING: return "string";
 			case SEQUENCE: return "SEQUENCE";
 			case MAP: return "MAP";
+			case SEQUENCE_MAP: return "SEQUENCE_MAP";
 			default: return "UNKNOWN";
 			}
 		}
@@ -214,98 +239,89 @@ public:
 	{
 	}
 
-	YamlConfigurationNode(const YamlConfigurationNode &n)
-	: name_(n.name_),
-	  type_(n.type_),
-	  scalar_value_(n.scalar_value_),
-	  list_values_(n.list_values_),
-	  is_default_(n.is_default_)
-	{
-	}
-
-	YamlConfigurationNode(const YamlConfigurationNode *n)
-	: name_(n->name_),
-	  type_(n->type_),
-	  scalar_value_(n->scalar_value_),
-	  list_values_(n->list_values_),
-	  is_default_(n->is_default_)
-	{
-	}
-
-	YamlConfigurationNode(std::string name, const YAML::Node &node)
-	: name_(name), type_(Type::UNKNOWN), is_default_(false)
-	{
-#ifdef HAVE_YAMLCPP_0_5
-		scalar_value_ = node.Scalar();
-#else
-		node.GetScalar(scalar_value_);
-#endif
-		switch (node.Type()) {
-		case YAML::NodeType::Null: type_ = Type::NONE; break;
-		case YAML::NodeType::Scalar: type_ = determine_scalar_type(); break;
-		case YAML::NodeType::Sequence:
-			type_ = Type::SEQUENCE;
-			set_sequence(node);
-			break;
-		case YAML::NodeType::Map: type_ = Type::MAP; break;
-		default: type_ = Type::UNKNOWN; break;
-		}
-	}
-
 	YamlConfigurationNode(std::string name) : name_(name), type_(Type::NONE), is_default_(false)
 	{
 	}
 
+	YamlConfigurationNode(const YamlConfigurationNode &n) = delete;
+
 	~YamlConfigurationNode()
 	{
-		std::map<std::string, YamlConfigurationNode *>::iterator i;
-		for (i = children_.begin(); i != children_.end(); ++i) {
-			delete i->second;
+	}
+
+	static std::shared_ptr<YamlConfigurationNode>
+	create(const YAML::Node &node, const std::string &name = "root")
+	{
+		auto n = std::make_shared<YamlConfigurationNode>(name);
+
+		switch (node.Type()) {
+		case YAML::NodeType::Null: n->set_type(Type::NONE); break;
+
+		case YAML::NodeType::Scalar:
+			n->set_scalar(node.Scalar());
+			n->verify_scalar(node);
+			break;
+
+		case YAML::NodeType::Sequence:
+			n->set_type(Type::SEQUENCE);
+			n->set_sequence(node);
+			break;
+
+		case YAML::NodeType::Map:
+			n->set_type(Type::MAP);
+			n->set_map(node);
+			break;
+
+		default: n->set_type(Type::UNKNOWN); break;
 		}
+
+		return n;
 	}
 
 	void
-	add_child(std::string &p, YamlConfigurationNode *n)
+	add_child(std::string &p, std::shared_ptr<YamlConfigurationNode> n)
 	{
-		type_        = Type::MAP;
+		if (type_ != Type::MAP && type_ != Type::SEQUENCE_MAP) {
+			type_ = Type::MAP;
+		}
 		children_[p] = n;
 	}
 
-	std::map<std::string, YamlConfigurationNode *>::iterator
+	std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::iterator
 	begin()
 	{
 		return children_.begin();
 	}
 
-	std::map<std::string, YamlConfigurationNode *>::iterator
+	std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::iterator
 	end()
 	{
 		return children_.end();
 	}
 
-	std::map<std::string, YamlConfigurationNode *>::size_type
+	std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::size_type
 	size() const
 	{
 		return children_.size();
 	}
 
-	std::map<std::string, YamlConfigurationNode *>::const_iterator
+	std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::const_iterator
 	begin() const
 	{
 		return children_.begin();
 	}
 
-	std::map<std::string, YamlConfigurationNode *>::const_iterator
+	std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::const_iterator
 	end() const
 	{
 		return children_.end();
 	}
 
-	YamlConfigurationNode *
+	std::shared_ptr<YamlConfigurationNode>
 	find(std::queue<std::string> &q)
 	{
-		YamlConfigurationNode *n = this;
-		std::string            path;
+		std::shared_ptr<YamlConfigurationNode> n = shared_from_this();
+		std::string                            path;
 
 		while (!q.empty()) {
 			std::string pel = q.front();
@@ -323,16 +339,16 @@ public:
 		return n;
 	}
 
-	YamlConfigurationNode *
+	std::shared_ptr<YamlConfigurationNode>
 	find_or_insert(const char *path)
 	{
 		std::queue<std::string> q = fawkes::str_split_to_queue(path);
 
-		YamlConfigurationNode *n = this;
+		std::shared_ptr<YamlConfigurationNode> n = shared_from_this();
 		while (!q.empty()) {
 			std::string pel = q.front();
 			if (n->children_.find(pel) == n->children_.end()) {
-				n->add_child(pel, new YamlConfigurationNode(pel));
+				n->add_child(pel, std::make_shared<YamlConfigurationNode>(pel));
 			}
 			n = n->children_[pel];
 			q.pop();
@@ -344,11 +360,11 @@ public:
 	void
 	erase(const char *path)
 	{
-		std::queue<std::string>             q = fawkes::str_split_to_queue(path);
-		std::stack<YamlConfigurationNode *> qs;
-		std::string                         full_path;
+		std::queue<std::string>                            q = fawkes::str_split_to_queue(path);
+		std::stack<std::shared_ptr<YamlConfigurationNode>> qs;
+		std::string                                        full_path;
 
-		YamlConfigurationNode *n = this;
+		std::shared_ptr<YamlConfigurationNode> n = shared_from_this();
 		while (!q.empty()) {
 			std::string pel = q.front();
 			full_path += "/" + pel;
@@ -366,9 +382,9 @@ public:
 			throw fawkes::Exception("YamlConfig: cannot erase non-leaf value");
 		}
 
-		YamlConfigurationNode *child = n;
+		std::shared_ptr<YamlConfigurationNode> child = n;
 		while (!qs.empty()) {
-			YamlConfigurationNode *en = qs.top();
+			std::shared_ptr<YamlConfigurationNode> en = qs.top();
 
 			en->children_.erase(child->name());
 
@@ -382,7 +398,7 @@ public:
 		}
 	}
 
-	YamlConfigurationNode *
+	std::shared_ptr<YamlConfigurationNode>
 	find(const char *path)
 	{
 		try {
@@ -394,12 +410,12 @@ public:
 	}
 
 	void
-	operator=(const YamlConfigurationNode &n)
+	operator=(const YamlConfigurationNode &&n)
 	{
-		name_        = n.name_;
-		type_        = n.type_;
-		children_    = n.children_;
-		list_values_ = n.list_values_;
+		name_        = std::move(n.name_);
+		type_        = std::move(n.type_);
+		children_    = std::move(n.children_);
+		list_values_ = std::move(n.list_values_);
 	}
 
 	bool
@@ -408,9 +424,9 @@ public:
 		return this->name_ < n.name_;
 	}
 
-	YamlConfigurationNode *operator[](const std::string &p)
+	std::shared_ptr<YamlConfigurationNode> operator[](const std::string &p)
 	{
-		std::map<std::string, YamlConfigurationNode *>::iterator i;
+		std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::iterator i;
 		if ((i = children_.find(p)) != children_.end()) {
 			return i->second;
 		} else {
@@ -418,18 +434,19 @@ public:
 		}
 	}
 
-	YamlConfigurationNode &
-	operator+=(const YamlConfigurationNode *n)
+	std::shared_ptr<YamlConfigurationNode>
+	operator+=(const std::shared_ptr<YamlConfigurationNode> n)
 	{
 		if (!n)
-			return *this;
+			return shared_from_this();
 
-		YamlConfigurationNode *add_to = this;
+		std::shared_ptr<YamlConfigurationNode> add_to = shared_from_this();
 
 		if (n->name() != "root") {
-			std::map<std::string, YamlConfigurationNode *>::iterator i;
-			if ((i = children_.find(n->name())) == children_.end()) {
-				children_[n->name()] = new YamlConfigurationNode(n);
+			if (children_.find(n->name()) == children_.end()) {
+				auto new_val = std::make_shared<YamlConfigurationNode>(n->name());
+				new_val->set_type(n->get_type());
+				children_[n->name()] = new_val;
 			}
 			add_to = children_[n->name()];
 		}
@@ -437,17 +454,54 @@ public:
 		if (add_to->is_scalar()) {
 			if (!n->is_scalar()) {
 				throw fawkes::Exception("YamlConfig: cannot overwrite scalar value %s with non-scalar",
-				                        add_to->name().c_str());
+				                add_to->name().c_str());
 			}
 			add_to->set_scalar(n->get_scalar());
+		} else if (add_to->is_list()) {
+			if (!n->is_list()) {
+				throw fawkes::Exception("YamlConfig: cannot overwrite list value %s with non-list",
+				                add_to->name().c_str());
+			}
+			if (is_type<unsigned int>()) {
+				try {
+					int v = get_int();
+					if (v >= 0) {
+						add_to->set_list(n->get_list<unsigned int>());
+					} else {
+						add_to->set_list(n->get_list<int>());
+					}
+				} catch (fawkes::Exception &e) {
+					// can happen if value > MAX_INT
+					add_to->set_list(n->get_list<unsigned int>());
+				}
+			} else if (is_type<int>()) {
+				add_to->set_list(n->get_list<int>());
+			} else if (is_type<float>()) {
+				add_to->set_list(n->get_list<float>());
+			} else if (is_type<bool>()) {
+				add_to->set_list(n->get_list<bool>());
+			} else if (is_type<std::string>()) {
+				add_to->set_list(n->get_list<std::string>());
+			} else {
+				std::vector<std::string> empty;
+				add_to->set_list(empty);
+			}
+		} else if (add_to->get_type() == Type::SEQUENCE_MAP) {
+			if (n->get_type() != Type::SEQUENCE_MAP) {
+				throw fawkes::Exception("YamlConfig: cannot overwrite sequence map value %s with non-sequence-map",
+				                add_to->name().c_str());
+			}
+			add_to->children_.clear();
+			for (auto i = n->begin(); i != n->end(); ++i) {
+				*add_to += i->second;
+			}
 		} else {
-			std::map<std::string, YamlConfigurationNode *>::const_iterator i;
-			for (i = n->begin(); i != n->end(); ++i) {
+			for (auto i = n->begin(); i != n->end(); ++i) {
 				*add_to += i->second;
 			}
 		}
 
-		return *this;
+		return shared_from_this();
 	}
 
 	bool
@@ -463,24 +517,25 @@ public:
 	}
 
 	/** Check for differences in two trees.
-   * This returns a list of all changes that have occured in b opposed
-   * to b. This means keys which have been added or changed in b compared to
-   * a. It also includes keys which have been removed from a, i.e. which exist
-   * in b but not in a.
-   * @param a root node of first tree
-   * @param b root node of second tree
-   * @return list of paths to leaf nodes that changed
-   */
+	 * This returns a list of all changes that have occured in b opposed
+	 * to b. This means keys which have been added or changed in b compared to
+	 * a. It also includes keys which have been removed from a, i.e. which exist
+	 * in b but not in a.
+	 * @param a root node of first tree
+	 * @param b root node of second tree
+	 * @return list of paths to leaf nodes that changed
+	 */
 	static std::list<std::string>
-	diff(const YamlConfigurationNode *a, const YamlConfigurationNode *b)
+	diff(const std::shared_ptr<YamlConfigurationNode> a,
+	     const std::shared_ptr<YamlConfigurationNode> b)
 	{
 		std::list<std::string> rv;
 
-		std::map<std::string, YamlConfigurationNode *> na, nb;
+		std::map<std::string, std::shared_ptr<YamlConfigurationNode>> na, nb;
 		a->enum_leafs(na);
 		b->enum_leafs(nb);
 
-		std::map<std::string, YamlConfigurationNode *>::iterator i;
+		std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::iterator i;
 		for (i = na.begin(); i != na.end(); ++i) {
 			if (nb.find(i->first) == nb.end()) {
 				// this is a new key in a
@@ -505,11 +560,11 @@ public:
 	}
 
 	/** Retrieve value casted to given type T.
-   * @param path path to query
-   * @return value casted as desired
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @param path path to query
+	 * @return value casted as desired
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	template <typename T>
 	T
 	get_value() const
@@ -527,9 +582,9 @@ public:
 	}
 
 	/** Get the list elements as string.
-   * The first element determines the type of the list.
-   * @return value string as list, i.e. as space-separated list of items
-   */
+	 * The first element determines the type of the list.
+	 * @return value string as list, i.e. as space-separated list of items
+	 */
 	std::string
 	get_list_as_string() const
 	{
@@ -557,10 +612,10 @@ public:
 	}
 
 	/** Retrieve value casted to given type T.
-   * @return value casted as desired
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @return value casted as desired
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	template <typename T>
 	std::vector<T>
 	get_list() const
@@ -575,7 +630,7 @@ public:
 			T t;
 			if (!yaml_utils::convert(list_values_[i], t)) {
 				// might want to have custom exception here later
-				throw fawkes::Exception("YamlConfig: value or type error on %s", name_.c_str());
+				throw fawkes::Exception("YamlConfig: value or type error on %s[%zi]", name_.c_str(), i);
 			}
 			rv[i] = t;
 		}
@@ -583,10 +638,10 @@ public:
 	}
 
 	/** Retrieve list size.
-   * @return size of list
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @return size of list
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	size_t
 	get_list_size() const
 	{
@@ -597,16 +652,16 @@ public:
 	}
 
 	/** Set value of given type T.
-   * @param path path to query
-   * @return value casted as desired
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @param path path to query
+	 * @return value casted as desired
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	template <typename T>
 	void
 	set_value(const char *path, T t)
 	{
-		YamlConfigurationNode *n = find_or_insert(path);
+		std::shared_ptr<YamlConfigurationNode> n = find_or_insert(path);
 		if (n->has_children()) {
 			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s", path);
 		}
@@ -614,16 +669,16 @@ public:
 	}
 
 	/** Set list of given type T.
-   * @param path path to query
-   * @return value casted as desired
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @param path path to query
+	 * @return value casted as desired
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	template <typename T>
 	void
 	set_list(const char *path, std::vector<T> &t)
 	{
-		YamlConfigurationNode *n = find_or_insert(path);
+		std::shared_ptr<YamlConfigurationNode> n = find_or_insert(path);
 		if (n->has_children()) {
 			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s", path);
 		}
@@ -637,35 +692,33 @@ public:
 	}
 
 	/** Set value of given type T.
-   * @param path path to query
-   * @return value casted as desired
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @param path path to query
+	 * @return value casted as desired
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	template <typename T>
 	void
 	set_value(T t)
 	{
 		if (has_children()) {
-			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s",
-			                        name_.c_str());
+			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s", name_.c_str());
 		}
 		set_scalar(fawkes::StringConversions::to_string(t));
 	}
 
 	/** Set list of values of given type T.
-   * @param path path to query
-   * @return value casted as desired
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @param path path to query
+	 * @return value casted as desired
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	template <typename T>
 	void
-	set_list(std::vector<T> &t)
+	set_list(const std::vector<T> &t)
 	{
 		if (has_children()) {
-			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s",
-			                        name_.c_str());
+			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s", name_.c_str());
 		}
 		std::vector<std::string>           v;
 		typename std::vector<T>::size_type N = t.size();
@@ -677,11 +730,11 @@ public:
 	}
 
 	/** Check if value is of given type T.
-   * @param path path to query
-   * @return value casted as desired
-   * @throw YAML::ScalarInvalid thrown if value does not exist or is of
-   * a different type.
-   */
+	 * @param path path to query
+	 * @return value casted as desired
+	 * @throw YAML::ScalarInvalid thrown if value does not exist or is of
+	 * a different type.
+	 */
 	template <typename T>
 	bool
 	is_type() const
@@ -692,7 +745,7 @@ public:
 				T rv;
 				return (yaml_utils::convert(list_values_[0], rv));
 			} else {
-				return false;
+				return true;
 			}
 		} else {
 			return (yaml_utils::convert(scalar_value_, rv));
@@ -718,6 +771,12 @@ public:
 		}
 	}
 
+	bool
+	is_list() const
+	{
+		return (type_ == Type::SEQUENCE);
+	}
+
 	float
 	get_float() const
 	{
@@ -740,29 +799,6 @@ public:
 	get_bool() const
 	{
 		return get_value<bool>();
-	}
-
-	Type::value
-	determine_scalar_type() const
-	{
-		if (is_type<unsigned int>()) {
-			int v = get_int();
-			if (v >= 0) {
-				return Type::UINT32;
-			} else {
-				return Type::INT32;
-			}
-		} else if (is_type<int>()) {
-			return Type::INT32;
-		} else if (is_type<float>()) {
-			return Type::FLOAT;
-		} else if (is_type<bool>()) {
-			return Type::BOOL;
-		} else if (is_type<std::string>()) {
-			return Type::STRING;
-		} else {
-			return Type::UNKNOWN;
-		}
 	}
 
 	std::string
@@ -795,18 +831,78 @@ public:
 	set_sequence(const YAML::Node &n)
 	{
 		if (n.Type() != YAML::NodeType::Sequence) {
+#ifdef HAVE_YAMLCPP_NODE_MARK
+			throw fawkes::Exception("Cannot initialize list from non-sequence (line %i, column %i)",
+			                n.Mark().line,
+			                n.Mark().column);
+#else
 			throw fawkes::Exception("Cannot initialize list from non-sequence");
+#endif
 		}
 		type_ = Type::SEQUENCE;
 		list_values_.resize(n.size());
-		unsigned int i = 0;
-#ifdef HAVE_YAMLCPP_0_5
-		for (YAML::const_iterator it = n.begin(); it != n.end(); ++it) {
-			list_values_[i++] = it->as<std::string>();
+		if (n.size() > 0) {
+			if (n.begin()->Type() == YAML::NodeType::Scalar) {
+				unsigned int i = 0;
+				for (YAML::const_iterator it = n.begin(); it != n.end(); ++it) {
+					list_values_[i++] = it->as<std::string>();
+				}
+			} else if (n.begin()->Type() == YAML::NodeType::Map) {
+				type_ = Type::SEQUENCE_MAP;
+				for (size_t i = 0; i < n.size(); ++i) {
+					std::string key{std::to_string(i)};
+					add_child(key, YamlConfigurationNode::create(n[i], key));
+				}
+			} else {
+#ifdef HAVE_YAMLCPP_NODE_MARK
+				throw fawkes::Exception("Sequence neither of type scalar nor map (line %i, column %i)",
+				                n.Mark().line,
+				                n.Mark().column);
 #else
-		for (YAML::Iterator it = n.begin(); it != n.end(); ++it) {
-			*it >> list_values_[i++];
+				throw fawkes::Exception("Sequence neither of type scalar nor map");
 #endif
+			}
+		}
+	}
+
+	void
+	set_map(const YAML::Node &node)
+	{
+		for (YAML::const_iterator it = node.begin(); it != node.end(); ++it) {
+			std::string                            key = it->first.as<std::string>();
+			std::shared_ptr<YamlConfigurationNode> in  = shared_from_this();
+			if (key.find("/") != std::string::npos) {
+				// we need to split and find the proper insertion node
+				std::vector<std::string> pel = fawkes::str_split(key);
+				for (size_t i = 0; i < pel.size() - 1; ++i) {
+					std::shared_ptr<YamlConfigurationNode> n = (*in)[pel[i]];
+					if (!n) {
+						n = std::make_shared<YamlConfigurationNode>(pel[i]);
+						in->add_child(pel[i], n);
+					}
+					in = n;
+				}
+
+				key = pel.back();
+			}
+
+			if (children_.find(key) != children_.end()) {
+				// we are updating a value
+				auto new_value = YamlConfigurationNode::create(it->second, key);
+				if (new_value->get_type() != children_[key]->get_type()) {
+#ifdef HAVE_YAMLCPP_NODE_MARK
+					throw fawkes::Exception(
+					  "YamlConfig (line %d, column %d): overwriting value with incompatible type",
+					  node.Mark().line,
+					  node.Mark().column);
+#else
+					throw fawkes::Exception("YamlConfig: overwriting value with incompatible type");
+#endif
+				}
+				in->add_child(key, new_value);
+			} else {
+				in->add_child(key, YamlConfigurationNode::create(it->second, key));
+			}
 		}
 	}
 
@@ -825,20 +921,21 @@ public:
 	void
 	set_default(const char *path, bool is_default)
 	{
-		YamlConfigurationNode *n = find(path);
+		std::shared_ptr<YamlConfigurationNode> n = find(path);
 		n->set_default(is_default);
 	}
 
 	void
 	set_default(bool is_default)
 	{
-		is_default_ = is_default_;
+		is_default_ = is_default;
 	}
 
 	void
-	enum_leafs(std::map<std::string, YamlConfigurationNode *> &nodes, std::string prefix = "") const
+	enum_leafs(std::map<std::string, std::shared_ptr<YamlConfigurationNode>> &nodes,
+	           std::string                                                    prefix = "") const
 	{
-		std::map<std::string, YamlConfigurationNode *>::const_iterator c;
+		std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::const_iterator c;
 		for (c = children_.begin(); c != children_.end(); ++c) {
 			std::string path = prefix + "/" + c->first;
 			if (c->second->has_children()) {
@@ -852,10 +949,10 @@ public:
 	void
 	print(std::string indent = "")
 	{
-		std::cout << indent << name_ << " : ";
+		std::cout << indent << name_;
 		if (!children_.empty()) {
 			std::cout << std::endl;
-			std::map<std::string, YamlConfigurationNode *>::iterator c;
+			std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::iterator c;
 			for (c = children_.begin(); c != children_.end(); ++c) {
 				c->second->print(indent + "  ");
 			}
@@ -872,7 +969,7 @@ private:
 		if (!children_.empty()) {
 			ye << YAML::BeginMap;
 
-			std::map<std::string, YamlConfigurationNode *>::iterator c;
+			std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::iterator c;
 			for (c = children_.begin(); c != children_.end(); ++c) {
 				if (c->second->has_children()) {
 					// recurse
@@ -910,16 +1007,137 @@ public:
 	}
 
 private:
-	std::string                                    name_;
-	Type::value                                    type_;
-	std::string                                    scalar_value_;
-	std::map<std::string, YamlConfigurationNode *> children_;
-	std::vector<std::string>                       list_values_;
-	bool                                           is_default_;
+	void
+	set_name(const std::string &name)
+	{
+		name_ = name;
+	}
+
+	void
+	set_type(Type::value type)
+	{
+		type_ = type;
+	}
+
+	Type::value
+	determine_scalar_type() const
+	{
+		if (is_type<unsigned int>()) {
+			try {
+				int v = get_int();
+				if (v >= 0) {
+					return Type::UINT32;
+				} else {
+					return Type::INT32;
+				}
+			} catch (fawkes::Exception &e) {
+				// can happen if value > MAX_INT
+				return Type::UINT32;
+			}
+		} else if (is_type<int>()) {
+			return Type::INT32;
+		} else if (is_type<float>()) {
+			return Type::FLOAT;
+		} else if (is_type<bool>()) {
+			return Type::BOOL;
+		} else if (is_type<std::string>()) {
+			return Type::STRING;
+		} else {
+			return Type::UNKNOWN;
+		}
+	}
+
+	void
+	verify_scalar(const YAML::Node &node) const
+	{
+		if (node.Tag() == "tag:fawkesrobotics.org,cfg/ipv4"
+		    || node.Tag() == "tag:fawkesrobotics.org,cfg/ipv6") {
+			std::string addr_s;
+			try {
+				addr_s = get_string();
+			} catch (fawkes::Exception &e) {
+#ifdef HAVE_YAMLCPP_NODE_MARK
+				e.prepend("YamlConfig (line %d, column %d): Invalid IPv4 or IPv6 address (not a string)",
+				          node.Mark().line,
+				          node.Mark().column);
+#else
+				e.prepend("YamlConfig: Invalid IPv4 or IPv6 address (not a string)");
+#endif
+				throw;
+			}
+
+			if (node.Tag() == "tag:fawkesrobotics.org,cfg/ipv4") {
+				struct in_addr addr;
+				if (inet_pton(AF_INET, addr_s.c_str(), &addr) != 1) {
+					throw fawkes::Exception("YamlConfig: %s is not a valid IPv4 address", addr_s.c_str());
+				}
+			}
+			if (node.Tag() == "tag:fawkesrobotics.org,cfg/ipv6") {
+				struct in6_addr addr;
+				if (inet_pton(AF_INET6, addr_s.c_str(), &addr) != 1) {
+					throw fawkes::Exception("YamlConfig: %s is not a valid IPv6 address", addr_s.c_str());
+				}
+			}
+
+		} else if (node.Tag() == "tag:fawkesrobotics.org,cfg/tcp-port"
+		           || node.Tag() == "tag:fawkesrobotics.org,cfg/udp-port") {
+			unsigned int p = 0;
+			try {
+				p = get_uint();
+			} catch (fawkes::Exception &e) {
+#ifdef HAVE_YAMLCPP_NODE_MARK
+				e.prepend(
+				  "YamlConfig (line %d, column %d): Invalid TCP/UDP port number (not an unsigned int)",
+				  node.Mark().line,
+				  node.Mark().column);
+#else
+				e.prepend("YamlConfig: Invalid TCP/UDP port number (not an unsigned int)");
+#endif
+				throw;
+			}
+			if (p <= 0 || p >= 65535) {
+				throw fawkes::Exception("YamlConfig: Invalid TCP/UDP port number "
+				                "(%u out of allowed range)",
+				                p);
+			}
+		} else if (node.Tag() == "tag:fawkesrobotics.org,cfg/url") {
+			std::string scalar = node.Scalar();
+			if (!regex_match(scalar, yaml_utils::url_regex)) {
+#ifdef HAVE_YAMLCPP_NODE_MARK
+				throw fawkes::Exception("YamlConfig (line %d, column %d): %s is not a valid URL",
+				                node.Mark().line,
+				                node.Mark().column,
+				                scalar.c_str());
+#else
+				throw fawkes::Exception("YamlConfig: %s is not a valid URL", scalar.c_str());
+#endif
+			}
+		} else if (node.Tag() == "tag:fawkesrobotics.org,cfg/frame") {
+			std::string scalar = node.Scalar();
+			if (!regex_match(scalar, yaml_utils::frame_regex)) {
+#ifdef HAVE_YAMLCPP_NODE_MARK
+				throw fawkes::Exception("YamlConfig (line %d, column %d): %s is not a valid frame ID",
+				                node.Mark().line,
+				                node.Mark().column,
+				                scalar.c_str());
+#else
+				throw fawkes::Exception("YamlConfig: %s is not a valid frame ID", scalar.c_str());
+#endif
+			}
+		}
+	}
+
+private:
+	std::string                                                   name_;
+	Type::value                                                   type_;
+	std::string                                                   scalar_value_;
+	std::map<std::string, std::shared_ptr<YamlConfigurationNode>> children_;
+	std::vector<std::string>                                      list_values_;
+	bool                                                          is_default_;
 };
 
 /// @endcond
 
-} // end namespace llsfrb
+} // end namespace llsfb
 
 #endif

--- a/src/libs/config/yaml_node.h
+++ b/src/libs/config/yaml_node.h
@@ -454,13 +454,13 @@ public:
 		if (add_to->is_scalar()) {
 			if (!n->is_scalar()) {
 				throw fawkes::Exception("YamlConfig: cannot overwrite scalar value %s with non-scalar",
-				                add_to->name().c_str());
+				                        add_to->name().c_str());
 			}
 			add_to->set_scalar(n->get_scalar());
 		} else if (add_to->is_list()) {
 			if (!n->is_list()) {
 				throw fawkes::Exception("YamlConfig: cannot overwrite list value %s with non-list",
-				                add_to->name().c_str());
+				                        add_to->name().c_str());
 			}
 			if (is_type<unsigned int>()) {
 				try {
@@ -488,8 +488,9 @@ public:
 			}
 		} else if (add_to->get_type() == Type::SEQUENCE_MAP) {
 			if (n->get_type() != Type::SEQUENCE_MAP) {
-				throw fawkes::Exception("YamlConfig: cannot overwrite sequence map value %s with non-sequence-map",
-				                add_to->name().c_str());
+				throw fawkes::Exception(
+				  "YamlConfig: cannot overwrite sequence map value %s with non-sequence-map",
+				  add_to->name().c_str());
 			}
 			add_to->children_.clear();
 			for (auto i = n->begin(); i != n->end(); ++i) {
@@ -702,7 +703,8 @@ public:
 	set_value(T t)
 	{
 		if (has_children()) {
-			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s", name_.c_str());
+			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s",
+			                        name_.c_str());
 		}
 		set_scalar(fawkes::StringConversions::to_string(t));
 	}
@@ -718,7 +720,8 @@ public:
 	set_list(const std::vector<T> &t)
 	{
 		if (has_children()) {
-			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s", name_.c_str());
+			throw fawkes::Exception("YamlConfig: cannot set value on non-leaf path node %s",
+			                        name_.c_str());
 		}
 		std::vector<std::string>           v;
 		typename std::vector<T>::size_type N = t.size();
@@ -833,8 +836,8 @@ public:
 		if (n.Type() != YAML::NodeType::Sequence) {
 #ifdef HAVE_YAMLCPP_NODE_MARK
 			throw fawkes::Exception("Cannot initialize list from non-sequence (line %i, column %i)",
-			                n.Mark().line,
-			                n.Mark().column);
+			                        n.Mark().line,
+			                        n.Mark().column);
 #else
 			throw fawkes::Exception("Cannot initialize list from non-sequence");
 #endif
@@ -856,8 +859,8 @@ public:
 			} else {
 #ifdef HAVE_YAMLCPP_NODE_MARK
 				throw fawkes::Exception("Sequence neither of type scalar nor map (line %i, column %i)",
-				                n.Mark().line,
-				                n.Mark().column);
+				                        n.Mark().line,
+				                        n.Mark().column);
 #else
 				throw fawkes::Exception("Sequence neither of type scalar nor map");
 #endif
@@ -1097,17 +1100,17 @@ private:
 			}
 			if (p <= 0 || p >= 65535) {
 				throw fawkes::Exception("YamlConfig: Invalid TCP/UDP port number "
-				                "(%u out of allowed range)",
-				                p);
+				                        "(%u out of allowed range)",
+				                        p);
 			}
 		} else if (node.Tag() == "tag:fawkesrobotics.org,cfg/url") {
 			std::string scalar = node.Scalar();
 			if (!regex_match(scalar, yaml_utils::url_regex)) {
 #ifdef HAVE_YAMLCPP_NODE_MARK
 				throw fawkes::Exception("YamlConfig (line %d, column %d): %s is not a valid URL",
-				                node.Mark().line,
-				                node.Mark().column,
-				                scalar.c_str());
+				                        node.Mark().line,
+				                        node.Mark().column,
+				                        scalar.c_str());
 #else
 				throw fawkes::Exception("YamlConfig: %s is not a valid URL", scalar.c_str());
 #endif
@@ -1117,9 +1120,9 @@ private:
 			if (!regex_match(scalar, yaml_utils::frame_regex)) {
 #ifdef HAVE_YAMLCPP_NODE_MARK
 				throw fawkes::Exception("YamlConfig (line %d, column %d): %s is not a valid frame ID",
-				                node.Mark().line,
-				                node.Mark().column,
-				                scalar.c_str());
+				                        node.Mark().line,
+				                        node.Mark().column,
+				                        scalar.c_str());
 #else
 				throw fawkes::Exception("YamlConfig: %s is not a valid frame ID", scalar.c_str());
 #endif
@@ -1138,6 +1141,6 @@ private:
 
 /// @endcond
 
-} // end namespace llsfb
+} // namespace llsfrb
 
 #endif

--- a/src/libs/utils/misc/string_compare.cpp
+++ b/src/libs/utils/misc/string_compare.cpp
@@ -39,14 +39,14 @@ namespace fawkes {
  */
 
 /** Check equality of two strings.
- * @param __s1 first string
- * @param __s2 second string
+ * @param s1_ first string
+ * @param s2_ second string
  * @return true, if the strings are equal, false otherwise
  */
 bool
-StringEquality::operator()(const char *__s1, const char *__s2) const
+StringEquality::operator()(const char *s1_, const char *s2_) const
 {
-	return (strcmp(__s1, __s2) == 0);
+	return (strcmp(s1_, s2_) == 0);
 }
 
 /** @class StringLess <utils/misc/string_compare.h>
@@ -61,14 +61,14 @@ StringEquality::operator()(const char *__s1, const char *__s2) const
  */
 
 /** Check equality of two strings.
- * @param __s1 first string
- * @param __s2 second string
- * @return true, if the __s1 < __s2
+ * @param s1_ first string
+ * @param s2_ second string
+ * @return true, if the s1_ < s2_
  */
 bool
-StringLess::operator()(const char *__s1, const char *__s2) const
+StringLess::operator()(const char *s1_, const char *s2_) const
 {
-	return (strcmp(__s1, __s2) < 0);
+	return (strcmp(s1_, s2_) < 0);
 }
 
 } // end namespace fawkes

--- a/src/libs/utils/misc/string_compare.h
+++ b/src/libs/utils/misc/string_compare.h
@@ -21,21 +21,21 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __UTILS_MISC_STRING_COMPARE_H_
-#define __UTILS_MISC_STRING_COMPARE_H_
+#ifndef _UTILS_MISC_STRING_COMPARE_H_
+#define _UTILS_MISC_STRING_COMPARE_H_
 
 namespace fawkes {
 
 class StringEquality
 {
 public:
-	bool operator()(const char *__s1, const char *__s2) const;
+	bool operator()(const char *s1_, const char *s2_) const;
 };
 
 class StringLess
 {
 public:
-	bool operator()(const char *__s1, const char *__s2) const;
+	bool operator()(const char *s1_, const char *s2_) const;
 };
 
 } // end namespace fawkes

--- a/src/libs/utils/misc/string_conversions.cpp
+++ b/src/libs/utils/misc/string_conversions.cpp
@@ -30,17 +30,13 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <map>
 
 namespace fawkes {
 
 /** @class StringConversions <utils/misc/string_conversions.h>
  * Utility class that holds string methods.
  * @author Tim Niemueller
- *
- * @fn static std::string StringConversions::to_string(std::string &s)
- * No-op conversion of string.
- * @param s value to convert
- * @return string the very same string
  */
 
 /** Convert string to all-uppercase string.
@@ -190,6 +186,16 @@ StringConversions::to_int(std::string s)
 	return atoi(s.c_str());
 }
 
+/** Convert string to a long int value
+ * @param s string to convert
+ * @return value as represented by string
+ */
+long
+StringConversions::to_long(std::string s)
+{
+	return atol(s.c_str());
+}
+
 /** Convert string to a float value
  * @param s string to convert
  * @return value as represented by string
@@ -243,7 +249,7 @@ StringConversions::trim_inplace(std::string &s)
  * @return trimmed string
  */
 std::string
-StringConversions::trim(std::string &s)
+StringConversions::trim(const std::string &s)
 {
 	std::string::size_type p1 = s.find_first_not_of(' ');
 	std::string::size_type p2 = s.find_last_not_of(' ');

--- a/src/libs/utils/misc/string_conversions.h
+++ b/src/libs/utils/misc/string_conversions.h
@@ -21,10 +21,11 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __UTILS_MISC_STRINGTOOLS_H_
-#define __UTILS_MISC_STRINGTOOLS_H_
+#ifndef _UTILS_MISC_STRINGTOOLS_H_
+#define _UTILS_MISC_STRINGTOOLS_H_
 
 #include <string>
+#include <vector>
 
 namespace fawkes {
 
@@ -40,20 +41,26 @@ public:
 	static std::string to_string(float f);
 	static std::string to_string(double d);
 	static std::string to_string(bool b);
+
+	/** No-op conversion of string.
+   * @param s value to convert
+   * @return string the very same string
+   */
 	static std::string
-	to_string(std::string &s)
+	to_string(const std::string &s)
 	{
 		return s;
 	}
 
 	static unsigned int to_uint(std::string s);
 	static int          to_int(std::string s);
+	static long         to_long(std::string s);
 	static float        to_float(std::string s);
 	static double       to_double(std::string s);
 	static bool         to_bool(std::string s);
 
 	static void        trim_inplace(std::string &s);
-	static std::string trim(std::string &s);
+	static std::string trim(const std::string &s);
 
 private:
 	// may not be instantiated!

--- a/src/libs/utils/misc/string_split.h
+++ b/src/libs/utils/misc/string_split.h
@@ -21,8 +21,14 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __UTILS_MISC_STRING_SPLIT_H_
-#define __UTILS_MISC_STRING_SPLIT_H_
+#ifndef _UTILS_MISC_STRING_SPLIT_H_
+#define _UTILS_MISC_STRING_SPLIT_H_
+
+#include <list>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace fawkes {
 
@@ -44,22 +50,61 @@ str_split(const std::string &s, char delim = '/')
 	return elems;
 }
 
+/** Split string by delimiter string.
+ * @param s string to split
+ * @param delim delimiter
+ * @return vector of split strings
+ */
+static inline std::vector<std::string>
+str_split(const std::string &s, std::string delim)
+{
+	std::vector<std::string> elems;
+	std::string::size_type   pos = 0;
+	do {
+		std::string::size_type dpos = s.find(delim, pos);
+		std::string            sub  = s.substr(pos, dpos);
+		elems.push_back(sub);
+		if (dpos != std::string::npos)
+			pos = dpos + delim.length();
+		else
+			pos = dpos;
+	} while (pos != std::string::npos);
+	return elems;
+}
+
 /** Split string by delimiter.
  * @param s string to split
  * @param delim delimiter
  * @return queue of split strings
  */
-static inline std::queue<std::string>
-str_split_to_queue(const std::string &s, char delim = '/')
+static inline std::list<std::string>
+str_split_list(const std::string &s, char delim = '/')
 {
-	std::queue<std::string> elems;
-	std::stringstream       ss(s);
-	std::string             item;
+	std::list<std::string> elems;
+	std::stringstream      ss(s);
+	std::string            item;
 	while (std::getline(ss, item, delim)) {
 		if (item != "")
-			elems.push(item);
+			elems.push_back(item);
 	}
 	return elems;
+}
+
+/** Join vector of strings string using given delimiter.
+ * @param v vector with strings to join
+ * @param delim delimiter
+ * @return string of strings in vector separated by given delimiter
+ */
+static inline std::string
+str_join(const std::vector<std::string> &v, char delim = '/')
+{
+	std::string rv;
+	for (size_t i = 0; i < v.size(); ++i) {
+		if (i > 0)
+			rv += delim;
+		rv += v[i];
+	}
+	return rv;
 }
 
 /** Join list of strings string using given delimiter.
@@ -75,6 +120,29 @@ str_join(const std::list<std::string> &l, char delim = '/')
 	for (std::list<std::string>::const_iterator i = l.begin(); i != l.end(); ++i) {
 		if (first)
 			first = false;
+		else
+			rv += delim;
+		rv += *i;
+	}
+	return rv;
+}
+
+/** Join list of strings string using given delimiter.
+ * The iterator must be produce a std::string for operator*().
+ * @param first input iterator to beginning of range
+ * @param last input iterator to end of range
+ * @param delim delimiter
+ * @return string of strings in list separated by given delimiter
+ */
+template <typename InputIterator>
+std::string
+str_join(const InputIterator &first, const InputIterator &last, char delim = '/')
+{
+	std::string rv;
+	bool        is_first = true;
+	for (InputIterator i = first; i != last; ++i) {
+		if (is_first)
+			is_first = false;
 		else
 			rv += delim;
 		rv += *i;
@@ -100,6 +168,47 @@ str_join(const std::list<std::string> &l, std::string delim)
 		rv += *i;
 	}
 	return rv;
+}
+
+/** Join list of strings string using given delimiter.
+ * The iterator must be produce a std::string for operator*().
+ * @param first input iterator to beginning of range
+ * @param last input iterator to end of range
+ * @param delim delimiter
+ * @return string of strings in list separated by given delimiter
+ */
+template <typename InputIterator>
+std::string
+str_join(const InputIterator &first, const InputIterator &last, std::string delim)
+{
+	std::string rv;
+	bool        is_first = true;
+	for (InputIterator i = first; i != last; ++i) {
+		if (is_first)
+			is_first = false;
+		else
+			rv += delim;
+		rv += *i;
+	}
+	return rv;
+}
+
+/** Split string by delimiter.
+ * @param s string to split
+ * @param delim delimiter
+ * @return queue of split strings
+ */
+static inline std::queue<std::string>
+str_split_to_queue(const std::string &s, char delim = '/')
+{
+	std::queue<std::string> elems;
+	std::stringstream       ss(s);
+	std::string             item;
+	while (std::getline(ss, item, delim)) {
+		if (item != "")
+			elems.push(item);
+	}
+	return elems;
 }
 
 } // end namespace fawkes


### PR DESCRIPTION
The config parser lib was originally taken from fawkes. Since then, various improvements to the parser were made in the fakes repository. In an attempt to bring those changes to this repo, i simply copied the files over and adapted them to the refbox namespace.

However, since i did not want to introduce unused features that would effectively act as dead code, i refrained from also copying related utility libs or dependencies that are used on fawkes side but are not part of the refbox repo, as of yet.

Hence, this PR does not add new files, it rather just updates the yaml config lib and the `libs/utils/misc/` lib files. The build process and dependencies remain untouched.
As a consequence, some advanced features available in fawkes are not carried over, yet.

My intentions for this PR were driven by the observation that currently empty lists cannot be parsed from `.yaml` configs. I thought it would be useful to improve the current config parser with minimal effort.