### PR TITLE
Adapt to freeopcua with system spdlog

### DIFF
--- a/src/libs/mps_comm/opcua/machine.cpp
+++ b/src/libs/mps_comm/opcua/machine.cpp
@@ -25,6 +25,9 @@
 #include "../time_utils.h"
 #include "mps_io_mapping.h"
 
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_sinks.h>
+
 #include <chrono>
 #include <iostream>
 #include <pthread.h>

--- a/src/libs/mps_comm/opcua/machine.cpp
+++ b/src/libs/mps_comm/opcua/machine.cpp
@@ -25,8 +25,10 @@
 #include "../time_utils.h"
 #include "mps_io_mapping.h"
 
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_sinks.h>
+#if HAVE_SYSTEM_SPDLOG
+#	include <spdlog/sinks/basic_file_sink.h>
+#	include <spdlog/sinks/stdout_sinks.h>
+#endif
 
 #include <chrono>
 #include <iostream>


### PR DESCRIPTION
Add missing includes of spdlog sinks.

Those became necessary by a recent freeopcua update, which uses the system spdlog instead of bundling it. Those files were previously included from the freeopcua headers.

Conditionalize the include on `HAVE_SYSTEM_SPDLOG` to stay compatible with the old version of freeopcua.