### PR TITLE
Use realistic durations for MPS mockup operations

### DIFF
--- a/etc/buildsys/gcc.mk
+++ b/etc/buildsys/gcc.mk
@@ -62,6 +62,7 @@ ifeq ($(call gcc_atleast_version,6,0),1)
   # Reset flags, also CPP11 to avoid downgrade to C++11.
   CFLAGS_CPP11=
   CFLAGS_CPP14=
+  CFLAGS_CPP17=-std=c++17
 endif
 
 ifeq ($(call gcc_lessthan_version,4,7),1)

--- a/src/libs/mps_comm/Makefile
+++ b/src/libs/mps_comm/Makefile
@@ -27,7 +27,14 @@ OBJS_opcua = opcua/opc_utils.o opcua/machine.o opcua/base_station.o \
 OBJS_mockup = mockup/machine.o mockup/base_station.o mockup/cap_station.o \
 							mockup/delivery_station.o mockup/ring_station.o \
               mockup/storage_station.o
-OBJS_libmps_comm = time_utils.o machine_factory.o $(OBJS_mockup)
+OBJS_libmps_comm = time_utils.o machine_factory.o
+
+ifeq ($(HAVE_CPP17),1)
+  OBJS_libmps_comm += $(OBJS_mockup)
+  CFLAGS += $(CFLAGS_CPP17) -DHAVE_MOCKUP
+else
+  WARN_TARGETS += warning_cpp17
+endif
 
 ifeq ($(HAVE_FREEOPCUA),1)
   OBJS_libmps_comm += $(OBJS_opcua)
@@ -45,6 +52,8 @@ all: $(WARN_TARGETS)
 .PHONY: $(WARN_TARGETS)
 warning_freeopcua:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)No OPC-UA support$(TNORMAL) (freeopcua not found)"
+warning_cpp17:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)No Mockup support$(TNORMAL) (C++17 not supported)"
 endif
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/libs/mps_comm/machine_factory.cpp
+++ b/src/libs/mps_comm/machine_factory.cpp
@@ -70,6 +70,7 @@ MachineFactory::create_machine(const std::string &name,
 		return std::move(mps);
 	}
 #endif
+#ifdef HAVE_MOCKUP
 	if (connection_mode == "mockup") {
 		if (type == "BS") {
 			return std::make_unique<MockupBaseStation>(name);
@@ -88,11 +89,11 @@ MachineFactory::create_machine(const std::string &name,
 			  name.c_str(),
 			  connection_mode.c_str());
 		}
-	} else {
-		throw fawkes::Exception("Unexpected connection mode '%s' for machine '%s'",
-		                        connection_mode.c_str(),
-		                        name.c_str());
 	}
+#endif
+	throw fawkes::Exception("Unexpected connection mode '%s' for machine '%s'",
+	                        connection_mode.c_str(),
+	                        name.c_str());
 }
 } // namespace mps_comm
 } // namespace llsfrb

--- a/src/libs/mps_comm/mockup/base_station.cpp
+++ b/src/libs/mps_comm/mockup/base_station.cpp
@@ -20,6 +20,8 @@
 
 #include "base_station.h"
 
+#include "durations.h"
+
 namespace llsfrb {
 namespace mps_comm {
 MockupBaseStation::MockupBaseStation(const std::string &name) : Machine(name)
@@ -33,9 +35,9 @@ MockupBaseStation::get_base(llsf_msgs::BaseColor color)
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::max(std::chrono::milliseconds(1000),
-	                                         std::chrono::milliseconds(
-	                                           static_cast<int>(1000.f / exec_speed_)))));
+	                              + std::max(min_operation_duration_,
+	                                         std::chrono::round<std::chrono::milliseconds>(
+	                                           duration_base_dispense_ / exec_speed_))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/cap_station.cpp
+++ b/src/libs/mps_comm/mockup/cap_station.cpp
@@ -20,6 +20,8 @@
 
 #include "cap_station.h"
 
+#include "durations.h"
+
 namespace llsfrb {
 namespace mps_comm {
 
@@ -46,9 +48,9 @@ MockupCapStation::cap_op()
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::max(std::chrono::milliseconds(1000),
-	                                         std::chrono::milliseconds(
-	                                           static_cast<int>(3000.f / exec_speed_)))));
+	                              + std::max(min_operation_duration_,
+	                                         std::chrono::round<std::chrono::milliseconds>(
+	                                           duration_cap_op_ / exec_speed_))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/delivery_station.cpp
+++ b/src/libs/mps_comm/mockup/delivery_station.cpp
@@ -20,6 +20,10 @@
 
 #include "delivery_station.h"
 
+#include "durations.h"
+
+#include <chrono>
+
 namespace llsfrb {
 namespace mps_comm {
 
@@ -35,9 +39,9 @@ MockupDeliveryStation::deliver_product(int slot)
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::max(std::chrono::milliseconds(2000),
-	                                         std::chrono::milliseconds(
-	                                           static_cast<int>((1 + slot) * 1000 / exec_speed_)))));
+	                              + std::max(min_operation_duration_,
+	                                         std::chrono::round<std::chrono::milliseconds>(
+	                                           duration_ds_slots[slot - 1] / exec_speed_))));
 	queue_condition_.notify_one();
 }
 

--- a/src/libs/mps_comm/mockup/durations.h
+++ b/src/libs/mps_comm/mockup/durations.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *  durations.h - Durations of mockup actions
+ *
+ *  Created: Tue 14 Apr 2020 13:15:37 CEST 13:15
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include <array>
+#include <chrono>
+
+inline const std::chrono::milliseconds min_operation_duration_{1000};
+inline const std::chrono::milliseconds duration_band_input_to_mid_{1538};
+inline const std::chrono::milliseconds duration_band_mid_to_output_{2656};
+//inline const std::chrono::milliseconds duration_cap_retrieval_{17660};
+//inline const std::chrono::milliseconds duration_cap_mount_{17848};
+inline const std::chrono::milliseconds                      duration_cap_op_{17500};
+inline const std::chrono::milliseconds                      duration_ring_mount_{17308};
+inline const std::chrono::milliseconds                      duration_base_dispense_{1100};
+inline const std::chrono::milliseconds                      duration_ready_at_output_{15000};
+inline const std::array<const std::chrono::milliseconds, 3> duration_ds_slots{
+  std::chrono::milliseconds{3746},
+  std::chrono::milliseconds{4746},
+  std::chrono::milliseconds{3983}};

--- a/src/libs/mps_comm/mockup/ring_station.cpp
+++ b/src/libs/mps_comm/mockup/ring_station.cpp
@@ -20,6 +20,10 @@
 
 #include "ring_station.h"
 
+#include "durations.h"
+
+#include <chrono>
+
 namespace llsfrb {
 namespace mps_comm {
 
@@ -34,9 +38,9 @@ MockupRingStation::mount_ring(unsigned int feeder)
 	std::lock_guard<std::mutex> lg(queue_mutex_);
 	queue_.push(std::make_tuple([this] { callback_busy_(false); },
 	                            std::chrono::system_clock::now()
-	                              + std::max(std::chrono::milliseconds(1000),
-	                                         std::chrono::milliseconds(
-	                                           static_cast<int>(3000.f / exec_speed_)))));
+	                              + std::max(min_operation_duration_,
+	                                         std::chrono::round<std::chrono::milliseconds>(
+	                                           duration_ring_mount_ / exec_speed_))));
 	queue_condition_.notify_one();
 }
 


### PR DESCRIPTION
* Move all durations into a separate file so they can be easier checked and modified
* Use measurements from our lab for the mockup durations (thanks to @lyndwyrm666 for the data)