### PR TITLE
Fix Fedora 33 compiler warnings

### DIFF
--- a/src/libs/mps_comm/opcua/machine.cpp
+++ b/src/libs/mps_comm/opcua/machine.cpp
@@ -190,27 +190,17 @@ OpcUaMachine::set_light(llsf_msgs::LightColor color,
                         llsf_msgs::LightState state,
                         unsigned short        time)
 {
-	LightColor m_color;
+	LightColor m_color = LIGHT_COLOR_RESET;
 	switch (color) {
 	case llsf_msgs::LightColor::RED: m_color = LightColor::LIGHT_COLOR_RED; break;
 	case llsf_msgs::LightColor::YELLOW: m_color = LightColor::LIGHT_COLOR_YELLOW; break;
 	case llsf_msgs::LightColor::GREEN: m_color = LightColor::LIGHT_COLOR_GREEN; break;
 	}
-	switch (m_color) {
-	case LightColor::LIGHT_COLOR_RESET:
-	case LightColor::LIGHT_COLOR_RED:
-	case LightColor::LIGHT_COLOR_YELLOW:
-	case LightColor::LIGHT_COLOR_GREEN: break;
-	default: throw std::invalid_argument("Illegal color! See MPSIoMapping.h for choices.");
-	}
-	unsigned short int plc_state;
+	unsigned short int plc_state = LightState::LIGHT_STATE_OFF;
 	switch (state) {
 	case llsf_msgs::ON: plc_state = LightState::LIGHT_STATE_ON; break;
 	case llsf_msgs::OFF: plc_state = LightState::LIGHT_STATE_OFF; break;
 	case llsf_msgs::BLINK: plc_state = LightState::LIGHT_STATE_BLINK; break;
-	default:
-		plc_state = LightState::LIGHT_STATE_OFF;
-		// TODO error
 	}
 	enqueue_instruction(m_color, plc_state, time);
 }

--- a/src/libs/utils/time/time.cpp
+++ b/src/libs/utils/time/time.cpp
@@ -180,7 +180,7 @@ Time::Time(const Time &t)
 	clock_        = t.clock_;
 	if (t.timestr_) {
 		timestr_ = (char *)malloc(TIMESTR_SIZE);
-		strncpy(timestr_, t.timestr_, TIMESTR_SIZE);
+		strncpy(timestr_, t.timestr_, TIMESTR_SIZE - 1);
 	} else {
 		timestr_ = NULL;
 	}
@@ -196,7 +196,7 @@ Time::Time(const Time *t)
 	clock_        = t->clock_;
 	if (t->timestr_) {
 		timestr_ = (char *)malloc(TIMESTR_SIZE);
-		strncpy(timestr_, t->timestr_, TIMESTR_SIZE);
+		strncpy(timestr_, t->timestr_, TIMESTR_SIZE - 1);
 	} else {
 		timestr_ = NULL;
 	}

--- a/src/shell/Makefile
+++ b/src/shell/Makefile
@@ -44,7 +44,8 @@ ifeq ($(HAVE_PROTOBUF)$(HAVE_BOOST_LIBS)$(HAVE_NCURSES),111)
   BINS_all =	$(BINDIR)/llsf-refbox-shell
 
   CFLAGS  += $(CFLAGS_PROTOBUF) $(CFLAGS_NCURSES) \
-	     $(call boost-libs-cflags,$(REQ_BOOST_LIBS))
+	     $(call boost-libs-cflags,$(REQ_BOOST_LIBS)) \
+	     -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
   LDFLAGS += $(LDFLAGS_PROTOBUF) $(LDFLAGS_NCURSES) \
 	     $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
   #MANPAGES_all =  $(MANDIR)/man1/refbox-llsf.1

--- a/src/shell/robot.cpp
+++ b/src/shell/robot.cpp
@@ -34,8 +34,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
-
 #include "robot.h"
 
 #include "colors.h"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -34,8 +34,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
-
 #include "shell.h"
 
 #include "colors.h"


### PR DESCRIPTION
When compiled with distro build flags (`make  CFLAGS_EXTRA="$(rpm --eval '%{optflags}')"`), the compiler would give some additional warnings and errors. Fix those warnings as they may all be real issues.