### PR TITLE
Accelerate games in simulation

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -180,6 +180,12 @@ llsfrb:
   simulation:
     enable: false
 
+    # factor by which the game time should elapse per second. Also affects
+    # mockup machine process durations. However, every single step will
+    # take at least 1s (2s in case of the delvery station) to prevent
+    # unobservable state changes.
+    speedup: 1.0
+
     # Disable in case machine feedback from the slides is unavailable (e.g.,
     # if one ring station is unresponsive)
     #

--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -350,6 +350,7 @@
 
 (deftemplate sim-time
   (slot enabled (type SYMBOL) (allowed-values false true) (default false))
+  (slot speedup (type FLOAT) (default 1.0))
   (slot estimate (type SYMBOL) (allowed-values false true) (default false))
   (multislot now (type INTEGER) (cardinality 2 2) (default 0 0))
   (multislot last-recv-time (type INTEGER) (cardinality 2 2) (default 0 0))

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -210,10 +210,9 @@
 		    (game-time ?game-time) (cont-time ?cont-time)
 		    (last-time $?last-time&:(neq ?last-time ?now)))
   ?st <- (sim-time (enabled ?sts) (estimate ?ste) (now $?sim-time)
-		   (real-time-factor ?rtf) (last-recv-time $?lrt))
+		(speedup ?speedup) (real-time-factor ?rtf) (last-recv-time $?lrt))
   (or (sim-time (enabled false))
       (gamestate (last-time $?last-time&:(neq ?last-time ?sim-time))))
-  (confval (path "/llsfrb/simulation/speedup") (type UINT|FLOAT|INT) (value ?speedup))
   =>
   (bind ?points-cyan (game-calc-points CYAN))
   (bind ?points-magenta (game-calc-points MAGENTA))

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -213,11 +213,12 @@
 		   (real-time-factor ?rtf) (last-recv-time $?lrt))
   (or (sim-time (enabled false))
       (gamestate (last-time $?last-time&:(neq ?last-time ?sim-time))))
+  (confval (path "/llsfrb/simulation/speedup") (type UINT|FLOAT|INT) (value ?speedup))
   =>
   (bind ?points-cyan (game-calc-points CYAN))
   (bind ?points-magenta (game-calc-points MAGENTA))
   (bind ?now (get-time ?sts ?ste ?now ?sim-time ?lrt ?rtf))
-  (bind ?timediff (time-diff-sec ?now ?last-time))
+  (bind ?timediff (* (time-diff-sec ?now ?last-time) ?speedup))
   (modify ?gf (game-time (+ ?game-time ?timediff)) (cont-time (+ ?cont-time ?timediff))
 	  (last-time ?now) (points ?points-cyan ?points-magenta))
 )

--- a/src/games/rcll/simulation.clp
+++ b/src/games/rcll/simulation.clp
@@ -19,10 +19,11 @@
   (not (sim-time-initialized))
   (confval (path "/llsfrb/simulation/time-sync/estimate-time") (type BOOL) (value ?time-estimate-enable))
   (confval (path "/llsfrb/simulation/time-sync/enable") (type BOOL) (value ?time-sync-enable))
+  (confval (path "/llsfrb/simulation/speedup") (type UINT|FLOAT|INT) (value ?speedup))
   =>
   (assert (sim-time-initialized)
 	  (sim-time (enabled ?time-sync-enable) (estimate ?time-estimate-enable)
-		    (now (create$ 0 0)))
+              (speedup ?speedup) (now (create$ 0 0)))
   )
 )
 

--- a/src/libs/Makefile
+++ b/src/libs/Makefile
@@ -23,7 +23,8 @@ SUBDIRS = core utils config logging netcomm protobuf_comm protobuf_clips \
 # Explicit dependencies, this is needed to have make bail out if there is any
 # error. This is also necessary for working parallel build (i.e. for dual core)
 netcomm config mongodb_log: core utils
-utils mps_comm mps_placing_clips: core
+utils mps_placing_clips: core
+mps_comm: core config
 logging: core protobuf_comm
 protobuf_clips: protobuf_comm
 mongodb_log: logging

