### PR TITLE
Adapt to boost 1.73 and gecode 6 (Fedora 33)

### DIFF
--- a/src/libs/logging/llsf_log_msgs/LogMessage.proto
+++ b/src/libs/logging/llsf_log_msgs/LogMessage.proto
@@ -34,6 +34,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+syntax = "proto2";
+
 package llsf_log_msgs;
 
 message LogMessage {

--- a/src/libs/mps_placing_clips/mps_placing.h
+++ b/src/libs/mps_placing_clips/mps_placing.h
@@ -680,11 +680,26 @@ public:
 	}
 
 #if GECODE_VERSION_NUMBER >= 600200
-	virtual Gecode::IntMinimizeSpace *
+	virtual MPSPlacing *
 	copy()
 	{
 		return new MPSPlacing(*this);
 	}
+	explicit MPSPlacing(MPSPlacing &s) : Gecode::IntMinimizeSpace(s)
+	{
+		height_ = s.height_;
+		width_  = s.width_;
+		mps_type_.update(*this, s.mps_type_);
+		mps_angle_.update(*this, s.mps_angle_);
+		mps_count_.update(*this, s.mps_count_);
+		mps_resource_.resize(width_ + 2);
+		for (int x = 0; x < width_ + 2; x++) {
+			mps_resource_[x].resize(height_ + 2);
+			for (int y = 0; y < height_ + 2; y++) {
+				mps_resource_[x][y].update(*this, s.mps_resource_[x][y]);
+			}
+		}
+	};
 #else
 	MPSPlacing(bool share, MPSPlacing &s) : Gecode::IntMinimizeSpace(share, s)
 	{
@@ -702,7 +717,7 @@ public:
 		}
 	}
 
-	Gecode::IntMinimizeSpace *
+	MPSPlacing *
 	copy(bool share)
 	{
 		return new MPSPlacing(share, *this);

--- a/src/libs/mps_placing_clips/mps_placing.h
+++ b/src/libs/mps_placing_clips/mps_placing.h
@@ -679,6 +679,13 @@ public:
 		solution = NULL;
 	}
 
