### PR TITLE
netcomm: let avahi thread sleep for a while if creating a client fails

### DIFF
--- a/src/libs/netcomm/dns-sd/avahi_thread.cpp
+++ b/src/libs/netcomm/dns-sd/avahi_thread.cpp
@@ -43,6 +43,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
+#include <thread>
 
 namespace fawkes {
 
@@ -54,6 +55,9 @@ namespace fawkes {
  * @ingroup NetComm
  * @author Tim Niemueller
  */
+
+/** Time to wait if creating an avahi client fails. **/
+const std::chrono::seconds AvahiThread::wait_on_init_failure{5};
 
 /** Constructor. */
 AvahiThread::AvahiThread() : Thread("AvahiThread")
@@ -146,6 +150,10 @@ AvahiThread::loop()
 		need_recover = false;
 
 		avahi_simple_poll_iterate(simple_poll, -1);
+	} else {
+		// We failed to create a client, e.g., because the daemon is not running.
+		// Wait for a while and try again.
+		std::this_thread::sleep_for(wait_on_init_failure);
 	}
 }
 

--- a/src/libs/netcomm/dns-sd/avahi_thread.h
+++ b/src/libs/netcomm/dns-sd/avahi_thread.h
@@ -33,6 +33,7 @@
 #include <netcomm/service_discovery/service_publisher.h>
 #include <netinet/in.h>
 
+#include <chrono>
 #include <string>
 #include <utility>
 
@@ -181,9 +182,10 @@ private:
 	bool do_erase_browsers;
 	bool do_reset_groups;
 
-	AvahiSimplePoll *simple_poll;
-	AvahiClient *    client;
-	AvahiClientState client_state;
+	AvahiSimplePoll *                 simple_poll;
+	AvahiClient *                     client;
+	AvahiClientState                  client_state;
+	const static std::chrono::seconds wait_on_init_failure;
 
 	WaitCondition *init_wc;
 


### PR DESCRIPTION
Sometimes, creating a client fails, e.g., if the daemon is not
available. In that case, instead of directly trying again in the next
iteration, let the thread sleep for a while. This avoids the thread to
run on 100% CPU because it continuously tries re-creating the client.

This fixes #67.