--- a/src/libs/mps_comm/Makefile
+++ b/src/libs/mps_comm/Makefile
@@ -20,7 +20,7 @@ include $(BUILDSYSDIR)/protobuf.mk
 include $(BUILDSYSDIR)/boost.mk
 include $(BASEDIR)/src/libs/mps_comm/freeopcua.mk
 
-LIBS_libmps_comm = stdc++ m llsfrbcore pthread
+LIBS_libmps_comm = stdc++ m llsfrbcore llsfrbconfig pthread
 OBJS_opcua = opcua/opc_utils.o opcua/machine.o opcua/base_station.o \
 						 opcua/cap_station.o opcua/delivery_station.o opcua/ring_station.o \
              opcua/storage_station.o

--- a/src/libs/mps_comm/mockup/base_station.cpp
+++ b/src/libs/mps_comm/mockup/base_station.cpp
@@ -20,8 +20,6 @@
 
 #include "base_station.h"
 
-#include <cmath>
-
 namespace llsfrb {
 namespace mps_comm {
 MockupBaseStation::MockupBaseStation(const std::string &name) : Machine(name)
@@ -35,7 +33,9 @@ MockupBaseStation::get_base(llsf_msgs::BaseColor color)
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::chrono::seconds((int)std::ceil(1.f / exec_speed_))));
+	                              + std::max(std::chrono::milliseconds(1000),
+	                                         std::chrono::milliseconds(
+	                                           static_cast<int>(1000.f / exec_speed_)))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/base_station.cpp
+++ b/src/libs/mps_comm/mockup/base_station.cpp
@@ -20,6 +20,8 @@
 
 #include "base_station.h"
 
+#include <cmath>
+
 namespace llsfrb {
 namespace mps_comm {
 MockupBaseStation::MockupBaseStation(const std::string &name) : Machine(name)
@@ -32,7 +34,8 @@ MockupBaseStation::get_base(llsf_msgs::BaseColor color)
 	callback_busy_(true);
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
-	                            std::chrono::system_clock::now() + std::chrono::seconds(1)));
+	                            std::chrono::system_clock::now()
+	                              + std::chrono::seconds((int)std::ceil(1.f / exec_speed_))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/cap_station.cpp
+++ b/src/libs/mps_comm/mockup/cap_station.cpp
@@ -20,8 +20,6 @@
 
 #include "cap_station.h"
 
-#include <cmath>
-
 namespace llsfrb {
 namespace mps_comm {
 
@@ -48,7 +46,9 @@ MockupCapStation::cap_op()
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::chrono::seconds((int)std::ceil(3.f / exec_speed_))));
+	                              + std::max(std::chrono::milliseconds(1000),
+	                                         std::chrono::milliseconds(
+	                                           static_cast<int>(3000.f / exec_speed_)))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/cap_station.cpp
+++ b/src/libs/mps_comm/mockup/cap_station.cpp
@@ -20,6 +20,8 @@
 
 #include "cap_station.h"
 
+#include <cmath>
+
 namespace llsfrb {
 namespace mps_comm {
 
@@ -45,7 +47,8 @@ MockupCapStation::cap_op()
 	callback_busy_(true);
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
-	                            std::chrono::system_clock::now() + std::chrono::seconds(3)));
+	                            std::chrono::system_clock::now()
+	                              + std::chrono::seconds((int)std::ceil(3.f / exec_speed_))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/delivery_station.cpp
+++ b/src/libs/mps_comm/mockup/delivery_station.cpp
@@ -20,8 +20,6 @@
 
 #include "delivery_station.h"
 