+#if GECODE_VERSION_NUMBER >= 600200
+	virtual Gecode::IntMinimizeSpace *
+	copy()
+	{
+		return new MPSPlacing(*this);
+	}
+#else
 	MPSPlacing(bool share, MPSPlacing &s) : Gecode::IntMinimizeSpace(share, s)
 	{
 		height_ = s.height_;
@@ -700,6 +707,7 @@ public:
 	{
 		return new MPSPlacing(share, *this);
 	}
+#endif
 
 	Gecode::IntVar
 	cost(void) const

--- a/src/libs/protobuf_clips/communicator.cpp
+++ b/src/libs/protobuf_clips/communicator.cpp
@@ -41,8 +41,11 @@
 #include <protobuf_comm/peer.h>
 #include <protobuf_comm/server.h>
 
+#include <boost/bind/bind.hpp>
+
 using namespace google::protobuf;
 using namespace protobuf_comm;
+using namespace boost::placeholders;
 
 namespace protobuf_clips {
 #if 0 /* just to make Emacs auto-indent happy */

--- a/src/libs/rest-api/Makefile
+++ b/src/libs/rest-api/Makefile
@@ -44,8 +44,8 @@ LIBS_all = $(LIBDIR)/libllsfrbrestapi.so
 ifeq ($(HAVE_BOOST_LIBS)$(HAVE_LIBMICROHTTPD),11)
   LIBS_build = $(LIBS_all)
 
-  CFLAGS  += $(call boost-libs-cflags,$(REQ_BOOST_LIBS))
-  LDFLAGS += $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
+  CFLAGS  += $(call boost-libs-cflags,$(REQ_BOOST_LIBS)) $(CFLAGS_LIBMICROHTTPD)
+  LDFLAGS += $(call boost-libs-ldflags,$(REQ_BOOST_LIBS)) $(LDFLAGS_LIBMICROHTTPD)
 
   ifeq ($(HAVE_APR_UTIL),1)
     CFLAGS  += $(CFLAGS_APR_UTIL)

--- a/src/libs/webview/Makefile
+++ b/src/libs/webview/Makefile
@@ -20,13 +20,12 @@ LDFLAGS += $(LDFLAGS_LIBMICROHTTPD)
 CFLAGS  += $(CFLAGS_LIBMICROHTTPD)
 LIBS_libllsfrbwebview = stdc++ llsfrbcore llsfrbutils llsfrblogging
 OBJS_libllsfrbwebview = $(patsubst %.cpp,%.o,$(patsubst qa/%,,$(subst $(SRCDIR)/,,$(realpath $(wildcard $(SRCDIR)/*.cpp $(SRCDIR)/*/*.cpp)))))
-HDRS_libfawkeswebview = $(subst $(SRCDIR)/,,$(wildcard $(SRCDIR)/*.h $(SRCDIR)/*/*.h))
+HDRS_libllsfrbwebview = $(subst $(SRCDIR)/,,$(wildcard $(SRCDIR)/*.h $(SRCDIR)/*/*.h))
 
-OBJS_all = $(OBJS_libllsfrbswebview)
-LIBS_all = $(LIBDIR)/libllsfrbwebview.so
 
 ifeq ($(HAVE_LIBMICROHTTPD),1)
-  LIBS_build = $(LIBS_all)
+  OBJS_all = $(OBJS_libllsfrbwebview)
+  LIBS_all = $(LIBDIR)/libllsfrbwebview.so
 else
   WARN_TARGETS += warning_libmicrohttpd
 endif

--- a/src/libs/webview/webview.mk
+++ b/src/libs/webview/webview.mk
@@ -31,8 +31,16 @@ else
   endif
 endif
 
+ifeq ($(HAVE_LIBMICROHTTPD),1)
+  # boost's property_tree uses deprecated global placeholders
+  CFLAGS_LIBMICROHTTPD += -DBOOST_BIND_GLOBAL_PLACEHOLDERS
+endif
+
 # RapidJSON is optional, but may be convenient
 ifeq ($(HAVE_RAPIDJSON),1)
   CFLAGS_RAPIDJSON  = -DHAVE_RAPIDJSON $(shell $(PKGCONFIG) --cflags 'RapidJSON')
   LDFLAGS_RAPIDJSON = $(shell $(PKGCONFIG) --libs 'RapidJSON')
 endif
+
+CFLAGS_WEBVIEW = $(CFLAGS_LIBMICROHTTPD) $(CFLAGS_RAPIDJSON)
+LDFLAGS_WEBVIEW = $(LDFLAGS_LIBMICROHTTPD) $(LDFLAGS_RAPIDJSON)

--- a/src/refbox/Makefile
+++ b/src/refbox/Makefile
@@ -22,6 +22,7 @@ include $(BUILDSYSDIR)/boost.mk
 include $(BUILDCONFDIR)/mongodb_log/mongodb.mk
 include $(BUILDCONFDIR)/netcomm/netcomm.mk
 include $(BUILDCONFDIR)/websocket/websocket.mk
+include $(BUILDCONFDIR)/webview/webview.mk
 
 CFLAGS += -Wno-deprecated-declarations
 
@@ -37,14 +38,14 @@ LIBS_llsf_refbox = stdc++ stdc++fs llsfrbcore llsfrbconfig llsfrblogging llsfrbn
 
 OBJS_llsf_refbox = main.o refbox.o clips_logger.o
 
-ifeq ($(HAVE_CPP17)$(HAVE_PROTOBUF)$(HAVE_CLIPS)$(HAVE_BOOST_LIBS),1111)
+ifeq ($(HAVE_CPP17)$(HAVE_PROTOBUF)$(HAVE_CLIPS)$(HAVE_BOOST_LIBS)$(HAVE_WEBVIEW),11111)
   OBJS_all =	$(OBJS_llsf_refbox)
   BINS_all =	$(BINDIR)/llsf-refbox
 
   CFLAGS  += $(CFLAGS_PROTOBUF) $(CFLAGS_CLIPS) $(CFLAGS_CPP17) \
-	     $(call boost-libs-cflags,$(REQ_BOOST_LIBS))
+	     $(call boost-libs-cflags,$(REQ_BOOST_LIBS)) $(CFLAGS_WEBVIEW)
   LDFLAGS += $(LDFLAGS_PROTOBUF) $(LDFLAGS_CLIPS) \
-	     $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
+	     $(call boost-libs-ldflags,$(REQ_BOOST_LIBS)) $(LDFLAGS_WEBVIEW)
   #MANPAGES_all =  $(MANDIR)/man1/llsf-refbox.1
 
   ifeq ($(HAVE_AVAHI),1)
@@ -84,6 +85,9 @@ else
   ifneq ($(HAVE_WEBSOCKET),1)
     WARN_TARGETS_WEBSOCKET = $(foreach l,$(BOOST_LIBS_WEBSOCKET),$(if $(call boost-have-lib,$l),, warning_boost_$l))
   endif
+  ifneq ($(HAVE_WEBVIEW),1)
+  WARN_TARGETS += warning_webview
+  endif
 endif
 
 
@@ -98,6 +102,8 @@ warning_clips:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build RCLL RefBox$(TNORMAL) (clipsmm not found)"
 warning_mongodb:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting MongoDB logging support$(TNORMAL) (MongoDB not found)"
+warning_webview:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build RCLL RefBox$(TNORMAL) (no webview support)"
 $(WARN_TARGETS_BOOST): warning_boost_%:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build protobuf_comm library$(TNORMAL) (Boost library $* not found)"
 $(WARN_TARGETS_WEBSOCKET):

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -60,7 +60,7 @@
 #	include <logging/websocket.h>
 #endif
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 #include <cstdlib>
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -57,7 +57,7 @@
 #include <msgs/VersionInfo.pb.h>
 #include <protobuf_comm/client.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cstring>
 #include <cursesf.h>
@@ -75,6 +75,7 @@
 #define MIN_NUM_ROBOTS 6
 
 using namespace protobuf_comm;
+using namespace boost::placeholders;
 
 namespace llsfrb_shell {
 #if 0 /* just to make Emacs auto-indent happy */


### PR DESCRIPTION
gecode 6 changed its API. Adapt accordingly, but keep backwards compatibility.

boost 1.73 deprecates global placeholders. Adapt by
* avoiding the use of global placeholders (use `boost/bind/bind.hpp` instead of `boost/bind.hpp`)
* using the placeholders namespace where necessary
* disabling the deprecation warning where we include external headers which trigger the warning