### PR TITLE
rework storage and retrieval of mongodb game reports

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -170,6 +170,9 @@ llsfrb:
     random-machine-setup: true
     random-orders: true
     random-storage: true
+    restore-gamestate:
+      enable: false
+      phase: PRODUCTION
     # load data from latest game report with a given name
     # leave empty to always load from latest stored report
     load-from-report: ""

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -167,6 +167,9 @@ llsfrb:
     # If enabled, some machines will randomly go DOWN for some period during
     # the game. If disabled, no machine will go DOWN.
     random-machine-down-times: true
+    random-machine-setup: true
+    random-orders: true
+    random-storage: true
     # load data from latest game report with a given name
     # leave empty to always load from latest stored report
     load-from-report: ""

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -161,10 +161,17 @@ llsfrb:
     crypto-keys:
       Carologistics: randomkey
     # set to true to generate a random field at startup
+    # disabling randomization requires mongodb to be enabled as the game
+    # parameters are loaded from a mongodb game report in this case
     random-field: true
     # If enabled, some machines will randomly go DOWN for some period during
     # the game. If disabled, no machine will go DOWN.
     random-machine-down-times: true
+    # load data from latest game report with a given name
+    # leave empty to always load from latest stored report
+    load-from-report: ""
+    # store game report under a name for later reference
+    store-to-report: ""
 
   shell:
     refbox-host: localhost

