### PR TITLE
Use the official Fedora package for freeopcua

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
               clips-devel \
               clipsmm-devel \
               findutils \
+              freeopcua-devel \
               gcc-c++ \
               gecode-devel \
               git \
@@ -30,12 +31,6 @@ jobs:
               which \
               yaml-cpp-devel \
               yamllint
-      - run:
-          name: Install freeopcua from COPR
-          command: >
-            dnf install -y --nodocs 'dnf-command(copr)' &&
-            dnf -y copr enable thofmann/freeopcua &&
-            dnf install -y --nodocs freeopcua-devel
       - checkout
       - run: make quick-check
       - run: make all FAIL_ON_WARNING=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf install -y --nodocs \
       boost-devel \
       clips-devel \
       clipsmm-devel \
+      freeopcua-devel \
       gcc-c++ \
       gecode-devel \
       git \
@@ -29,9 +30,6 @@ RUN dnf install -y --nodocs \
       which \
       yaml-cpp-devel \
     && \
-    dnf install -y --nodocs 'dnf-command(copr)' && \
-    dnf -y copr enable thofmann/freeopcua && \
-    dnf install -y --nodocs freeopcua-devel && \
     dnf install -y --nodocs rpm-build && \
     dnf clean all
 COPY . /buildenv/
@@ -53,7 +51,5 @@ COPY --from=buildenv /buildenv/src/msgs/*.proto /usr/local/share/rcll-refbox/msg
 COPY --from=buildenv /buildenv/cfg/* /etc/rcll-refbox/
 COPY --from=buildenv /buildenv/requires.txt /
 RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && /sbin/ldconfig
-RUN dnf install -y --nodocs 'dnf-command(copr)' && \
-    dnf -y copr enable thofmann/freeopcua && \
-    dnf install -y --nodocs $(cat /requires.txt) && dnf clean all && rm /requires.txt
+RUN dnf install -y --nodocs $(cat /requires.txt) && dnf clean all && rm /requires.txt
 CMD ["llsf-refbox"]

--- a/src/libs/mps_comm/Makefile
+++ b/src/libs/mps_comm/Makefile
@@ -51,7 +51,7 @@ ifeq ($(OBJSSUBMAKE),1)
 all: $(WARN_TARGETS)
 .PHONY: $(WARN_TARGETS)
 warning_freeopcua:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)No OPC-UA support$(TNORMAL) (freeopcua not found)"
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)No OPC-UA support$(TNORMAL) ($(WARNING_FREEOPCUA))"
 warning_cpp17:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)No Mockup support$(TNORMAL) (C++17 not supported)"
 endif

--- a/src/libs/mps_comm/spdlog.mk
+++ b/src/libs/mps_comm/spdlog.mk
@@ -1,0 +1,23 @@
+#*****************************************************************************
+#                      Makefile Build System for Fawkes
+#                            -------------------
+#   Created on Mon 04 May 2020 10:30:53 CEST
+#   Copyright (C) 2020 by Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+ifneq ($(PKGCONFIG),)
+  HAVE_SPDLOG= $(if $(shell $(PKGCONFIG) --exists spdlog; echo $${?/1/}),1,0)
+endif
+
+ifeq ($(HAVE_SPDLOG),1)
+  CFLAGS_SPDLOG = $(shell $(PKGCONFIG) --cflags spdlog)
+  LDFLAGS_SPDLOG = $(shell $(PKGCONFIG) --libs spdlog)
+endif


### PR DESCRIPTION
Fedora now has an [official freeopcua package](https://bugzilla.redhat.com/show_bug.cgi?id=1824467). Use that package instead of the COPR.

Also adapt the build system so it properly checks for freeopcua and spdlog. This resolves a small complication with freeopcua: The package may be built either using a bundled spdlog or a system installation of spdlog. Furthermore, spdlog may in turn ship a bundled libfmt or use the system libfmt. If freeopcua uses the system spdlog, then we also need to check for the package being available and also use its build flags. Otherwise, we just use the build flags of freeopcua.