### PR TITLE
add configurable refbox-sided ring-payment feedbacks

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -193,8 +193,8 @@ llsfrb:
     #
     # To register a machine for this behavior, enter its full mane, e.g., to
     # add all ring stations simply use:
-    # disable-base-payment-check: [C-RS1, C-RS2, M-RS1, M-RS2]
-    disable-base-payment-check: []
+    disable-base-payment-check: [C-RS1, C-RS2, M-RS1, M-RS2]
+    # disable-base-payment-check: []
 
     # synchronize refbox time with the time of a simulation
     time-sync:

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -179,6 +179,23 @@ llsfrb:
 
   simulation:
     enable: false
+
+    # Disable in case machine feedback from the slides is unavailable (e.g.,
+    # if one ring station is unresponsive)
+    #
+    # Slide counters of ring stations listed here will increment the slide
+    # counter whenever a payment is due.
+    #
+    # This also implicates for all listed machines that:
+    #   1. Rings can be mounted without payment and the refbox awards additional
+    #      points as if the payment was actually made
+    #   2. Points for payments are only given, if they are used afterwards.
+    #
+    # To register a machine for this behavior, enter its full mane, e.g., to
+    # add all ring stations simply use:
+    # disable-base-payment-check: [C-RS1, C-RS2, M-RS1, M-RS2]
+    disable-base-payment-check: []
+
     # synchronize refbox time with the time of a simulation
     time-sync:
       enable: true

--- a/src/games/rcll/config.clp
+++ b/src/games/rcll/config.clp
@@ -15,6 +15,26 @@
   (multislot list-value)
 )
 
+(defrule config-print-disabled-slide-counter-checks
+  (confval (path "/llsfrb/simulation/disable-base-payment-check")
+					 (is-list TRUE) (list-value $?disabled-machines))
+	=>
+  (do-for-all-facts ((?m machine))
+      (and (eq ?m:mtype RS)
+					 (member$ (str-cat ?m:name) ?disabled-machines))
+    (printout warn "Slide counter check for "
+                   (str-cat ?m:name) " disabled, by config" crlf))
+)
+
+(defrule config-print-invalid-slide-counter-check-option
+  (confval (path "/llsfrb/simulation/disable-base-payment-check")
+					 (is-list TRUE) (list-value $? ?m $?))
+	(not (machine (name ?machine&:(eq ?machine (sym-cat ?m))) (mtype RS)))
+	=>
+  (printout warn "Disabling of slide counter check on machine " ?m " failed. "
+                 "Reason: " ?m " is not a ring station" crlf)
+)
+
 ;(defrule print-confval
 ;  (confval (path ?p) (type ?t) (value ?v) (is-list ?is-list) (list-value $?lv))
 ;  =>

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -350,6 +350,12 @@
   (delayed-do-for-all-facts ((?machine machine)) TRUE
     (modify ?machine (desired-lights RED-BLINK))
   )
+  (do-for-all-facts ((?cfg confval) (?m machine))
+      (and (eq ?cfg:path "/llsfrb/simulation/disable-base-payment-check")
+					 (eq ?m:mtype RS)
+					 (member$ (str-cat ?m:name) ?cfg:list-value))
+    (printout warn "Please add points for remaining bases in slide of "
+                   (str-cat ?m:name) " manually." crlf))
   (if (any-factp ((?pd referee-confirmation)) TRUE) then
     (assert (attention-message (text "Game ended, please confirm deliveries!")))
     (assert (postgame-for-unconfirmed-deliveries))

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -315,6 +315,7 @@
 	(confval (path "/llsfrb/simulation/disable-base-payment-check")
 			(type STRING) (is-list TRUE)
 			(list-value $?disabled&:(member$ (str-cat ?n) ?disabled)))
+	(not (mps-add-base-on-slide ?n))
   =>
   (printout warn "Simulating "(str-cat ?n) " base payment feedback. "
 									"Please verify that the payment was actually made" crlf)
@@ -378,6 +379,7 @@
 	?m <- (machine (name ?n) (state ?state) (mtype RS) (team ?team)
 	               (bases-used ?bases-used) (bases-added ?old-num-bases))
 	?fb <- (mps-add-base-on-slide ?n)
+  (not (points (game-time ?gt)))
 	=>
 	(retract ?fb)
 	(if (neq ?state BROKEN)


### PR DESCRIPTION
This PR deals with an issue that occurs, whenever a ring station should be simulated logically (e.g., when a RS is physically broken, has empty batteries or a malfunctioning slide counter sensor).

**Status Quo:** It is already possible to simulate all other machines logically without further work from the refbox operator, because usual machine interactions are in the form of instructions that can be processed in the refbox, skipping the machine-sided communication. Field referees may move the workpieces around, such that games can be played out normally.
Ring stations have the distinct feature of a one-sided feedback from the machine to the refbox, whenever a payment at the slide is registered. Since no instructions from the acting robot is sent in that case, it currently requires a manual increment of the slide counter by the refbox operator, whenever a workpiece is placed into the slide of an inoperable machine in order to ensure proper further usage of said MPS.

**Alternative Solution:** The slide counter check of disabled machines may simply be skipped under the assumption that teams play correctly. Whenever insufficient bases for a requested payments are detected, the slide counter is automatically incremented until it matches the requested payment.

Assuming a disabled ring station `C-RS1` the following scenarios apply:
### Previously:
#### Procedure:
1. Field referees report successful slide puts at `C-RS1`
2. Refbox operator manually sends slide increment instruction to the refbox
3. `C-RS1` breaks automatically, if slide becomes overfull or `C-RS1` is instructed to mount without having sufficient payment.
#### Drawbacks:
1. Refbox operator has additional work in games, where teams play correctly
2. Timing issues, in case a team places someting at `C-RS1`, then pays more bases to the slide and sends the prepare instruction as soon as the required payment was made.
### Alternative Solution:
#### Procedure:
1. Field referees also have to keep track of slide puts at `C-RS1`
2. When `C-RS1` is instructed but not enough payment was made, or when `C-RS1` is overfed, the refbox operator manually breaks the machine
3. At the end of the game all remaining bases in the slide of `C-RS1` should be awarded the points for successful slide payments
#### Drawbacks:
1. Refbox operator has additional work in games, where teams wrongly operate `C-RS1`
2. Additional point adjustment post game necessary
3. Refbox does not act according to the rules in this setting, but rather assumes correct behaviour, such that misplays have to be dealt with manually.
### How does this help?
1. In case of a malfunctioning MPS the teams are not at mercy of referees and refbox operators to play a game correcty. Instead, additional interventions from referees and refbox are only required in case of wrongful machine operations. 
2. There are likely more slide payments done than wrongly operated ring-mount requrests. 
3. Timing is no issue when interfering because of a wrongly used machine: The phyiscal transportation is carried out by humans that can simply wait.
4. It provides a configurable alternative to the current setting that allows fully automatically managed games with (partially) simulated MPS in settings where wrongly instructed machines are of no issue (such as perfect simulation scenarios)