-#include <cmath>
-
 namespace llsfrb {
 namespace mps_comm {
 
@@ -35,10 +33,11 @@ MockupDeliveryStation::deliver_product(int slot)
 	assert(slot == 1 || slot == 2 || slot == 3);
 	callback_busy_(true);
 	std::lock_guard<std::mutex> lg(queue_mutex_);
-	queue_.push(
-	  std::make_tuple([this] { callback_busy_(false); },
-	                  std::chrono::system_clock::now()
-	                    + std::chrono::seconds(1 + (int)std::ceil(float(slot / exec_speed_)))));
+	queue_.push(std::make_tuple([this] { callback_busy_(false); },
+	                            std::chrono::system_clock::now()
+	                              + std::max(std::chrono::milliseconds(2000),
+	                                         std::chrono::milliseconds(
+	                                           static_cast<int>((1 + slot) / exec_speed_)))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/delivery_station.cpp
+++ b/src/libs/mps_comm/mockup/delivery_station.cpp
@@ -20,6 +20,8 @@
 
 #include "delivery_station.h"
 
+#include <cmath>
+
 namespace llsfrb {
 namespace mps_comm {
 
@@ -33,8 +35,10 @@ MockupDeliveryStation::deliver_product(int slot)
 	assert(slot == 1 || slot == 2 || slot == 3);
 	callback_busy_(true);
 	std::lock_guard<std::mutex> lg(queue_mutex_);
-	queue_.push(std::make_tuple([this] { callback_busy_(false); },
-	                            std::chrono::system_clock::now() + std::chrono::seconds(4 + slot)));
+	queue_.push(
+	  std::make_tuple([this] { callback_busy_(false); },
+	                  std::chrono::system_clock::now()
+	                    + std::chrono::seconds(1 + (int)std::ceil(float(slot / exec_speed_)))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/delivery_station.cpp
+++ b/src/libs/mps_comm/mockup/delivery_station.cpp
@@ -37,7 +37,7 @@ MockupDeliveryStation::deliver_product(int slot)
 	                            std::chrono::system_clock::now()
 	                              + std::max(std::chrono::milliseconds(2000),
 	                                         std::chrono::milliseconds(
-	                                           static_cast<int>((1 + slot) / exec_speed_)))));
+	                                           static_cast<int>((1 + slot) * 1000 / exec_speed_)))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/machine.cpp
+++ b/src/libs/mps_comm/mockup/machine.cpp
@@ -20,6 +20,8 @@
 
 #include "machine.h"
 
+#include <config/yaml.h>
+
 #include <chrono>
 #include <thread>
 
@@ -28,6 +30,9 @@ namespace mps_comm {
 
 MockupMachine::MockupMachine() : shutdown_(false)
 {
+	Configuration *config = new YamlConfiguration(CONFDIR);
+	config->load("config.yaml");
+	exec_speed_    = config->get_float_or_default("llsfrb/simulation/speedup", 1);
 	worker_thread_ = std::thread(&MockupMachine::queue_worker, this);
 }
 

--- a/src/libs/mps_comm/mockup/machine.cpp
+++ b/src/libs/mps_comm/mockup/machine.cpp
@@ -23,6 +23,7 @@
 #include <config/yaml.h>
 
 #include <chrono>
+#include <cmath>
 #include <thread>
 
 namespace llsfrb {
@@ -94,12 +95,15 @@ MockupMachine::conveyor_move(ConveyorDirection direction, MPSSensor sensor)
 	callback_busy_(true);
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
-	                            std::chrono::system_clock::now() + std::chrono::seconds(4)));
+	                            std::chrono::system_clock::now()
+	                              + std::chrono::seconds((int)std::ceil(4.f / exec_speed_))));
 	if (sensor == INPUT || sensor == OUTPUT) {
 		queue_.push(std::make_tuple([this] { callback_ready_(true); },
-		                            std::chrono::system_clock::now() + std::chrono::seconds(4)));
+		                            std::chrono::system_clock::now()
+		                              + std::chrono::seconds((int)std::ceil(4.f / exec_speed_))));
 		queue_.push(std::make_tuple([this] { callback_ready_(false); },
-		                            std::chrono::system_clock::now() + std::chrono::seconds(14)));
+		                            std::chrono::system_clock::now()
+		                              + std::chrono::seconds((int)std::ceil(14.f / exec_speed_))));
 	}
 	queue_condition_.notify_one();
 }

