### PR TITLE
Fixes for boost 1.73

### DIFF
--- a/src/libs/protobuf_clips/communicator.cpp
+++ b/src/libs/protobuf_clips/communicator.cpp
@@ -43,6 +43,7 @@
 
 using namespace google::protobuf;
 using namespace protobuf_comm;
+using namespace boost::placeholders;
 
 namespace protobuf_clips {
 #if 0 /* just to make Emacs auto-indent happy */

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -60,7 +60,7 @@
 #	include <logging/websocket.h>
 #endif
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 #include <cstdlib>
 
@@ -105,6 +105,7 @@ using namespace protobuf_clips;
 using namespace llsf_utils;
 using namespace fawkes;
 using namespace llsfrb::mps_comm;
+using namespace boost::placeholders;
 
 #ifdef HAVE_MONGODB
 using bsoncxx::builder::basic::document;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -57,7 +57,7 @@
 #include <msgs/VersionInfo.pb.h>
 #include <protobuf_comm/client.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cstring>
 #include <cursesf.h>
@@ -75,6 +75,7 @@
 #define MIN_NUM_ROBOTS 6
 
 using namespace protobuf_comm;
+using namespace boost::placeholders;
 
 namespace llsfrb_shell {
 #if 0 /* just to make Emacs auto-indent happy */


### PR DESCRIPTION
It's the `boost::bind` issue, i.e. the `_1`, `_2` etc. placeholders shouldn't be declared in the global namespace any more. The `boost/bind.hpp` header still does it, but warns about it. So switch to including `boost/bind/bind.hpp` and do `using namespace boost::placeholders`.