--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -369,6 +369,7 @@
 	(slot machine-positions (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
 	(slot machine-setup (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
 	(slot orders (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
+	(slot gamestate (type SYMBOL) (allowed-values PENDING RECOVERED FRESH) (default PENDING))
 	(slot storage-status (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
 )
 

--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -363,6 +363,15 @@
   (slot real-time-factor (type FLOAT) (default 0.0))
 )
 
+(deftemplate game-parameters
+	(slot is-parameterized (type SYMBOL) (allowed-values TRUE FALSE) (default FALSE))
+	(slot is-initialized (type SYMBOL) (allowed-values TRUE FALSE) (default FALSE))
+	(slot machine-positions (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
+	(slot machine-setup (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
+	(slot orders (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
+	(slot storage-status (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
+)
+
 ; Machine directions in LLSF arena frame when looking from bird's eye perspective
 (defglobal
   ?*M-EAST*   = (* (/ 3.0 2.0) (pi))   ; 270 deg or -90 deg
@@ -374,6 +383,7 @@
 (deffacts startup
   (gamestate (phase PRE_GAME))
   (machine-generation (state NOT-STARTED))
+  (game-parameters)
   (signal (type beacon) (time (create$ 0 0)) (seq 1))
   (signal (type gamestate) (time (create$ 0 0)) (seq 1))
   (signal (type robot-info) (time (create$ 0 0)) (seq 1))

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -345,6 +345,13 @@
   (assert (attention-message (text "Starting setup phase") (time 15)))
 )
 
+(defrule game-set-start-time-if-unset
+  ?gs <- (gamestate (teams ?team_cyan ?team_magenta) (phase ~PRE_GAME) (start-time 0 0))
+  =>
+  (modify ?gs (start-time (now)))
+  (assert (attention-message (text "Start time unset, despite not in PRE_GAME. Setting it now!") (time 15)))
+)
+
 (defrule game-setup-warn-end-near
   (gamestate (phase SETUP) (state RUNNING)
 	     (game-time ?game-time&:(>= ?game-time (* ?*SETUP-TIME* .9))))

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -7,8 +7,101 @@
 ;             2017       Tobias Neumann
 ;             2019       Till Hofmann
 ;             2019       Mostafa Gomaa
+;             2020       Tarik Viehmann
 ;  Licensed under BSD license, cf. LICENSE file
 ;---------------------------------------------------------------------------
+
+(deffunction game-randomize-orders ()
+	(bind ?ring-colors (create$))
+	(do-for-all-facts ((?rs ring-spec)) TRUE
+	  (bind ?ring-colors (append$ ?ring-colors ?rs:color))
+	)
+	(bind ?ring-colors (randomize$ ?ring-colors))
+	(bind ?c1-first-ring (subseq$ ?ring-colors 1 1))
+	(bind ?c2-first-ring (subseq$ ?ring-colors 2 2))
+	(bind ?c3-first-ring (subseq$ ?ring-colors 3 3))
+	(bind ?cx-first-ring (subseq$ ?ring-colors 4 4))
+
+	(bind ?c1-counter 0)
+	(bind ?c2-counter 0)
+	(bind ?c3-counter 0)
+	; reset orders, assign random times
+	(delayed-do-for-all-facts ((?order order)) TRUE
+		(bind ?deliver-start (random (nth$ 1 ?order:start-range)
+		                             (nth$ 2 ?order:start-range)))
+		(bind ?deliver-end
+		  (+ ?deliver-start (random (nth$ 1 ?order:duration-range)
+		                            (nth$ 2 ?order:duration-range))))
+		(if (and (> ?deliver-end ?*PRODUCTION-TIME*) (not ?order:allow-overtime))
+		 then
+			(printout t "Revising deliver time (" ?deliver-start "-" ?deliver-end ") to ("
+			            (- ?deliver-start (- ?deliver-end ?*PRODUCTION-TIME*)) "-" ?*PRODUCTION-TIME* "), "
+			            "time shift: " (- ?deliver-end ?*PRODUCTION-TIME*) crlf)
+			(bind ?deliver-start (- ?deliver-start (- ?deliver-end ?*PRODUCTION-TIME*)))
+			(bind ?deliver-end ?*PRODUCTION-TIME*)
+		)
+		(bind ?activation-pre-time
+		      (random (nth$ 1 ?order:activation-range) (nth$ 2 ?order:activation-range)))
+		(bind ?activate-at (max (- ?deliver-start ?activation-pre-time) 0))
+		(if ?*RANDOMIZE-ACTIVATE-ALL-AT-START* then (bind ?activate-at 0))
+		(bind ?gate (random 1 3))
+
+		; check workpiece-assign-order rule in workpieces.clp for specific
+		; assumptions for the 2016 game and order to workpiece assignment!
+		(bind ?order-ring-colors (create$))
+		(switch ?order:complexity
+			;(case C0 then) ; for C0 we have nothing to do, no ring color
+			(case C1 then (bind ?c1-counter (+ ?c1-counter 1))
+			              (if (<= ?c1-counter 1) then (bind ?first-ring ?c1-first-ring)
+			                                     else (bind ?first-ring ?cx-first-ring))
+			              (bind ?order-ring-colors (create$ ?first-ring)))
+			(case C2 then (bind ?c2-counter (+ ?c2-counter 1))
+			              (if (<= ?c2-counter 1) then (bind ?first-ring ?c2-first-ring)
+			                                     else (bind ?first-ring ?cx-first-ring))
+			              (bind ?order-ring-colors (create$ ?first-ring (subseq$ (randomize$ (remove$ ?ring-colors ?first-ring)) 1 1))))
+			(case C3 then (bind ?c3-counter (+ ?c3-counter 1))
+			              (if (<= ?c3-counter 1) then (bind ?first-ring ?c3-first-ring)
+			                                     else (bind ?first-ring ?cx-first-ring))
+			              (bind ?order-ring-colors (create$ ?first-ring (subseq$ (randomize$ (remove$ ?ring-colors ?first-ring)) 1 2))))
+		)
+
+		(bind ?order-base-color (pick-random$ (deftemplate-slot-allowed-values order base-color)))
+		(bind ?order-cap-color (pick-random$ (deftemplate-slot-allowed-values order cap-color)))
+
+		(modify ?order (active FALSE) (activate-at ?activate-at) (delivery-gate ?gate)
+		  (delivery-period ?deliver-start ?deliver-end) (base-color ?order-base-color)
+		  (ring-colors ?order-ring-colors) (cap-color ?order-cap-color))
+		)
+
+	; Randomize number of required additional bases
+	(bind ?m-add-bases (randomize$ (create$ 1 3)))
+	(do-for-fact ((?ring ring-spec)) (eq ?ring:color (nth$ (nth$ 1 ?m-add-bases) ?ring-colors))
+	  (modify ?ring (req-bases 2))
+	)
+	(do-for-fact ((?ring ring-spec)) (eq ?ring:color (nth$ (nth$ 2 ?m-add-bases) ?ring-colors))
+	  (modify ?ring (req-bases 1))
+	)
+	(delayed-do-for-all-facts ((?ring ring-spec))
+	  (or (eq ?ring:color (nth$ 2 ?ring-colors)) (eq ?ring:color (nth$ 4 ?ring-colors)))
+	  (modify ?ring (req-bases 0))
+	)
+
+	; Randomly assign an order to be a competitive order
+	(bind ?potential-competitive-orders (create$))
+	(do-for-all-facts ((?order order))
+	                  (and (eq ?order:complexity C0) ; must be C0
+	                       (eq ?order:quantity-requested 1) ; must not request more than 1 product
+	                       (eq ?order:allow-overtime FALSE) ; no overtime order
+	                       (or (neq (nth$ 1 ?order:delivery-period) 0) ; no standing order
+	                           (neq (nth$ 2 ?order:delivery-period) ?*PRODUCTION-TIME*))
+	                  )
+	                  (bind ?potential-competitive-orders (insert$ ?potential-competitive-orders 1 ?order:id))
+	)
+	;(printout t "Potential competitive orders: " ?potential-competitive-orders crlf)
+	(bind ?competitive-order-id (nth$ (random 1 (length$ ?potential-competitive-orders)) ?potential-competitive-orders))
+	(do-for-fact ((?order order)) (eq ?order:id ?competitive-order-id)
+	  (modify ?order (competitive TRUE)))
+)
 
 (deffunction game-calc-phase-points (?team-color ?phase)
   (bind ?phase-points 0)
@@ -55,11 +148,39 @@
 	)
 )
 
+(defrule game-init-parameterization-from-config
+	?gt <- (game-parameters (is-initialized FALSE))
+	(confval (path "/llsfrb/game/random-field") (type BOOL) (value ?random-field))
+	(confval (path "/llsfrb/game/random-machine-setup") (type BOOL) (value ?random-machine-setup))
+	(confval (path "/llsfrb/game/random-orders") (type BOOL) (value ?random-orders))
+	(confval (path "/llsfrb/game/random-storage") (type BOOL) (value ?random-storage))
+	(confval (path "/llsfrb/mongodb/enable") (type BOOL) (value ?cfg-mongodb-enabled))
+	=>
+	(bind ?m-positions PENDING)
+	(bind ?m-setup PENDING)
+	(bind ?orders PENDING)
+	(bind ?s-status PENDING)
+	(bind ?mongodb-enabled (eq ?cfg-mongodb-enabled true))
+	(if (and (not ?mongodb-enabled) (member$ false (create$ ?random-field ?random-machine-setup ?random-orders ?random-storage )))
+	 then
+		(printout warn "Mongodb disabled, randomize all parameters despite configured static settings." crlf)
+	)
+	(if (or (not ?mongodb-enabled) (eq ?random-field  true)) then (bind ?m-positions RANDOM))
+	(if (or (not ?mongodb-enabled) (eq ?random-machine-setup true)) then (bind ?m-setup RANDOM))
+	(if (or (not ?mongodb-enabled) (eq ?random-orders true)) then (bind ?orders RANDOM))
+	(if (or (not ?mongodb-enabled) (eq ?random-storage true)) then (bind ?s-status RANDOM))
+	(modify ?gt (machine-positions ?m-positions)
+	            (machine-setup ?m-setup)
+	            (orders ?orders)
+	            (storage-status ?s-status)
+	            (is-initialized TRUE))
+)
+
 (defrule game-mps-solver-start
   "start the solver"
   (gamestate (game-time ?gt))
-  (not (game-parameterized))
   ?mg <- (machine-generation (state NOT-STARTED))
+  (game-parameters (is-parameterized FALSE) (machine-positions RANDOM))
   =>
   (printout t "starting the solver for the generation of the machine positions" crlf)
   (mps-generator-start)
@@ -82,113 +203,39 @@
 )
 
 (defrule game-parameterize
-  (gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
-  (not (game-parameterized))
-  (or (machine-generation (state FINISHED))
-      (and (not (test (any-factp ((?m machine)) (eq ?m:zone TBD))))
-           (confval (path "/llsfrb/game/random-field") (type BOOL) (value false))
-      )
-  )
-  =>
-  (assert (game-parameterized))
+	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
+	?gp <- (game-parameters (machine-positions ?m-positions&~PENDING)
+	                        (machine-setup ?m-setup&~PENDING)
+	                        (orders ?orders&~PENDING)
+	                        (storage-status ?s-status&~PENDING)
+	                        (is-parameterized FALSE))
+	(machine-generation (state ?s&:(or (eq ?s FINISHED) (eq ?m-positions STATIC))))
+	=>
+	(modify ?gp (is-parameterized TRUE))
 
-  (bind ?ring-colors (create$))
-  (do-for-all-facts ((?rs ring-spec)) TRUE
-    (bind ?ring-colors (append$ ?ring-colors ?rs:color))
-  )
-  (bind ?ring-colors (randomize$ ?ring-colors))
-	(bind ?c1-first-ring (subseq$ ?ring-colors 1 1))
-	(bind ?c2-first-ring (subseq$ ?ring-colors 2 2))
-	(bind ?c3-first-ring (subseq$ ?ring-colors 3 3))
-	(bind ?cx-first-ring (subseq$ ?ring-colors 4 4))
-
-	(bind ?c1-counter 0)
-	(bind ?c2-counter 0)
-	(bind ?c3-counter 0)
-  ; machine assignment if not already done
-  (if (not (any-factp ((?mi machines-initialized)) TRUE))
-			then (machine-init-randomize))
-
-  ; reset orders, assign random times
-  (delayed-do-for-all-facts ((?order order)) TRUE
-    (bind ?deliver-start
-      (random (nth$ 1 ?order:start-range)
-              (nth$ 2 ?order:start-range)))
-    (bind ?deliver-end
-      (+ ?deliver-start (random (nth$ 1 ?order:duration-range)
-																(nth$ 2 ?order:duration-range))))
-		(if (and (> ?deliver-end ?*PRODUCTION-TIME*) (not ?order:allow-overtime))
-		 then
-		  (printout t "Revising deliver time (" ?deliver-start "-" ?deliver-end ") to ("
-								(- ?deliver-start (- ?deliver-end ?*PRODUCTION-TIME*)) "-" ?*PRODUCTION-TIME* "), "
-								"time shift: " (- ?deliver-end ?*PRODUCTION-TIME*) crlf)
-			(bind ?deliver-start (- ?deliver-start (- ?deliver-end ?*PRODUCTION-TIME*)))
-			(bind ?deliver-end ?*PRODUCTION-TIME*)
-		)
-    (bind ?activation-pre-time
-          (random (nth$ 1 ?order:activation-range) (nth$ 2 ?order:activation-range)))
-    (bind ?activate-at (max (- ?deliver-start ?activation-pre-time) 0))
-		(if ?*RANDOMIZE-ACTIVATE-ALL-AT-START* then (bind ?activate-at 0))
-    (bind ?gate (random 1 3))
-
-		; check workpiece-assign-order rule in workpieces.clp for specific
-		; assumptions for the 2016 game and order to workpiece assignment!
-		(bind ?order-ring-colors (create$))
-		(switch ?order:complexity
-			;(case C0 then) ; for C0 we have nothing to do, no ring color
-			(case C1 then (bind ?c1-counter (+ ?c1-counter 1))
-			              (if (<= ?c1-counter 1) then (bind ?first-ring ?c1-first-ring)
-			                                     else (bind ?first-ring ?cx-first-ring))
-			              (bind ?order-ring-colors (create$ ?first-ring)))
-			(case C2 then (bind ?c2-counter (+ ?c2-counter 1))
-			              (if (<= ?c2-counter 1) then (bind ?first-ring ?c2-first-ring)
-			                                     else (bind ?first-ring ?cx-first-ring))
-                             (bind ?order-ring-colors (create$ ?first-ring (subseq$ (randomize$ (remove$ ?ring-colors ?first-ring)) 1 1))))
-			(case C3 then (bind ?c3-counter (+ ?c3-counter 1))
-			              (if (<= ?c3-counter 1) then (bind ?first-ring ?c3-first-ring)
-			                                     else (bind ?first-ring ?cx-first-ring))
-			              (bind ?order-ring-colors (create$ ?first-ring (subseq$ (randomize$ (remove$ ?ring-colors ?first-ring)) 1 2))))
-    )
-
-		(bind ?order-base-color (pick-random$ (deftemplate-slot-allowed-values order base-color)))
-		(bind ?order-cap-color (pick-random$ (deftemplate-slot-allowed-values order cap-color)))
-
-    (modify ?order (active FALSE) (activate-at ?activate-at) (delivery-gate ?gate)
-	    (delivery-period ?deliver-start ?deliver-end) (base-color ?order-base-color)
-			(ring-colors ?order-ring-colors) (cap-color ?order-cap-color))
-  )
-
-  ; Randomize number of required additional bases
-  (bind ?m-add-bases (randomize$ (create$ 1 3)))
-  (do-for-fact ((?ring ring-spec)) (eq ?ring:color (nth$ (nth$ 1 ?m-add-bases) ?ring-colors))
-    (modify ?ring (req-bases 2))
-  )
-  (do-for-fact ((?ring ring-spec)) (eq ?ring:color (nth$ (nth$ 2 ?m-add-bases) ?ring-colors))
-    (modify ?ring (req-bases 1))
-  )
-  (delayed-do-for-all-facts ((?ring ring-spec))
-    (or (eq ?ring:color (nth$ 2 ?ring-colors)) (eq ?ring:color (nth$ 4 ?ring-colors)))
-    (modify ?ring (req-bases 0))
-  )
-
-	; Randomly assign an order to be a competitive order
-	(bind ?potential-competitive-orders (create$))
-	(do-for-all-facts ((?order order))
-	                  (and (eq ?order:complexity C0) ; must be C0
-	                       (eq ?order:quantity-requested 1) ; must not request more than 1 product
-	                       (eq ?order:allow-overtime FALSE) ; no overtime order
-	                       (or (neq (nth$ 1 ?order:delivery-period) 0) ; no standing order
-	                           (neq (nth$ 2 ?order:delivery-period) ?*PRODUCTION-TIME*))
-	                  )
-	                  (bind ?potential-competitive-orders (insert$ ?potential-competitive-orders 1 ?order:id))
+	; reset machines
+	(delayed-do-for-all-facts ((?machine machine)) TRUE
+	  (if (eq ?machine:mtype RS) then (mps-reset-base-counter (str-cat ?machine:name)))
+	  (modify ?machine (productions 0) (state IDLE)
+	             (proc-start 0.0) (desired-lights GREEN-ON YELLOW-ON RED-ON))
 	)
-	;(printout t "Potential competitive orders: " ?potential-competitive-orders crlf)
-	(bind ?competitive-order-id (nth$ (random 1 (length$ ?potential-competitive-orders)) ?potential-competitive-orders))
-	(do-for-fact ((?order order)) (eq ?order:id ?competitive-order-id)
-	  (modify ?order (competitive TRUE)))
+	(if (eq ?m-positions RANDOM)
+	 then
+		(machine-randomize-positions)
+	)
+	(if (eq ?m-setup RANDOM)
+	 then
+		(machine-randomize-machine-setup)
+	)
+	(if (eq ?orders RANDOM)
+	 then
+		(game-randomize-orders)
+	)
+	(if (eq ?s-status RANDOM)
+	 then
+		(ss-shuffle-shelves)
+	)
 
-	; Randomize storage station initial shelf positions by shuffling each shelf
-	(ss-shuffle-shelves)
 	(ss-print-storage C-SS)
 	(ss-print-storage M-SS)
 	(printout t "Top  5        1 3 5 7" crlf)
@@ -197,7 +244,7 @@
 )
 
 (defrule game-print
-  (game-parameterized)
+  (game-parameters (is-parameterized TRUE))
   (gamestate (teams $?teams))
   (not (game-printed))
   =>
@@ -417,10 +464,6 @@
 )
 
 (deffunction game-reset ()
-	; Retract machine initialization state, if set
-	(do-for-fact ((?mi machines-initialized)) TRUE
-		(retract ?mi)
-	)
 	; Retract all delivery periods
 	(delayed-do-for-all-facts ((?dp delivery-period)) TRUE
 		(retract ?dp)
@@ -430,9 +473,10 @@
 		(modify ?m (down-period (deftemplate-slot-default-value machine down-period)))
 	)
 	; Reset game parameterization
-	(do-for-fact ((?gp game-parameterized)) TRUE
+	(delayed-do-for-all-facts ((?gp game-parameters)) TRUE
 		(retract ?gp)
 	)
+	(assert (game-parameters))
 	; Reset machine generation
 	(do-for-fact ((?mg machine-generation)) TRUE
 		(modify ?mg (state NOT-STARTED))

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -74,127 +74,104 @@
 	(return (if (eq ?prefix "C") then CYAN else MAGENTA))
 )
 
-(deffunction machine-init-randomize ()
-  ; reset machines
-  (delayed-do-for-all-facts ((?machine machine)) TRUE
-    (if (eq ?machine:mtype RS) then (mps-reset-base-counter (str-cat ?machine:name)))
-    (modify ?machine (productions 0) (state IDLE)
-	             (proc-start 0.0) (desired-lights GREEN-ON YELLOW-ON RED-ON))
-  )
-
-  (bind ?overwrite-generating false)
-  (do-for-fact ((?cv confval)) (and (eq ?cv:path "/llsfrb/game/random-field")
-                                    (eq ?cv:type BOOL)
-                               )
-    (bind ?overwrite-generating ?cv:value)
-  )
-
-  ; if the field is not compleate
-  ; or when the field should be regenerated
-  (if (or (any-factp ((?m machine)) (eq ?m:zone TBD))
-          (eq (str-cat ?overwrite-generating) "true")
-      )
-   then
-    (printout t "Randomizing from scratch" crlf)
-    ; reset all zones, since we cannot do partial assinemend anymore
-    (delayed-do-for-all-facts ((?m machine)) TRUE
-      (modify ?m (zone TBD))
-    )
-    ; randomly assigned machines to zones using the external generator
-		(bind ?zones-magenta ?*MACHINE-ZONES-MAGENTA*)
-    (bind ?machines (mps-generator-get-generated-field))
-    (delayed-do-for-all-facts ((?m machine)) (and (eq ?m:team MAGENTA) (eq ?m:zone TBD))
-      (if (member$ ?m:name ?machines)
-       then
-        (bind ?zone (nth$ (+ (member$ ?m:name ?machines) 1) ?machines))
-        (bind ?rot (nth$ (+ (member$ ?m:name ?machines) 2) ?machines))
-        (printout t ?m:name ": " ?zone " with " ?rot crlf)
-        (modify ?m (zone ?zone) (rotation ?rot))
-       else
-        (printout error ?m:name " not found in generation" crlf)
-      )
-    )
-
-    ; Mirror machines for other team
-    (delayed-do-for-all-facts ((?mm machine)) (eq ?mm:team MAGENTA)                 ; for each MAGENTA
-      (do-for-fact ((?mc machine)) (and (eq ?mm:name (mirror-name ?mc:name)) (eq ?mc:team CYAN))  ; get the CYAN
-        (modify ?mc
-          (zone (mirror-zone ?mm:zone))
-          (rotation (mirror-orientation ?mm:mtype ?mm:zone ?mm:rotation))
-        )
-      )
-    )
-
-    ; Swap machines
-		(bind ?machines-to-swap
-	    (create$ (str-cat "RS" (random 1 2)) (str-cat "CS" (random 1 2))))
-		(foreach ?ms ?machines-to-swap
-      (do-for-fact ((?m-cyan machine) (?m-magenta machine))
-          (and (eq ?m-cyan:team CYAN) (eq ?m-cyan:name (sym-cat C- ?ms))
-					  	 (eq ?m-magenta:team MAGENTA) (eq ?m-magenta:name (sym-cat M- ?ms)))
-
-				(printout t "Swapping " ?m-cyan:name " with " ?m-magenta:name crlf)
-
-				(bind ?z-cyan ?m-cyan:zone)
-				(bind ?r-cyan ?m-cyan:rotation)
-				(bind ?z-magenta ?m-magenta:zone)
-				(bind ?r-magenta ?m-magenta:rotation)
-				(modify ?m-cyan    (zone ?z-magenta) (rotation ?r-magenta))
-				(modify ?m-magenta (zone ?z-cyan) (rotation ?r-cyan))
-			)
+(deffunction machine-randomize-positions ()
+	(printout t "Randomizing from scratch" crlf)
+	; reset all zones, since we cannot do partial assignment anymore
+	(delayed-do-for-all-facts ((?m machine)) TRUE
+	  (modify ?m (zone TBD))
+	)
+	; randomly assigned machines to zones using the external generator
+	(bind ?zones-magenta ?*MACHINE-ZONES-MAGENTA*)
+	(bind ?machines (mps-generator-get-generated-field))
+	(delayed-do-for-all-facts ((?m machine)) (and (eq ?m:team MAGENTA) (eq ?m:zone TBD))
+	  (if (member$ ?m:name ?machines)
+	   then
+	    (bind ?zone (nth$ (+ (member$ ?m:name ?machines) 1) ?machines))
+	    (bind ?rot (nth$ (+ (member$ ?m:name ?machines) 2) ?machines))
+	    (printout t ?m:name ": " ?zone " with " ?rot crlf)
+	    (modify ?m (zone ?zone) (rotation ?rot))
+	   else
+	    (printout error ?m:name " not found in generation" crlf)
 	  )
-		; Randomize ring colors per machine
-		(bind ?ring-colors (create$))
-		(do-for-all-facts ((?rs ring-spec)) TRUE
-			(bind ?ring-colors (append$ ?ring-colors ?rs:color))
-		)
-		(do-for-fact ((?m-cyan machine) (?m-magenta machine))
-			(and (eq ?m-cyan:name C-RS1) (eq ?m-magenta:name M-RS1))
+	)
 
-			(modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 1 2)))
-			(modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 1 2)))
-		)
-		(do-for-fact ((?m-cyan machine) (?m-magenta machine))
-			(and (eq ?m-cyan:name C-RS2) (eq ?m-magenta:name M-RS2))
+	; Mirror machines for other team
+	(delayed-do-for-all-facts ((?mm machine)) (eq ?mm:team MAGENTA)                 ; for each MAGENTA
+	  (do-for-fact ((?mc machine)) (and (eq ?mm:name (mirror-name ?mc:name)) (eq ?mc:team CYAN))  ; get the CYAN
+	    (modify ?mc
+	      (zone (mirror-zone ?mm:zone))
+	      (rotation (mirror-orientation ?mm:mtype ?mm:zone ?mm:rotation))
+	    )
+	  )
+	)
 
-			(modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 3 4)))
-			(modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+  ; Swap machines
+	(bind ?machines-to-swap
+    (create$ (str-cat "RS" (random 1 2)) (str-cat "CS" (random 1 2))))
+	(foreach ?ms ?machines-to-swap
+		(do-for-fact ((?m-cyan machine) (?m-magenta machine))
+		    (and (eq ?m-cyan:team CYAN) (eq ?m-cyan:name (sym-cat C- ?ms))
+		         (eq ?m-magenta:team MAGENTA) (eq ?m-magenta:name (sym-cat M- ?ms)))
+
+		  (printout t "Swapping " ?m-cyan:name " with " ?m-magenta:name crlf)
+
+		  (bind ?z-cyan ?m-cyan:zone)
+		  (bind ?r-cyan ?m-cyan:rotation)
+		  (bind ?z-magenta ?m-magenta:zone)
+		  (bind ?r-magenta ?m-magenta:rotation)
+		  (modify ?m-cyan    (zone ?z-magenta) (rotation ?r-magenta))
+		  (modify ?m-magenta (zone ?z-cyan) (rotation ?r-cyan))
 		)
   )
+)
 
-  ; assign random down times
+(deffunction machine-randomize-machine-setup ()
+	; Randomize ring colors per machine
+	(bind ?ring-colors (create$))
+	(do-for-all-facts ((?rs ring-spec)) TRUE
+	  (bind ?ring-colors (append$ ?ring-colors ?rs:color))
+	)
+	(do-for-fact ((?m-cyan machine) (?m-magenta machine))
+	  (and (eq ?m-cyan:name C-RS1) (eq ?m-magenta:name M-RS1))
+	  (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 1 2)))
+	  (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 1 2)))
+	)
+	(do-for-fact ((?m-cyan machine) (?m-magenta machine))
+	  (and (eq ?m-cyan:name C-RS2) (eq ?m-magenta:name M-RS2))
+	  (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+	  (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+	)
+
+	; assign random down times
   (if (and ?*RANDOMIZE-GAME*
            (config-get-bool "/llsfrb/game/random-machine-down-times"))
    then
-    (bind ?candidates (create$))
-    (foreach ?t ?*DOWN-TYPES*
-      (bind ?t-candidates (find-all-facts ((?m machine))
-    	      (and (eq ?m:mtype ?t) (eq ?m:team CYAN))))
+		(bind ?candidates (create$))
+		(foreach ?t ?*DOWN-TYPES*
+			(bind ?t-candidates (find-all-facts ((?m machine))
+			                      (and (eq ?m:mtype ?t) (eq ?m:team CYAN))))
 
-      (bind ?candidates (append$ ?candidates (first$ (randomize$ ?t-candidates))))
-    )
+		  (bind ?candidates (append$ ?candidates (first$ (randomize$ ?t-candidates))))
+		)
 
-    (foreach ?c ?candidates
-      (bind ?duration (random ?*DOWN-TIME-MIN* ?*DOWN-TIME-MAX*))
-      (bind ?start-time (random 1 (- ?*PRODUCTION-TIME* ?duration)))
-      (bind ?end-time (+ ?start-time ?duration))
+		(foreach ?c ?candidates
+			(bind ?duration (random ?*DOWN-TIME-MIN* ?*DOWN-TIME-MAX*))
+			(bind ?start-time (random 1 (- ?*PRODUCTION-TIME* ?duration)))
+			(bind ?end-time (+ ?start-time ?duration))
 
-      ; Copy to magenta machine
-      (do-for-fact ((?m-magenta machine))
-        (eq ?m-magenta:name (machine-magenta-for-cyan (fact-slot-value ?c name)))
-        (modify ?m-magenta (down-period ?start-time ?end-time))
-      )
+			; Copy to magenta machine
+			(do-for-fact ((?m-magenta machine))
+			  (eq ?m-magenta:name (machine-magenta-for-cyan (fact-slot-value ?c name)))
+			  (modify ?m-magenta (down-period ?start-time ?end-time))
+			)
 
-      (modify ?c (down-period ?start-time ?end-time))
-    )
-  )
-
-
-  (assert (machines-initialized))
+		  (modify ?c (down-period ?start-time ?end-time))
+		)
+	)
 )
 
 (defrule machines-print
-  (machines-initialized)
+  (game-parameters (is-parameterized TRUE))
   (gamestate (teams $?teams) (phase PRODUCTION|EXPLORATION))
   (not (machines-printed))
   =>

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -5,38 +5,208 @@
 ;  Created: Mon Jun 10 19:06:19 2013
 ;  Copyright  2013  Tim Niemueller [www.niemueller.de]
 ;             2017  Tobias Neumann
+;             2020  Tarik Viehmann
 ;  Licensed under BSD license, cf. LICENSE file
 ;---------------------------------------------------------------------------
 
-(deftemplate mongodb-last-game-report
-  (multislot points (type INTEGER) (cardinality 2 2) (default 0 0))
+(deftemplate mongodb-game-report
+	(multislot start (type INTEGER) (cardinality 2 2) (default 0 0))
+	(multislot end (type INTEGER) (cardinality 2 2) (default 0 0))
+	(slot name (type STRING) (default ""))
+	(multislot points (type INTEGER) (cardinality 2 2) (default 0 0))
 )
 
 (deffunction mongodb-time-as-ms (?time)
 	(return (+ (* (nth$ 1 ?time) 1000) (div (nth$ 2 ?time) 1000)))
 )
 
-(defrule mongodb-init
-  (init)
-  =>
-  (assert (mongodb-last-game-report))
+(deffunction mongodb-fact-to-bson (?fact-id)
+" Create a bson document from a fact.
+  @param ?fact-id Fact to encode as bson document
+  @return ?doc bson document containing all slots of ?fact-id
+"
+	(bind ?doc (bson-create))
+	(bind ?slots (fact-slot-names ?fact-id))
+	(foreach ?slot ?slots
+		(bind ?is-multislot (deftemplate-slot-multip (fact-relation ?fact-id) ?slot))
+		(bind ?slot-value (fact-slot-value ?fact-id ?slot))
+		(if ?is-multislot
+		 then
+			(bson-append-array ?doc (str-cat ?slot) ?slot-value)
+		 else
+			(bson-append ?doc (str-cat ?slot) ?slot-value)
+		)
+	)
+	(return ?doc)
 )
 
-(defrule mongodb-reset
-  (reset-game)
-  ?f1 <- (mongodb-wrote-game-report $?)
-  ?f2 <- (mongodb-last-game-report)
-  =>
-  (retract ?f1)
-  (modify ?f2 (points 0 0))
+(deffunction mongodb-pack-value-to-string (?value ?type)
+" Convert a value or list of values to a string, such that CLIPS can retrieve
+  the type later on.
+  Useful helper when using 'assert-string'.
+  @param ?value Value or list of values
+  @param ?type Type of the value(s) of ?value
+  @return string packed with the value(s)
+"
+	(bind ?raw-val ?value)
+	(bind ?is-list (eq (type ?value) MULTIFIELD))
+	(if ?is-list
+	 then
+		(bind ?tmp ?raw-val)
+		(progn$ (?f ?tmp) (bind ?raw-val (replace$ ?raw-val ?f-index ?f-index (type-cast ?f ?type))))
+		(bind ?typed-string (implode$ ?raw-val))
+	 else
+		(bind ?typed-string (str-cat (type-cast ?value ?type)))
+		(if (eq ?type STRING) then (bind ?typed-string (str-cat "\"" ?typed-string "\"")))
+	)
+	(return ?typed-string)
 )
 
-(deffunction mongodb-write-game-report (?teams ?stime ?etime)
+(deffunction mongodb-retrieve-value-from-doc (?doc ?field ?type ?is-list)
+" Retrieve the value(s) with a given type from a field of a bson document.
+  @param ?doc bson document
+  @param ?field Name of the field within ?doc that holds the desired value
+  @param ?type Type of the value that is retrieved
+  @param ?is-list TRUE if the field contains an array, FALSE otherwise
+  @return Value(s) of ?field with type ?type
+"
+	(if ?is-list
+	 then
+		(bind ?raw-val (bson-get-array ?doc ?field))
+		(return (type-cast-list ?raw-val ?type))
+	 else
+		(bind ?raw-val (bson-get ?doc ?field))
+		(return (type-cast ?raw-val ?type))
+	)
+)
+
+(deffunction mongodb-update-fact-from-bson (?doc ?template ?slot-id $?only-slots)
+" Update a fact by the content of a bson document.
+  @param ?doc bson document
+  @param ?template Template name of the fact that is encoded in ?doc
+  @param ?slot-id Name of the slot that uniquely determines the ?template fact
+                  that is updated
+  @param $?only-slots optional list of slots within ?template that are updated
+                      by the values contained in ?doc. If unspecified all slots
+                      are updated.
+"
+	; determine all slots that are updated
+	(bind ?slots ?only-slots)
+	(if (eq (length$ ?slots) 0)
+	 then
+		(bind ?slots (deftemplate-slot-names ?template))
+	)
+
+	; retrieve fact matching the document
+	(bind ?id-types (deftemplate-slot-types ?template ?slot-id))
+	(if (neq (length$ ?id-types) 1)
+	 then
+		(printout error "mongodb-update-fact-from-bson: Type of identifier slot "
+		                ?slot-id " not uniquely determined: " ?id-types crlf)
+		(return)
+	 else
+		(bind ?id-type (nth$ 1 ?id-types))
+	)
+	(bind ?id-value
+	      (mongodb-retrieve-value-from-doc ?doc
+	                                       ?slot-id
+	                                       ?id-type
+	                                       (deftemplate-slot-multip ?template ?slot-id)))
+	(bind ?f-list (find-fact ((?x ?template)) (eq (fact-slot-value ?x ?slot-id) ?id-value)))
+	(if (eq (length$ ?f-list) 0) then
+		(printout error "mongodb-update-fact-from-bson: No " ?template
+		                " fact with identifier " ?slot-id
+		                " found that matches doc value " ?id-value crlf)
+		(return)
+	)
+	(bind ?f (nth$ 1 ?f-list))
+
+	; build string of the updated fact
+	(bind ?update-str (str-cat "(" ?template))
+	(foreach ?slot (deftemplate-slot-names ?template)
+		(bind ?is-multislot (deftemplate-slot-multip ?template ?slot))
+		(bind ?types (deftemplate-slot-types ?template ?slot))
+		(if (neq (length$ ?types) 1)
+		 then
+			(printout error "mongodb-bson-to-fact: type of slot " ?slot
+			                " of template "  ?template " cannot be determined, skipping." crlf)
+		 else
+			(bind ?type (nth$ 1 ?types))
+			(if (member$ ?slot ?slots)
+			 then
+				(bind ?value (mongodb-retrieve-value-from-doc ?doc ?slot ?type ?is-multislot))
+			 else
+				(bind ?value (fact-slot-value ?f ?slot))
+			)
+			(bind ?value (mongodb-pack-value-to-string ?value ?type))
+			(bind ?update-str (str-cat ?update-str " (" ?slot " " ?value ")"))
+		)
+	)
+	(bind ?update-str (str-cat ?update-str ")"))
+
+	; update the fact
+	(retract ?f)
+	(assert-string ?update-str)
+)
+
+(deffunction mongodb-write-game-report(?doc ?stime)
+" Upsert a game report to mongodb.
+  @param ?doc bson document storing the game report
+  @param ?stime start time of the report
+"
+	(mongodb-upsert "game_report" ?doc
+	  (str-cat "{\"start-timestamp\": [" (nth$ 1 ?stime) ", " (nth$ 2 ?stime) "]}"))
+	(bson-builder-destroy ?doc)
+)
+
+(deffunction mongodb-load-facts-from-game-report (?report-name ?facts ?template ?id-slot $?only-slots)
+" Update facts with values from a game report.
+  @param ?report-name Name of the report from which data is loaded. In case
+                      Multiple reports have the same name the newest one is
+                      chosen.
+  @param ?facts field name within game reports taht contains the facts
+  @param ?template Template name of the fact that is encoded in ?facts
+  @param ?slot-id Name of the slot that uniquely determines the ?template fact
+                  that is updated
+  @param $?only-slots optional list of slots within ?template that are updated
+                      by the values contained in ?doc. If unspecified all slots
+                      are updated.
+  @return TRUE if the game report has a field name ?facts, FALSE otherwise.
+"
+	(bind ?success FALSE)
+	(bind ?t-query (bson-parse "{}"))
+	(if (neq ?report-name "")
+	 then
+		(bind ?t-query (bson-parse (str-cat "{\"report-name\": " ?report-name "}")))
+	)
+	(bind ?t-sort  (bson-parse "{\"start-timestamp\": -1}"))
+	(bind ?t-cursor (mongodb-query-sort "game_report" ?t-query ?t-sort))
+	(bind ?t-doc (mongodb-cursor-next ?t-cursor))
+	(if (neq ?t-doc FALSE) then
+	 then
+		(bind ?m-arr (bson-get-array ?t-doc ?facts))
+		(foreach ?m-p ?m-arr
+			(mongodb-update-fact-from-bson ?m-p ?template ?id-slot ?only-slots)
+			(bson-destroy ?m-p)
+		)
+		(bson-destroy ?t-doc)
+		(bind ?success TRUE)
+	 else
+		(printout error "Empty result in mongoDB from game_report" crlf)
+	)
+	(mongodb-cursor-destroy ?t-cursor)
+	(bson-builder-destroy ?t-query)
+	(bson-builder-destroy ?t-sort)
+	(return ?success)
+)
+
+(deffunction mongodb-create-game-report (?teams ?stime ?etime ?report-name)
   (bind ?doc (bson-create))
 
   (bson-append-array ?doc "start-timestamp" ?stime)
   (bson-append-time  ?doc "start-time" ?stime)
   (bson-append-array ?doc "teams" ?teams)
+  (bson-append ?doc "report-name" ?report-name)
 
   (if (time-nonzero ?etime) then
     (bson-append-time ?doc "end-time" ?etime)
@@ -52,11 +222,7 @@
     (bind ?phase-points-cyan 0)
     (bind ?phase-points-magenta 0)
     (do-for-all-facts ((?p points)) (eq ?p:phase ?phase)
-      (bind ?point-doc (bson-create))
-      (bson-append ?point-doc "game-time" ?p:game-time)
-      (bson-append ?point-doc "team"   ?p:team)
-      (bson-append ?point-doc "points" ?p:points)
-      (bson-append ?point-doc "reason" ?p:reason)
+      (bind ?point-doc (mongodb-fact-to-bson ?p))
       (if (eq ?p:team CYAN)
         then (bind ?phase-points-cyan (+ ?phase-points-cyan ?p:points))
         else (bind ?phase-points-magenta (+ ?phase-points-magenta ?p:points))
@@ -77,91 +243,78 @@
   (bson-builder-destroy ?phase-points-doc-cyan)
   (bson-builder-destroy ?phase-points-doc-magenta)
 
-  (bind ?m-arr (bson-array-start))
-  (do-for-all-facts ((?m machine)) TRUE
-     (bind ?m-doc (bson-create))
-     (bson-append ?m-doc "name" ?m:name)
-     (bson-append ?m-doc "team" ?m:team)
-     (bson-append ?m-doc "type" ?m:mtype)
-     (bson-append ?m-doc "zone" ?m:zone)
-     (bson-append-array ?m-doc "pose" ?m:pose)
-     (bson-append ?m-doc "orientation" ?m:rotation)
-     (bson-append ?m-doc "productions" ?m:productions)
-     (bson-append ?m-doc "proc-time" ?m:proc-time)
-     (bson-append-array ?m-doc "down-period" ?m:down-period)
-
-     (if (eq ?m:mtype RS) then
-       (bson-append-array ?m-doc "rs-ring-colors" ?m:rs-ring-colors)
-     )
-     (bson-array-append ?m-arr ?m-doc)
-  )
-  (bson-array-finish ?doc "machines" ?m-arr)
-
-  (bind ?o-arr (bson-array-start))
-  (do-for-all-facts ((?o order)) TRUE
-     (bind ?o-doc (bson-create))
-     (bson-append ?o-doc "id" ?o:id)
-     (bson-append ?o-doc "complexity" ?o:complexity)
-     (bson-append ?o-doc "quantity-requested" ?o:quantity-requested)
-     (bson-append ?o-doc "base-color" ?o:base-color)
-     (bson-append-array ?o-doc "ring-colors" ?o:ring-colors)
-     (bson-append ?o-doc "cap-color" ?o:cap-color)
-     (bson-append-array ?o-doc "quantity-delivered" ?o:quantity-delivered)
-     (bson-append-array ?o-doc "delivery-period" ?o:delivery-period)
-     (bson-append ?o-doc "delivery-gate" ?o:delivery-gate)
-     (bson-append ?o-doc "activate-at" ?o:activate-at)
-     (bson-array-append ?o-arr ?o-doc)
-  )
-  (bson-array-finish ?doc "orders" ?o-arr)
+	(bind ?o-arr (bson-array-start))
+	(do-for-all-facts ((?o order)) TRUE
+		(bson-array-append ?o-arr (mongodb-fact-to-bson ?o))
+	)
+	(bson-array-finish ?doc "orders" ?o-arr)
 
   ;(printout t "Storing game report" crlf (bson-tostring ?doc) crlf)
+	(return ?doc)
+)
 
-  (mongodb-upsert "game_report" ?doc
-  		  (str-cat "{\"start-timestamp\": [" (nth$ 1 ?stime) ", " (nth$ 2 ?stime) "]}"))
-  (bson-builder-destroy ?doc)
+
+(defrule mongodb-reset
+	(reset-game)
+	?f1 <- (mongodb-game-report)
+	=>
+	(modify ?f1 (points 0 0) (end 0 0))
 )
 
 (defrule mongodb-game-report-begin
   (declare (salience ?*PRIORITY_HIGH*))
   (gamestate (teams $?teams&:(neq ?teams (create$ "" "")))
 	     (prev-phase PRE_GAME) (phase ~PRE_GAME) (start-time $?stime) (end-time $?etime))
-  (not (mongodb-wrote-game-report begin $?stime))
-  ?f <- (mongodb-last-game-report)
+	(confval (path "/llsfrb/game/store-to-report") (type STRING) (value ?report-name))
+  (not (mongodb-game-report (start $?stime) (name ?report-name)))
   =>
-  (mongodb-write-game-report ?teams ?stime ?etime)
-  (assert (mongodb-wrote-game-report begin ?stime))
-  (modify ?f (points 0 0))
+  (assert (mongodb-game-report (start ?stime) (name ?report-name)))
+  (bind ?doc (mongodb-create-game-report ?teams ?stime ?etime ?report-name))
+	; store information describing the game setup only once
+	(bind ?m-arr (bson-array-start))
+	(do-for-all-facts ((?m ring-spec)) TRUE
+		(bson-array-append ?m-arr (mongodb-fact-to-bson ?m))
+	)
+	(bson-array-finish ?doc "ring-specs" ?m-arr)
+	(bind ?m-arr (bson-array-start))
+	(do-for-all-facts ((?m machine)) TRUE
+		(bson-array-append ?m-arr (mongodb-fact-to-bson ?m))
+	)
+	(bson-array-finish ?doc "machines" ?m-arr)
+	(mongodb-write-game-report ?doc ?stime)
 )
 
 (defrule mongodb-game-report-end
   (gamestate (teams $?teams&:(neq ?teams (create$ "" "")))
 						 (phase POST_GAME) (start-time $?stime) (end-time $?etime))
-  (not (mongodb-wrote-game-report end $?stime))
+	(confval (path "/llsfrb/game/store-to-report") (type STRING) (value ?report-name))
+  ?gr <- (mongodb-game-report (start $?stime) (name ?report-name) (end $?end&:(neq ?end ?etime)))
   =>
 	(printout t "Writing game report to MongoDB" crlf)
-  (mongodb-write-game-report ?teams ?stime ?etime)
-  (assert (mongodb-wrote-game-report end ?stime))
+	(modify ?gr (end ?etime))
+	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime)
 )
 
 (defrule mongodb-game-report-update
   (declare (salience ?*PRIORITY_HIGH*))
-  ?gr <- (mongodb-last-game-report (points $?gr-points))
+	?gr <- (mongodb-game-report (points $?gr-points) (name ?report-name))
   (gamestate (state RUNNING)
 	     (teams $?teams&:(neq ?teams (create$ "" "")))
 	     (start-time $?stime) (end-time $?etime)
 	     (points $?points&:(neq ?points ?gr-points)))
   =>
-  (mongodb-write-game-report ?teams ?stime ?etime)
   (modify ?gr (points ?points))
+	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime)
 )
 
 (defrule mongodb-game-report-finalize
   (declare (salience ?*PRIORITY_HIGH*))
   (gamestate (teams $?teams&:(neq ?teams (create$ "" "")))
 	     (start-time $?stime) (end-time $?etime))
+  ?gr <- (mongodb-game-report (points $?gr-points) (name ?report-name))
   (finalize)
   =>
-  (mongodb-write-game-report ?teams ?stime ?etime)
+	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime)
 )
 
 (defrule mongodb-net-client-connected
@@ -195,111 +348,40 @@
 )
 
 
-(deffunction mongodb-store-machine-zones (?time)
-  (bind ?doc (bson-create))
-
-  (bson-append-array ?doc "timestamp" ?time)
-  (bson-append-time  ?doc "time" ?time)
-  (bind ?m-arr (bson-array-start))
-
-	(do-for-all-facts ((?m machine)) TRUE
-    (bind ?m-doc (bson-create))
-		(bson-append ?m-doc "name" ?m:name)
-		(bson-append ?m-doc "zone" ?m:zone)
-		(bson-append ?m-doc "rotation" ?m:rotation)
-		(bson-append ?m-doc "type" ?m:mtype)
-		(if (eq ?m:mtype RS) then
-			(bson-append-array ?m-doc "rs-ring-colors" ?m:rs-ring-colors)
-		)
-		(bson-array-append ?m-arr ?m-doc)
-		(bson-builder-destroy ?m-doc)
-  )
-
-	(bson-array-finish ?doc "machines" ?m-arr)
-  (mongodb-upsert "machine_zones" ?doc
-  		  (str-cat "{\"timestamp\": [" (nth$ 1 ?time) ", " (nth$ 2 ?time) "]}"))
-  (bson-builder-destroy ?doc)
-
-)
-
-(deffunction mongodb-load-machine-zones ()
-	; retrieve time range of latest completed game
-  ;(bind ?t-query (bson-parse "{\"end-time\": { \"$exists\": 1 }}"))
-  (bind ?t-query (bson-parse "{}"))
-  (bind ?t-sort  (bson-parse "{\"start-timestamp\": -1}"))
-	(bind ?t-cursor (mongodb-query-sort "game_report" ?t-query ?t-sort))
-  (bind ?t-doc (mongodb-cursor-next ?t-cursor))
-  (if (neq ?t-doc FALSE) then
-	  (bind ?stime (bson-get-time ?t-doc "start-time"))
-    (bson-destroy ?t-doc)
-;	  (bind ?etime (bson-get-time ?t-doc "end-time"))
-
-	  ; retrieve machine config
-;		(bind ?qs (str-cat "{\"$and\": [{time: { \"$gte\": { \"$date\": "
-;											 (mongodb-time-as-ms ?stime) "}}},"
-;											 "{time: { \"$lte\": { \"$date\": "
-;											 (mongodb-time-as-ms ?etime) "}}}]}}"))
-		;(bind ?qs (str-cat "{\"time\": ISODate(\"" (mongodb-time-as-ms ?stime) "\"}"))
-		(bind ?qs (str-cat "{}"))
-		(bind ?query (bson-parse ?qs))
-		(bind ?sort  (bson-parse "{\"time\": -1}"))
-		(bind ?cursor (mongodb-query-sort "machine_zones" ?query ?sort))
-		(bind ?doc (mongodb-cursor-next ?cursor))
-		(if (neq ?doc FALSE) then
-		 then
-			(bind ?fn (bson-field-names ?doc))
-			(bind ?m-arr (bson-get-array ?doc "machines"))
-			(foreach ?m-p ?m-arr
-				(bind ?m-name (sym-cat (bson-get ?m-p "name")))
-				(bind ?m-zone (sym-cat (bson-get ?m-p "zone")))
-				(bind ?m-rotation (sym-cat (bson-get ?m-p "rotation")))
-				(bind ?m-rs-ring-colors (create$))
-				(bind ?m-rs-ring-colors-strings (create$))
-				(bind ?m-type (sym-cat (bson-get ?m-p "type")))
-				(if (eq ?m-type RS) then
-					(bind ?m-rs-ring-colors-strings (bson-get-array ?m-p "rs-ring-colors"))
-					(foreach ?c ?m-rs-ring-colors-strings
-						(bind ?m-rs-ring-colors (append$ ?m-rs-ring-colors (sym-cat ?c)))
-					)
-				)
-				;(printout t "Machine " ?m-name " is in zone " ?m-zone " with rotation " ?m-rotation crlf)
-				(do-for-fact ((?m machine)) (eq ?m:name ?m-name)
-					(modify ?m (zone ?m-zone) (rotation (integer (eval ?m-rotation))) (rs-ring-colors ?m-rs-ring-colors))
-				)
-				(bson-destroy ?m-p)
-			)
-			(bson-destroy ?doc)
-     else
-	    (printout error "Empty result in mongoDB from machine_zones" crlf)
-    )
-    (mongodb-cursor-destroy ?cursor)
-	  (bson-builder-destroy ?query)
-	  (bson-builder-destroy ?sort)
-   else
-	  (printout error "Empty result in mongoDB from game_report" crlf)
-
-  )
-  (mongodb-cursor-destroy ?t-cursor)
-	(bson-builder-destroy ?t-query)
-	(bson-builder-destroy ?t-sort)
-)
-
-(defrule mongodb-store-machine-zones
-  (game-parameterized)
-	(mongodb-wrote-game-report begin $?stime)
+(defrule mongodb-load-storage-status
+	(declare (salience ?*PRIORITY_FIRST*))
+	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
+	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
+	(confval (path "/llsfrb/game/random-storage") (type BOOL) (value false))
+	; load only once
+	(not (storage-tried-from-db))
 	=>
-	(printout t "Storing machine zones to database" crlf)
-	(mongodb-store-machine-zones ?stime)
+	(printout t "Loading storage from database" crlf)
+	(assert (storage-tried-from-db))
+	(mongodb-load-facts-from-game-report ?report-name "machine-ss-shelf-slots" machine-ss-shelf-slot name)
 )
+
 
 (defrule mongodb-load-machine-zones
 	(declare (salience ?*PRIORITY_FIRST*))
 	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
 	(not (confval (path "/llsfrb/game/random-field") (type BOOL) (value true)))
-	; load only once
-	(not (loaded-machine-zones-from-db))
+	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
+	; try only once
+	(not (machine-positions-tried-from-db))
 	=>
-	(printout t "Loading machine positions from database" crlf)
-	(assert (loaded-machine-zones-from-db))
-	(mongodb-load-machine-zones)
+		(printout t "Loading machine positions from database" crlf)
+	(if (mongodb-load-facts-from-game-report ?report-name
+	                                         "machines"
+	                                         machine
+	                                         name
+	                                         (create$ zone rotation))
+	 then
+		; disable generation of machine positions
+		(assert (machine-positions-loaded))
+		(printout t "Loading machine positions finished" crlf)
+	 else
+		(printout error "Loading machines from database failed, fallback to random generation." crlf)
+	)
+		(assert (machine-positions-tried-from-db))
 )

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -8,6 +8,10 @@
 ;             2020  Tarik Viehmann
 ;  Licensed under BSD license, cf. LICENSE file
 ;---------------------------------------------------------------------------
+(defglobal
+	; Mongodb Game Report Version,
+	?*MONGODB-REPORT-VERSION* = 1.0
+)
 
 (deftemplate mongodb-game-report
 	(multislot start (type INTEGER) (cardinality 2 2) (default 0 0))
@@ -228,6 +232,7 @@
   (bson-append-time  ?doc "start-time" ?stime)
   (bson-append-array ?doc "teams" ?teams)
   (bson-append ?doc "report-name" ?report-name)
+	(bson-append ?doc "report-version" ?*MONGODB-REPORT-VERSION*)
 
   (if (time-nonzero ?etime) then
     (bson-append-time ?doc "end-time" ?etime)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -389,14 +389,24 @@
 	(do-for-all-facts ((?mh mongodb-machine-history)) TRUE
 		(bind ?history-doc (mongodb-fact-to-bson ?mh))
 		(bind ?temp-fact (assert-string ?mh:fact-string))
+		(bind ?machine-doc FALSE)
 		(if ?temp-fact
 		 then
 			(bind ?machine-doc (mongodb-fact-to-bson ?temp-fact))
 		 else
-			(bind ?machine-doc (find-fact ((?m machine)) (eq ?mh:name ?m:name)))
+			(bind ?machine-facts (find-fact ((?m machine)) (eq ?mh:name ?m:name)))
+			(if ?machine-facts then
+				(bind ?machine-doc (mongodb-fact-to-bson (nth$ 1 ?machine-facts)))
+			)
 		)
-		(bson-append ?history-doc "machine-fact" ?machine-doc)
-		(retract ?temp-fact)
+		(if ?machine-doc then
+			(bson-append ?history-doc "machine-fact" ?machine-doc)
+		 else
+			(printout warn "mongodb: machine history fact without machine fact!" crlf)
+		)
+		(if ?temp-fact then
+			(retract ?temp-fact)
+		)
 		(bson-array-append ?machine-history-arr ?history-doc)
 		(bson-builder-destroy ?machine-doc)
 		(bson-builder-destroy ?history-doc)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -231,7 +231,7 @@
   @param ?report-name Name of the report from which data is loaded. In case
                       Multiple reports have the same name the newest one is
                       chosen.
-  @param ?facts field name within game reports taht contains the facts
+  @param ?facts field name within game reports that contains the facts
   @param ?template Template name of the fact that is encoded in ?facts
   @param ?slot-id Name of the slot that uniquely determines the ?template fact
                   that is updated
@@ -471,7 +471,6 @@
 	?gp <- (game-parameters (storage-status PENDING))
 	=>
 	(printout t "Loading storage from database" crlf)
-	(assert (storage-tried-from-db))
 	(if (mongodb-load-facts-from-game-report ?report-name
 	                                         "machine-ss-shelf-slots"
 	                                         machine-ss-shelf-slot
@@ -493,7 +492,6 @@
 	?gp <- (game-parameters (orders PENDING))
 	=>
 	(printout t "Loading orders from database" crlf)
-	(assert (orders-tried-from-db))
 	(if (mongodb-load-facts-from-game-report ?report-name
 	                                         "orders"
 	                                          order

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -189,11 +189,11 @@
 			(mongodb-update-fact-from-bson ?m-p ?template ?id-slot ?only-slots)
 			(bson-destroy ?m-p)
 		)
-		(bson-destroy ?t-doc)
 		(bind ?success TRUE)
 	 else
 		(printout error "Empty result in mongoDB from game_report" crlf)
 	)
+	(bson-destroy ?t-doc)
 	(mongodb-cursor-destroy ?t-cursor)
 	(bson-builder-destroy ?t-query)
 	(bson-builder-destroy ?t-sort)
@@ -245,7 +245,9 @@
 
 	(bind ?o-arr (bson-array-start))
 	(do-for-all-facts ((?o order)) TRUE
-		(bson-array-append ?o-arr (mongodb-fact-to-bson ?o))
+		(bind ?order-doc (mongodb-fact-to-bson ?o))
+		(bson-array-append ?o-arr ?order-doc)
+		(bson-builder-destroy ?order-doc)
 	)
 	(bson-array-finish ?doc "orders" ?o-arr)
 
@@ -275,17 +277,23 @@
 	; store information describing the game setup only once
 	(bind ?m-arr (bson-array-start))
 	(do-for-all-facts ((?m ring-spec)) TRUE
-		(bson-array-append ?m-arr (mongodb-fact-to-bson ?m))
+		(bind ?ring-spec-doc (mongodb-fact-to-bson ?m))
+		(bson-array-append ?m-arr ?ring-spec-doc)
+		(bson-builder-destroy ?ring-spec-doc)
 	)
 	(bson-array-finish ?doc "ring-specs" ?m-arr)
 	(bind ?m-arr (bson-array-start))
 	(do-for-all-facts ((?m machine-ss-shelf-slot)) TRUE
-		(bson-array-append ?m-arr (mongodb-fact-to-bson ?m))
+		(bind ?ss-doc (mongodb-fact-to-bson ?m))
+		(bson-array-append ?m-arr ?ss-doc)
+		(bson-builder-destroy ?ss-doc)
 	)
 	(bson-array-finish ?doc "machine-ss-shelf-slots" ?m-arr)
 	(bind ?m-arr (bson-array-start))
 	(do-for-all-facts ((?m machine)) TRUE
-		(bson-array-append ?m-arr (mongodb-fact-to-bson ?m))
+		(bind ?machine-doc (mongodb-fact-to-bson ?m))
+		(bson-array-append ?m-arr ?machine-doc)
+		(bson-builder-destroy ?machine-doc)
 	)
 	(bson-array-finish ?doc "machines" ?m-arr)
 	(mongodb-write-game-report ?doc ?stime)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -465,9 +465,17 @@
 	 then
 		(printout t "Loading gamestate finished" crlf)
 		(modify ?gp (gamestate RECOVERED))
-		; ensure that time elapses from now on
+		(bind ?team-colors (create$ CYAN MAGENTA))
 		(do-for-fact ((?g gamestate)) TRUE
+			; ensure that time elapses from now on
 			(modify ?g (last-time $?now))
+			; setup the team peer
+			(foreach ?team ?g:teams
+				(if (neq ?team "")
+				 then
+					(assert (net-SetTeamName (nth$ ?team-index ?team-colors) ?team))
+				)
+			)
 		)
 	 else
 		(printout error "Loading gamestate from database failed, fallback to fresh one." crlf)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -384,14 +384,18 @@
 )
 
 (defrule mongodb-game-report-update
-  (declare (salience ?*PRIORITY_HIGH*))
-	?gr <- (mongodb-game-report (points $?gr-points) (name ?report-name))
-  (gamestate (state RUNNING)
+	(declare (salience ?*PRIORITY_HIGH*))
+	(time $?now)
+	(gamestate (state RUNNING)
 	     (teams $?teams&:(neq ?teams (create$ "" "")))
 	     (start-time $?stime) (end-time $?etime)
-	     (points $?points&:(neq ?points ?gr-points)))
-  =>
-  (modify ?gr (points ?points))
+	     (points $?points))
+	?gr <- (mongodb-game-report (points $?gr-points) (name ?report-name)
+	     (last-updated $?last-updated&:(or
+	       (neq $?points $?gr-points)
+	       (timeout $?now $?last-updated ?*MONGODB-REPORT-UPDATE-FREQUENCY*))))
+	=>
+	(modify ?gr (points $?points) (last-updated $?now))
 	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime)
 )
 

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -230,13 +230,13 @@
 	(assert-string ?update-str)
 )
 
-(deffunction mongodb-write-game-report(?doc ?stime)
+(deffunction mongodb-write-game-report(?doc ?stime ?report-name)
 " Upsert a game report to mongodb.
   @param ?doc bson document storing the game report
   @param ?stime start time of the report
 "
 	(mongodb-upsert "game_report" ?doc
-	  (str-cat "{\"start-timestamp\": [" (nth$ 1 ?stime) ", " (nth$ 2 ?stime) "]}"))
+	  (str-cat "{\"start-timestamp\": [" (nth$ 1 ?stime) ", " (nth$ 2 ?stime) "], \"report-name\": \"" ?report-name "\"}"))
 	(bson-builder-destroy ?doc)
 )
 
@@ -448,7 +448,7 @@
 		(bson-builder-destroy ?machine-doc)
 	)
 	(bson-array-finish ?doc "machines" ?m-arr)
-	(mongodb-write-game-report ?doc ?stime)
+	(mongodb-write-game-report ?doc ?stime ?report-name)
 )
 
 (defrule mongodb-game-report-end
@@ -459,7 +459,7 @@
 	=>
 	(printout t "Writing game report to MongoDB" crlf)
 	(modify ?gr (end ?etime))
-	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime)
+	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime ?report-name)
 )
 
 (defrule mongodb-game-report-update
@@ -475,7 +475,7 @@
 	       (timeout $?now $?last-updated ?*MONGODB-REPORT-UPDATE-FREQUENCY*))))
 	=>
 	(modify ?gr (points $?points) (last-updated $?now))
-	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime)
+	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime ?report-name)
 )
 
 (defrule mongodb-game-report-finalize
@@ -485,7 +485,7 @@
 	?gr <- (mongodb-game-report (points $?gr-points) (name ?report-name))
 	(finalize)
 	=>
-	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime)
+	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime ?report-name)
 )
 
 (defrule mongodb-net-client-connected

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -198,7 +198,7 @@
 	(bind ?t-query (bson-parse "{}"))
 	(if (neq ?report-name "")
 	 then
-		(bind ?t-query (bson-parse (str-cat "{\"report-name\": " ?report-name "}")))
+		(bind ?t-query (bson-parse (str-cat "{\"report-name\": \"" ?report-name "\"}")))
 	)
 	(bind ?t-sort  (bson-parse "{\"start-timestamp\": -1}"))
 	(bind ?t-cursor (mongodb-query-sort "game_report" ?t-query ?t-sort))

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -455,7 +455,7 @@
 	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
 	(confval (path "/llsfrb/game/restore-gamestate/enable") (type BOOL) (value true))
 	(confval (path "/llsfrb/game/restore-gamestate/phase") (type STRING) (value ?p))
-	?gp <- (game-parameters (gamestate PENDING))
+	?gp <- (game-parameters (gamestate PENDING) (is-parameterized TRUE))
 	=>
 	(printout t "Loading gamestate from database" crlf)
 	(if (mongodb-load-fact-from-game-report ?report-name

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -389,7 +389,12 @@
 	(do-for-all-facts ((?mh mongodb-machine-history)) TRUE
 		(bind ?history-doc (mongodb-fact-to-bson ?mh))
 		(bind ?temp-fact (assert-string ?mh:fact-string))
-		(bind ?machine-doc (mongodb-fact-to-bson ?temp-fact))
+		(if ?temp-fact
+		 then
+			(bind ?machine-doc (mongodb-fact-to-bson ?temp-fact))
+		 else
+			(bind ?machine-doc (find-fact ((?m machine)) (eq ?mh:name ?m:name)))
+		)
 		(bson-append ?history-doc "machine-fact" ?machine-doc)
 		(retract ?temp-fact)
 		(bson-array-append ?machine-history-arr ?history-doc)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -212,10 +212,14 @@
 	(bind ?t-doc (mongodb-cursor-next ?t-cursor))
 	(if (neq ?t-doc FALSE) then
 	 then
-		(bind ?m-p (bson-get ?t-doc ?fact))
-		(mongodb-update-fact-from-bson ?m-p ?template ?id-slot ?only-slots)
-		(bson-destroy ?m-p)
-		(bind ?success TRUE)
+		(if (bind ?m-p (bson-get ?t-doc ?fact))
+		 then
+			(mongodb-update-fact-from-bson ?m-p ?template ?id-slot ?only-slots)
+			(bson-destroy ?m-p)
+			(bind ?success TRUE)
+		 else
+			(printout error "Specified game report does not contain field " ?fact crlf)
+		)
 	 else
 		(printout error "Empty result in mongoDB from game_report for fact " ?template crlf)
 	)
@@ -251,12 +255,16 @@
 	(bind ?t-doc (mongodb-cursor-next ?t-cursor))
 	(if (neq ?t-doc FALSE) then
 	 then
-		(bind ?m-arr (bson-get-array ?t-doc ?facts))
-		(foreach ?m-p ?m-arr
-			(mongodb-update-fact-from-bson ?m-p ?template ?id-slot ?only-slots)
-			(bson-destroy ?m-p)
+		(if (bind ?m-arr (bson-get-array ?t-doc ?facts))
+		 then
+			(foreach ?m-p ?m-arr
+				(mongodb-update-fact-from-bson ?m-p ?template ?id-slot ?only-slots)
+				(bson-destroy ?m-p)
+			)
+			(bind ?success TRUE)
+		 else
+			(printout error "Specified game report does not contain field " ?facts crlf)
 		)
-		(bind ?success TRUE)
 	 else
 		(printout error "Empty result in mongoDB from game_report" crlf)
 	)

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -261,8 +261,10 @@
 	(modify ?f1 (points 0 0) (end 0 0))
 )
 
+
 (defrule mongodb-game-report-begin
   (declare (salience ?*PRIORITY_HIGH*))
+	?gp <- (game-parameters (is-parameterized TRUE))
   (gamestate (teams $?teams&:(neq ?teams (create$ "" "")))
 	     (prev-phase PRE_GAME) (phase ~PRE_GAME) (start-time $?stime) (end-time $?etime))
 	(confval (path "/llsfrb/game/store-to-report") (type STRING) (value ?report-name))

--- a/src/games/rcll/utils.clp
+++ b/src/games/rcll/utils.clp
@@ -184,6 +184,35 @@
   (return (if (> (- ?rf ?f) 0) then (- ?rf 1) else ?rf))
 )
 
+(deffunction type-cast (?value ?type)
+" Convert a value to a given type by a direct type cast.
+  @param ?value Value to cast
+  @param ?type Target type to cast
+  @return Value of ?value with ?type
+"
+	(switch ?type
+		(case INTEGER then (return (integer ?value)))
+		(case STRING then (return (str-cat ?value)))
+		(case FLOAT then (return (float ?value)))
+		(case SYMBOL then (return (sym-cat ?value)))
+	)
+	(printout debug "cast: unsupported type cast: " ?type " Expected INTEGER|STRING|FLOAT|SYMBOL" crlf)
+	(return ?value)
+)
+
+(deffunction type-cast-list (?list ?type)
+" Convert each member of a list to a given type.
+  @param ?list List to cast
+  @param ?type Target type to cast
+  @return List with all elements of ?list but with type ?type
+"
+	(bind ?res (create$))
+	(foreach ?c ?list
+		(bind ?res (append$ ?res (type-cast ?c ?type)))
+	)
+	(return ?res)
+)
+
 (deffunction assert-points-with-threshold (?upper-bounded ?prefix ?threshold ?msg ?points ?gt ?team ?phase)
 " Assert points without crossing the threshold
   @param ?upper-bounded: Set to FALSE iff the threshold is a lower bound


### PR DESCRIPTION
This PR reworks the mongodb usage to store and retrieve data in game reports.
 - It introduces new configurable options to de-randomize games using data stored in old reports, which can be beneficial to create reproducible benchmarks.
 - More data is captured in game reports (such as a history of all machine state changes). This creates a common data-format to evaluate performances of different runs. Future PRs will provide some scripts to evaluate the data automatically for some key criteria 
 - This PR also provides generic functions to store/retrieve any fact from/to a game-report and thereby allows to easily extend the functionalities in the future
