### PR TITLE
Restore phase points from gamereport

### DIFF
--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -572,33 +572,15 @@
 	(bind ?t-doc (mongodb-cursor-next ?t-cursor))
 	(if (neq ?t-doc FALSE) then
 	 then
-		(if (bind ?phasepoints (bson-get ?t-doc "phase-points-cyan")) then
-			(if (bind ?points (bson-get ?phasepoints "PRODUCTION")) then
-				(assert (points (points ?points) (team CYAN) (game-time 0.0) (phase PRODUCTION) (reason "Restored")))
+		(if (bind ?points-arr (bson-get-array ?t-doc "points"))
+		 then
+			(foreach ?point ?points-arr
+				(assert (points (points (bson-get ?point "points")) (team (bson-get ?point "team")) (game-time (bson-get ?point "game-time")) (phase (bson-get ?point "phase")) (reason (bson-get ?point "reason"))))
+				(bson-destroy ?point)
 			)
-			(if (bind ?points (bson-get ?phasepoints "EXPLORATION")) then
-				(assert (points (points ?points) (team CYAN) (game-time 0.0) (phase EXPLORATION) (reason "Restored")))
-			)
-			(if (bind ?points (bson-get ?phasepoints "WHACK_A_MOLE_CHALLENGE")) then
-				(assert (points (points ?points) (team CYAN) (game-time 0.0) (phase WHACK_A_MOLE_CHALLENGE) (reason "Restored")))
-			)
-		else
-			(printout error "Couldn't read phase points for cyan" crlf)
+		 else
+			(printout error "Couldn't read points array" crlf)
 		)
-		(if (bind ?phasepoints (bson-get ?t-doc "phase-points-magenta")) then
-			(if (bind ?points (bson-get ?phasepoints "PRODUCTION")) then
-				(assert (points (points ?points) (team MAGENTA) (game-time 0.0) (phase PRODUCTION) (reason "Restored")))
-			)
-			(if (bind ?points (bson-get ?phasepoints "EXPLORATION")) then
-				(assert (points (points ?points) (team MAGENTA) (game-time 0.0) (phase EXPLORATION) (reason "Restored")))
-			)
-			(if (bind ?points (bson-get ?phasepoints "WHACK_A_MOLE_CHALLENGE")) then
-				(assert (points (points ?points) (team MAGENTA) (game-time 0.0) (phase WHACK_A_MOLE_CHALLENGE) (reason "Restored")))
-			)
-		else
-			(printout error "Couldn't read phase points for magenta" crlf)
-		)
-
 	 else
 		(printout error "Empty result in mongoDB from game_report" crlf)
 	)

--- a/src/libs/protobuf_clips/communicator.h
+++ b/src/libs/protobuf_clips/communicator.h
@@ -217,7 +217,7 @@ private:
 	  sig_peer_sent_;
 
 	fawkes::Mutex map_mutex_;
-	long int      next_client_id_;
+	long int      next_client_id_ = 0;
 
 	std::map<long int, protobuf_comm::ProtobufStreamServer::ClientID>         server_clients_;
 	typedef std::map<protobuf_comm::ProtobufStreamServer::ClientID, long int> RevServerClientMap;


### PR DESCRIPTION
Restoring the total points directly does not work, because they get overwritten periodically and are not persistent. This PR creates a new points fact (just like when scoring in the game) with reason "restored" when the game is loaded from a gamereport. The points are taken from the phasepoints in the gamereport. 