### PR TITLE
Extend rcll-refbox-instruct to wait for a given number of robots

### DIFF
--- a/src/tools/rcll-refbox-instruct.cpp
+++ b/src/tools/rcll-refbox-instruct.cpp
@@ -149,9 +149,10 @@ handle_message(uint16_t                                   component_id,
 		current_game_state_ = g;
 	}
 	std::shared_ptr<RobotInfo> ri;
-	if ((ri = std::dynamic_pointer_cast<RobotInfo>(msg)) && wait_state_) {
+	if ((ri = std::dynamic_pointer_cast<RobotInfo>(msg))) {
 		current_robot_info_ = ri;
 	}
+
 	if (wait_state_ && current_game_state_ && current_robot_info_) {
 		bool matches = true;
 		if (msg_team_cyan_ && msg_team_cyan_->team_name() != current_game_state_->team_cyan()) {


### PR DESCRIPTION
Sometimes, we may want to wait for robots, e.g., when running in
simulation. Instead of guessing how long the robots need to connect,
extend the rcll-refbox-instruct tool to wait for some given number of
robots. This also works in conjunction with the other wait options,
e.g., waiting for a game phase.

Example usage:
```
$ ./rcll-refbox-instruct -n2 -W -p PRODUCTION
```
This will wait for two robots to appear, as well as for the phase to switch to PRODUCTION.