### PR TITLE
webview: adapt to MHD_Result enum

### DIFF
--- a/src/libs/webview/request.cpp
+++ b/src/libs/webview/request.cpp
@@ -30,10 +30,16 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#if MHD_VERSION >= 0x00097002
+#	define MHD_RESULT MHD_Result
+#else
+#	define MHD_RESULT int
+#endif
+
 namespace fawkes {
 
 /// @cond INTERNAL
-static int
+static MHD_RESULT
 cookie_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
 	WebRequest *request = static_cast<WebRequest *>(cls);
@@ -41,7 +47,7 @@ cookie_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char 
 	return MHD_YES;
 }
 
-static int
+static MHD_RESULT
 get_argument_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
 	WebRequest *request = static_cast<WebRequest *>(cls);
@@ -52,7 +58,7 @@ get_argument_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const
 	return MHD_YES;
 }
 
-static int
+static MHD_RESULT
 header_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
 	WebRequest *request = static_cast<WebRequest *>(cls);

--- a/src/libs/webview/request_dispatcher.h
+++ b/src/libs/webview/request_dispatcher.h
@@ -30,6 +30,11 @@
 #include <string>
 #include <vector>
 
+#if MHD_VERSION >= 0x00097002
+#	define MHD_RESULT MHD_Result
+#else
+#	define MHD_RESULT int
+#endif
 namespace fawkes {
 
 class WebRequestProcessor;
@@ -51,14 +56,14 @@ public:
 	                     WebPageFooterGenerator *footergen = 0);
 	~WebRequestDispatcher();
 
-	static int process_request_cb(void *                 callback_data,
-	                              struct MHD_Connection *connection,
-	                              const char *           url,
-	                              const char *           method,
-	                              const char *           version,
-	                              const char *           upload_data,
-	                              size_t *               upload_data_size,
-	                              void **                session_data);
+	static MHD_RESULT process_request_cb(void *                 callback_data,
+	                                     struct MHD_Connection *connection,
+	                                     const char *           url,
+	                                     const char *           method,
+	                                     const char *           version,
+	                                     const char *           upload_data,
+	                                     size_t *               upload_data_size,
+	                                     void **                session_data);
 
 	static void request_completed_cb(void *                          cls,
 	                                 struct MHD_Connection *         connection,
@@ -76,21 +81,21 @@ public:
 
 private:
 	struct MHD_Response *prepare_static_response(StaticWebReply *sreply);
-	int                  queue_static_reply(struct MHD_Connection *connection,
+	MHD_RESULT           queue_static_reply(struct MHD_Connection *connection,
 	                                        WebRequest *           request,
 	                                        StaticWebReply *       sreply);
-	int                  queue_dynamic_reply(struct MHD_Connection *connection,
+	MHD_RESULT           queue_dynamic_reply(struct MHD_Connection *connection,
 	                                         WebRequest *           request,
 	                                         DynamicWebReply *      sreply);
-	int   queue_basic_auth_fail(struct MHD_Connection *connection, WebRequest *request);
-	int   process_request(struct MHD_Connection *connection,
-	                      const char *           url,
-	                      const char *           method,
-	                      const char *           version,
-	                      const char *           upload_data,
-	                      size_t *               upload_data_size,
-	                      void **                session_data);
-	void *log_uri(const char *uri);
+	MHD_RESULT queue_basic_auth_fail(struct MHD_Connection *connection, WebRequest *request);
+	MHD_RESULT process_request(struct MHD_Connection *connection,
+	                           const char *           url,
+	                           const char *           method,
+	                           const char *           version,
+	                           const char *           upload_data,
+	                           size_t *               upload_data_size,
+	                           void **                session_data);
+	void *     log_uri(const char *uri);
 
 	void request_completed(WebRequest *request, MHD_RequestTerminationCode term_code);
 


### PR DESCRIPTION
The microhttpd lib introduced an enum `MHD_Result` instead of passing results via integers.

Note that they were a bit inconsistent as
`MHD_queue_basic_auth_fail_response` still returns int, which is caught
via static cast to the enum.
Edit: this also mentioned in #82.

This fixes #82.