### PR TITLE
fix inconsistent protobuf client ids

### DIFF
--- a/src/libs/protobuf_clips/communicator.cpp
+++ b/src/libs/protobuf_clips/communicator.cpp
@@ -64,7 +64,7 @@ namespace protobuf_clips {
  */
 ClipsProtobufCommunicator::ClipsProtobufCommunicator(CLIPS::Environment *env,
                                                      fawkes::Mutex &     env_mutex)
-: clips_(env), clips_mutex_(env_mutex), server_(NULL)
+: clips_(env), clips_mutex_(env_mutex), server_(NULL), next_client_id_(0)
 {
 	message_register_ = new MessageRegister();
 	setup_clips();
@@ -78,7 +78,7 @@ ClipsProtobufCommunicator::ClipsProtobufCommunicator(CLIPS::Environment *env,
 ClipsProtobufCommunicator::ClipsProtobufCommunicator(CLIPS::Environment *      env,
                                                      fawkes::Mutex &           env_mutex,
                                                      std::vector<std::string> &proto_path)
-: clips_(env), clips_mutex_(env_mutex), server_(NULL)
+: clips_(env), clips_mutex_(env_mutex), server_(NULL), next_client_id_(0)
 {
 	message_register_ = new MessageRegister(proto_path);
 	setup_clips();

--- a/src/libs/protobuf_clips/communicator.cpp
+++ b/src/libs/protobuf_clips/communicator.cpp
@@ -865,7 +865,7 @@ ClipsProtobufCommunicator::clips_assert_message(std::pair<std::string, unsigned 
                                                 uint16_t                                msg_type,
                                                 std::shared_ptr<google::protobuf::Message> &msg,
                                                 ClipsProtobufCommunicator::ClientType       ct,
-                                                unsigned int client_id)
+                                                long int client_id)
 {
 	CLIPS::Template::pointer temp = clips_->get_template("protobuf-msg");
 	if (temp) {

--- a/src/libs/protobuf_clips/communicator.h
+++ b/src/libs/protobuf_clips/communicator.h
@@ -163,7 +163,7 @@ private:
 	                          uint16_t                                    msg_type,
 	                          std::shared_ptr<google::protobuf::Message> &msg,
 	                          ClientType                                  ct,
-	                          unsigned int                                client_id = 0);
+	                          long int                                    client_id = 0);
 	void handle_server_client_connected(protobuf_comm::ProtobufStreamServer::ClientID client,
 	                                    boost::asio::ip::tcp::endpoint &              endpoint);
 	void handle_server_client_disconnected(protobuf_comm::ProtobufStreamServer::ClientID client,


### PR DESCRIPTION
A combination of an uninitialized `long int` client id and its conversion to an `unsigned int` before asserting the corresponding protobuf clips fact can potentially lead to broken client ids in clips. Avoid this by sticking to `long int` and initializing the client id increment value.