--- a/src/libs/mps_comm/mockup/machine.cpp
+++ b/src/libs/mps_comm/mockup/machine.cpp
@@ -23,7 +23,6 @@
 #include <config/yaml.h>
 
 #include <chrono>
-#include <cmath>
 #include <thread>
 
 namespace llsfrb {
@@ -96,14 +95,20 @@ MockupMachine::conveyor_move(ConveyorDirection direction, MPSSensor sensor)
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::chrono::seconds((int)std::ceil(4.f / exec_speed_))));
+	                              + std::max(std::chrono::milliseconds(1000),
+	                                         std::chrono::milliseconds(
+	                                           static_cast<int>(4000.f / exec_speed_)))));
 	if (sensor == INPUT || sensor == OUTPUT) {
 		queue_.push(std::make_tuple([this] { callback_ready_(true); },
 		                            std::chrono::system_clock::now()
-		                              + std::chrono::seconds((int)std::ceil(4.f / exec_speed_))));
+		                              + std::max(std::chrono::milliseconds(1000),
+		                                         std::chrono::milliseconds(
+		                                           static_cast<int>(4000.f / exec_speed_)))));
 		queue_.push(std::make_tuple([this] { callback_ready_(false); },
 		                            std::chrono::system_clock::now()
-		                              + std::chrono::seconds((int)std::ceil(14.f / exec_speed_))));
+		                              + std::max(std::chrono::milliseconds(1000),
+		                                         std::chrono::milliseconds(
+		                                           static_cast<int>(14000.f / exec_speed_)))));
 	}
 	queue_condition_.notify_one();
 }

--- a/src/libs/mps_comm/mockup/machine.h
+++ b/src/libs/mps_comm/mockup/machine.h
@@ -49,6 +49,7 @@ public:
 protected:
 	void                    queue_worker();
 	std::mutex              queue_mutex_;
+	float                   exec_speed_;
 	std::condition_variable queue_condition_;
 	std::queue<std::tuple<std::function<void()>, std::chrono::time_point<std::chrono::system_clock>>>
 	                                   queue_;

--- a/src/libs/mps_comm/mockup/ring_station.cpp
+++ b/src/libs/mps_comm/mockup/ring_station.cpp
@@ -20,8 +20,6 @@
 
 #include "ring_station.h"
 
-#include <cmath>
-
 namespace llsfrb {
 namespace mps_comm {
 
@@ -36,7 +34,9 @@ MockupRingStation::mount_ring(unsigned int feeder)
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::chrono::seconds((int)std::ceil(3.f / exec_speed_))));
+	                              + std::max(std::chrono::milliseconds(1000),
+	                                         std::chrono::milliseconds(
+	                                           static_cast<int>(3000.f / exec_speed_)))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/ring_station.cpp
+++ b/src/libs/mps_comm/mockup/ring_station.cpp
@@ -20,6 +20,8 @@
 
 #include "ring_station.h"
 
+#include <cmath>
+
 namespace llsfrb {
 namespace mps_comm {
 
@@ -33,7 +35,8 @@ MockupRingStation::mount_ring(unsigned int feeder)
 	callback_busy_(true);
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
-	                            std::chrono::system_clock::now() + std::chrono::seconds(3)));
+	                            std::chrono::system_clock::now()
+	                              + std::chrono::seconds((int)std::ceil(3.f / exec_speed_))));
 	queue_condition_.notify_one();
 }
 


### PR DESCRIPTION
This PR adds a configurable speedup factor that does two things:
1. Scaling of individual mockup mps instruction times and
2. scaling of the game-time updates by the given factor
This allows to simulate games faster than real-time while staying close to an actual regular-paced game, given that the participating robots are sped up accordingly.

One may be at risk of having mps states that move too fast to be observable. I set the minimal instruction time per command to one second (2 seconds in case of the delivery station) and it worked well on my laptop across multiple games (tested >10 games). 
This also means that the relation between machine instruction times and the corresponding elapsing in-game seconds will drift apart ("machine instructions take relatively way longer") the higher the scaling factor is. I personally tested using a factor of 5 and was quite satisfied, i would not recommend going much higher if you aim for results that are close to the real-world setting.