### PR TITLE
config improvement fixes

### DIFF
--- a/cfg/challenges/grasping/grasping.yaml
+++ b/cfg/challenges/grasping/grasping.yaml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+---
+# Grasping challenge, which from the refbox side consists simply of a static
+# field
+
+llsfrb:
+  challenges:
+    enable: false
+    name: ""
+    # max is 7 x 8
+    field:
+      width: 5
+      height: 5
+      # if true this effectively doubles the field size
+      mirror: false
+    # Phases in which the machine positions are broadcasted
+    send-mps-ground-truth: [Production]
+
+    production-time: 1020
+    orders:
+      # if disabled, use default orders from rcll
+      customize: true
+    publish-routes:
+      enable: false
+      num-points: 12
+      num-routes: 1
+      pause-duration: 5
+
+      # orders are randomized according to the given spec
+    machines: [BS, CS1, RS1]
+    machine-setup:
+      customize: true
+      rs1-colors: [RING_BLUE, RING_YELLOW]
+      rs2-colors: [RING_ORANGE, RING_GREEN]
+      ring-specs:
+        RING_BLUE: 1
+        RING_YELLOW: 0
+        RING_ORANGE: 2
+        RING_GREEN: 0

--- a/cfg/challenges/grasping/grasping_game.yaml
+++ b/cfg/challenges/grasping/grasping_game.yaml
@@ -1,0 +1,25 @@
+%YAML 1.2
+---
+---
+# Grasping Challenge static field load
+
+llsfrb:
+  game:
+    # set to true to generate a random field at startup
+    # disabling randomization requires mongodb to be enabled as the game
+    # parameters are loaded from a mongodb game report in this case
+    random-field: false
+    # If enabled, some machines will randomly go DOWN for some period during
+    # the game. If disabled, no machine will go DOWN.
+    random-machine-down-times: true
+    random-machine-setup: false
+    random-orders: true
+    random-storage: true
+    restore-gamestate:
+      enable: false
+      phase: PRODUCTION
+    # load data from latest game report with a given name
+    # leave empty to always load from latest stored report
+    load-from-report: "GraspingChallenge"
+    # store game report under a name for later reference
+    store-to-report: ""

--- a/cfg/challenges/nav/nav_easy.yaml
+++ b/cfg/challenges/nav/nav_easy.yaml
@@ -14,7 +14,7 @@ llsfrb:
       # if true this effectively doubles the field size
       mirror: false
     # Phases in which the machine positions are broadcasted
-    send-mps-ground-truth: []
+    send-mps-ground-truth: [PRODUCTION]
 
     production-time: 1020
     orders:

--- a/cfg/challenges/nav/nav_hard.yaml
+++ b/cfg/challenges/nav/nav_hard.yaml
@@ -14,7 +14,7 @@ llsfrb:
       # if true this effectively doubles the field size
       mirror: false
     # Phases in which the machine positions are broadcasted
-    send-mps-ground-truth: []
+    send-mps-ground-truth: [PRODUCTION]
 
     production-time: 1020
     orders:

--- a/cfg/challenges/nav/nav_medium.yaml
+++ b/cfg/challenges/nav/nav_medium.yaml
@@ -14,7 +14,7 @@ llsfrb:
       # if true this effectively doubles the field size
       mirror: false
     # Phases in which the machine positions are broadcasted
-    send-mps-ground-truth: []
+    send-mps-ground-truth: [PRODUCTION]
 
     production-time: 1020
     orders:

--- a/cfg/game/default_game.yaml
+++ b/cfg/game/default_game.yaml
@@ -5,9 +5,6 @@
 
 llsfrb:
   game:
-    teams: [Carologistics]
-    crypto-keys:
-      Carologistics: randomkey
     # set to true to generate a random field at startup
     # disabling randomization requires mongodb to be enabled as the game
     # parameters are loaded from a mongodb game report in this case

--- a/cfg/game/load_field_layout.yaml
+++ b/cfg/game/load_field_layout.yaml
@@ -1,14 +1,11 @@
 %YAML 1.2
 ---
 ---
-# Play on the same field aagain, only the orders are randomized.
+# Play on the same field again, only the orders are randomized.
 # Make sure Mongodb is enabled!
 
 llsfrb:
   game:
-    teams: [Carologistics]
-    crypto-keys:
-      Carologistics: randomkey
     # set to true to generate a random field at startup
     # disabling randomization requires mongodb to be enabled as the game
     # parameters are loaded from a mongodb game report in this case

--- a/cfg/game/load_game.yaml
+++ b/cfg/game/load_game.yaml
@@ -6,9 +6,6 @@
 
 llsfrb:
   game:
-    teams: [Carologistics]
-    crypto-keys:
-      Carologistics: randomkey
     # set to true to generate a random field at startup
     # disabling randomization requires mongodb to be enabled as the game
     # parameters are loaded from a mongodb game report in this case

--- a/cfg/simulation/default_simulation.yaml
+++ b/cfg/simulation/default_simulation.yaml
@@ -13,22 +13,6 @@ llsfrb:
     # unobservable state changes.
     speedup: 1.0
 
-    # Disable in case machine feedback from the slides is unavailable (e.g.,
-    # if one ring station is unresponsive)
-    #
-    # Slide counters of ring stations listed here will increment the slide
-    # counter whenever a payment is due.
-    #
-    # This also implicates for all listed machines that:
-    #   1. Rings can be mounted without payment and the refbox awards additional
-    #      points as if the payment was actually made
-    #   2. Points for payments are only given, if they are used afterwards.
-    #
-    # To register a machine for this behavior, enter its full mane, e.g., to
-    # add all ring stations simply use:
-    # disable-base-payment-check: [C-RS1, C-RS2, M-RS1, M-RS2]
-    disable-base-payment-check: []
-
     # synchronize refbox time with the time of a simulation
     time-sync:
       enable: true

--- a/cfg/simulation/fast_simulation.yaml
+++ b/cfg/simulation/fast_simulation.yaml
@@ -13,22 +13,6 @@ llsfrb:
     # unobservable state changes.
     speedup: 4.0
 
-    # Disable in case machine feedback from the slides is unavailable (e.g.,
-    # if one ring station is unresponsive)
-    #
-    # Slide counters of ring stations listed here will increment the slide
-    # counter whenever a payment is due.
-    #
-    # This also implicates for all listed machines that:
-    #   1. Rings can be mounted without payment and the refbox awards additional
-    #      points as if the payment was actually made
-    #   2. Points for payments are only given, if they are used afterwards.
-    #
-    # To register a machine for this behavior, enter its full mane, e.g., to
-    # add all ring stations simply use:
-    # disable-base-payment-check: [C-RS1, C-RS2, M-RS1, M-RS2]
-    disable-base-payment-check: [C-RS1, C-RS2, M-RS1, M-RS2]
-
     # synchronize refbox time with the time of a simulation
     time-sync:
       enable: false

--- a/cfg/simulation/gazebo_simulation.yaml
+++ b/cfg/simulation/gazebo_simulation.yaml
@@ -13,22 +13,6 @@ llsfrb:
     # unobservable state changes.
     speedup: 1.0
 
-    # Disable in case machine feedback from the slides is unavailable (e.g.,
-    # if one ring station is unresponsive)
-    #
-    # Slide counters of ring stations listed here will increment the slide
-    # counter whenever a payment is due.
-    #
-    # This also implicates for all listed machines that:
-    #   1. Rings can be mounted without payment and the refbox awards additional
-    #      points as if the payment was actually made
-    #   2. Points for payments are only given, if they are used afterwards.
-    #
-    # To register a machine for this behavior, enter its full mane, e.g., to
-    # add all ring stations simply use:
-    # disable-base-payment-check: [C-RS1, C-RS2, M-RS1, M-RS2]
-    disable-base-payment-check: []
-
     # synchronize refbox time with the time of a simulation
     time-sync:
       enable: true

--- a/cfg/team/default_team.yaml
+++ b/cfg/team/default_team.yaml
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+---
+# Start a fresh game per default.
+
+llsfrb:
+  game:
+    teams: [Carologistics]
+    crypto-keys:
+      Carologistics: randomkey

--- a/etc/scripts/challenge_startup.bash
+++ b/etc/scripts/challenge_startup.bash
@@ -35,6 +35,11 @@ Exactly one of the following options is required:
    --production [c0|c1|c2|c3]      Production Challenge (sets --cfg-challenges)
    --navigation                    Navigation challenge (sets --cfg-challenges)
    --exploration                   Exploration challenge (sets --cfg-challenges)
+   --grasping                      Grasping challenge
+                                   (sets --cfg-challenges and --cfg-game)
+                                   Make sure that
+                                   benchmarks/grasping_challenge.gz is
+                                   loaded to your mongodb instance
 
 Additional tweaking:
    --ground-truth                  Send Ground Truth
@@ -53,13 +58,14 @@ $LLSF_REFBOX_DIR/bin/./llsf-refbox -h
 }
 
 PACK_RESULTS=
+GAME_CFG=
 CHALLENGE_OPT=" --cfg-challenges "
 MPS_CFG=" --cfg-mps mps/mockup_mps.yaml "
 CHALLENGE_FILE=
 CHALLENGE_SUFFIX=
 CHALLENGE_FOLDER=
 MONGODB_CFG=" --cfg-mongodb mongodb/enable_mongodb.yaml"
-OPTS=$(getopt -o "h" -l "production:,ground-truth,navigation,exploration,difficulty:,team:,pack-results" -- "$@")
+OPTS=$(getopt -o "h" -l "production:,ground-truth,navigation,exploration,grasping,difficulty:,pack-results" -- "$@")
 
 if [ -z "$LLSF_REFBOX_DIR" ]; then
 	echo "LLSF_REFBOX_DIR not set, abort"
@@ -125,6 +131,16 @@ while true; do
 			fi
 			CHALLENGE_FILE="nav"
 			CHALLENGE_FOLDER="challenges/nav/"
+			;;
+		--grasping)
+			if [ -n "$CHALLENGE_FILE" ]; then
+				echo "Can only use one challenge at a time!"
+				exit
+			fi
+			CHALLENGE_FILE="grasping"
+			CHALLENGE_FOLDER="challenges/grasping/"
+			GAME_CFG=" --cfg-game challenges/grasping/grasping_game.yaml "
+			CHALLENGE_SUFFIX=".yaml"
 			;;
 		--difficulty)
 			case $OPTARG in
@@ -194,4 +210,4 @@ fi
 
 $LLSF_REFBOX_DIR/bin/./llsf-refbox $CHALLENGE_OPT \
 	$CHALLENGE_FOLDER$CHALLENGE_FILE$CHALLENGE_SUFFIX \
-	$MONGODB_CFG $MPS_CFG $@
+	$MONGODB_CFG $MPS_CFG $GAME_CFG $@

--- a/etc/scripts/challenge_startup.bash
+++ b/etc/scripts/challenge_startup.bash
@@ -61,12 +61,18 @@ CHALLENGE_FOLDER=
 MONGODB_CFG=" --cfg-mongodb mongodb/enable_mongodb.yaml"
 OPTS=$(getopt -o "h" -l "production:,ground-truth,navigation,exploration,difficulty:,team:,pack-results" -- "$@")
 
+if [ -z "$LLSF_REFBOX_DIR" ]; then
+	echo "LLSF_REFBOX_DIR not set, abort"
+	exit
+fi
+
 if [ $? != 0 ]
 then
 	echo "Failed to parse parameters"
 	usage
 	exit 1
 fi
+
 eval set -- "$OPTS"
 while true; do
 	OPTION=$1

--- a/etc/scripts/challenge_startup.bash
+++ b/etc/scripts/challenge_startup.bash
@@ -49,6 +49,7 @@ Additional tweaking:
 Any refbox option set via this wrapper script can be overridden
 using <refbox-options>, if necessary.
 EOF
+$LLSF_REFBOX_DIR/bin/./llsf-refbox -h
 }
 
 PACK_RESULTS=
@@ -73,7 +74,6 @@ while true; do
 	case $OPTION in
 		-h)
 			usage
-			$LLSF_REFBOX_DIR/bin/./llsf-refbox -h
 			exit 1
 			;;
 		--production)

--- a/etc/scripts/challenge_startup.bash
+++ b/etc/scripts/challenge_startup.bash
@@ -47,7 +47,6 @@ Additional tweaking:
    --difficulty [easy|medium|hard]
                                    (ignored, unless --navigation or
                                     --exploration is used)
-   --team <team-name>              Add team to RefBox config (sets --cfg-custom)
    --pack-results                  Pack the logfiles and mongodb game report
                                    to an archive
 
@@ -162,12 +161,6 @@ while true; do
 		--ground-truth)
 			CHALLENGE_FOLDER="challenges/prod_no_gt/"
 		;;
-		--team)
-			printf '%s\n%s\n%s\n%s\n%s\n' '%YAML 1.2' '---' \
-				'# Generated File, do not edit!' '---' \
-				"llsfrb/game/teams: [$OPTARG]" > $LLSF_REFBOX_DIR/cfg/team_generated.yaml
-			CUSTOM_CFG=" --cfg-custom team_generated.yaml "
-			;;
 		--pack-results)
 			PACK_RESULTS=1
 			;;

--- a/src/games/rcll/challenges.clp
+++ b/src/games/rcll/challenges.clp
@@ -18,7 +18,7 @@
 	?*PRIORITY_CHALLENGE_OVERRIDE* = 100
 	?*FIELD-WIDTH*  = (config-get-int "/llsfrb/challenges/field/width")
 	?*FIELD-HEIGHT* = (config-get-int "/llsfrb/challenges/field/height")
-	?*VISIT-ZOME-DURATION* = (config-get-int "/llsfrb/challenges/publish-routes/pause-duration")
+	?*VISIT-ZONE-DURATION* = (config-get-int "/llsfrb/challenges/publish-routes/pause-duration")
 )
 (deftemplate challenges-field
 	(multislot free-zones (type SYMBOL))
@@ -376,7 +376,7 @@
 	?route <- (challenges-route (team-color ?col) (id ?r-id)
 	  (remaining $?remaining) (reached $?reached))
 	?zv <- (challenges-zone-visit (team-color ?col) (route-id ?r-id)
-	  (visit-start ?start&:(> (- ?gt ?start) ?*VISIT-ZOME-DURATION*))
+	  (visit-start ?start&:(> (- ?gt ?start) ?*VISIT-ZONE-DURATION*))
 	  (visited-zone ?zone))
 
 =>

--- a/src/games/rcll/config.clp
+++ b/src/games/rcll/config.clp
@@ -16,23 +16,14 @@
 )
 
 (defrule config-print-disabled-slide-counter-checks
-  (confval (path "/llsfrb/simulation/disable-base-payment-check")
-					 (is-list TRUE) (list-value $?disabled-machines))
+	(machine (name ?n) (mtype RS))
+	(confval (path ?p&:(eq ?p (str-cat"/llsfrb/mps/stations/" ?n "/connection")))
+	         (type STRING) (is-list FALSE) (value "mockup"))
+	(not (disabled-slide-printed ?n))
 	=>
-  (do-for-all-facts ((?m machine))
-      (and (eq ?m:mtype RS)
-					 (member$ (str-cat ?m:name) ?disabled-machines))
-    (printout warn "Slide counter check for "
-                   (str-cat ?m:name) " disabled, by config" crlf))
-)
-
-(defrule config-print-invalid-slide-counter-check-option
-  (confval (path "/llsfrb/simulation/disable-base-payment-check")
-					 (is-list TRUE) (list-value $? ?m $?))
-	(not (machine (name ?machine&:(eq ?machine (sym-cat ?m))) (mtype RS)))
-	=>
-  (printout warn "Disabling of slide counter check on machine " ?m " failed. "
-                 "Reason: " ?m " is not a ring station" crlf)
+  (printout warn "Slide counter check for "
+                 ?n " disabled, as it is using mockup mode" crlf)
+	(assert (disabled-slide-printed ?n))
 )
 
 ;(defrule print-confval

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -442,9 +442,9 @@
     (modify ?machine (desired-lights RED-BLINK))
   )
   (do-for-all-facts ((?cfg confval) (?m machine))
-      (and (eq ?cfg:path "/llsfrb/simulation/disable-base-payment-check")
-					 (eq ?m:mtype RS)
-					 (member$ (str-cat ?m:name) ?cfg:list-value))
+      (and (eq ?m:mtype RS)
+           (eq ?cfg:path (str-cat "/llsfrb/mps/stations/" ?m:name "/connection"))
+           (eq ?cfg:value "mockup"))
     (printout warn "Please add points for remaining bases in slide of "
                    (str-cat ?m:name) " manually." crlf))
   (if (any-factp ((?pd referee-confirmation)) TRUE) then

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -319,10 +319,10 @@
 		 else
 			(printout error "Specified game report does not contain field " ?facts crlf)
 		)
+		(bson-destroy ?t-doc)
 	 else
 		(printout error "Empty result in mongoDB from game_report" crlf)
 	)
-	(bson-destroy ?t-doc)
 	(mongodb-cursor-destroy ?t-cursor)
 	(bson-builder-destroy ?t-query)
 	(bson-builder-destroy ?t-sort)

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -364,9 +364,8 @@
 		 (rs-ring-color ?ring-color) (bases-added ?ba) (bases-used ?bu))
   (ring-spec (color ?ring-color)
 	     (req-bases ?req-bases&:(> ?req-bases (- ?ba ?bu))))
-	(confval (path "/llsfrb/simulation/disable-base-payment-check")
-				(type STRING) (is-list TRUE)
-				(list-value $?disabled&:(not (member$ (str-cat ?n) ?disabled))))
+	(confval (path ?p&:(eq ?p (str-cat"/llsfrb/mps/stations/" ?n "/connection")))
+	         (type STRING) (is-list FALSE) (value ~"mockup"))
   =>
   (modify ?m (state BROKEN)
 	  (broken-reason (str-cat ?n ": insufficient bases ("
@@ -385,9 +384,8 @@
   (ring-spec (color ?ring-color)
 	     (req-bases ?req-bases&:(> ?req-bases (- ?ba ?bu))))
   (not (mps-status-feedback ?n SLIDE-COUNTER ?))
-	(confval (path "/llsfrb/simulation/disable-base-payment-check")
-			(type STRING) (is-list TRUE)
-			(list-value $?disabled&:(member$ (str-cat ?n) ?disabled)))
+	(confval (path ?p&:(eq ?p (str-cat"/llsfrb/mps/stations/" ?n "/connection")))
+	         (type STRING) (is-list FALSE) (value "mockup"))
 	(not (mps-add-base-on-slide ?n))
   =>
   (printout warn "Simulating "(str-cat ?n) " base payment feedback. "

--- a/src/libs/mps_comm/machine_factory.cpp
+++ b/src/libs/mps_comm/machine_factory.cpp
@@ -30,6 +30,8 @@
 
 namespace llsfrb {
 namespace mps_comm {
+MachineFactory::MachineFactory(std::shared_ptr<Configuration> config) : config_(config){};
+
 std::unique_ptr<Machine>
 MachineFactory::create_machine(const std::string &name,
                                const std::string &type,
@@ -73,16 +75,17 @@ MachineFactory::create_machine(const std::string &name,
 #endif
 #ifdef HAVE_MOCKUP
 	if (connection_mode == "mockup") {
+		float exec_speed = config_->get_float_or_default("llsfrb/simulation/speedup", 1);
 		if (type == "BS") {
-			return std::make_unique<MockupBaseStation>(name);
+			return std::make_unique<MockupBaseStation>(name, exec_speed);
 		} else if (type == "CS") {
-			return std::make_unique<MockupCapStation>(name);
+			return std::make_unique<MockupCapStation>(name, exec_speed);
 		} else if (type == "DS") {
-			return std::make_unique<MockupDeliveryStation>(name);
+			return std::make_unique<MockupDeliveryStation>(name, exec_speed);
 		} else if (type == "RS") {
-			return std::make_unique<MockupRingStation>(name);
+			return std::make_unique<MockupRingStation>(name, exec_speed);
 		} else if (type == "SS") {
-			return std::make_unique<MockupStorageStation>(name);
+			return std::make_unique<MockupStorageStation>(name, exec_speed);
 		} else {
 			throw fawkes::Exception(
 			  "Unexpected machine type '%s' for machine '%s' and connection mode '%s'",

--- a/src/libs/mps_comm/machine_factory.h
+++ b/src/libs/mps_comm/machine_factory.h
@@ -22,6 +22,8 @@
 
 #include "machine.h"
 
+#include <config/yaml.h>
+
 #include <memory>
 #include <string>
 
@@ -30,13 +32,18 @@ namespace mps_comm {
 class MachineFactory
 {
 public:
-	MachineFactory() = default;
+	MachineFactory(std::shared_ptr<Configuration> config);
+
 	std::unique_ptr<Machine> create_machine(const std::string &name,
 	                                        const std::string &type,
 	                                        const std::string &ip,
 	                                        unsigned int       port,
 	                                        const std::string &log_path        = "",
 	                                        const std::string &connection_mode = "plc");
+
+private:
+	std::shared_ptr<Configuration> config_;
 };
+
 } // namespace mps_comm
 } // namespace llsfrb

--- a/src/libs/mps_comm/mockup/base_station.cpp
+++ b/src/libs/mps_comm/mockup/base_station.cpp
@@ -24,7 +24,8 @@
 
 namespace llsfrb {
 namespace mps_comm {
-MockupBaseStation::MockupBaseStation(const std::string &name) : Machine(name)
+MockupBaseStation::MockupBaseStation(const std::string &name, float exec_speed)
+: MockupMachine(name, exec_speed)
 {
 }
 

--- a/src/libs/mps_comm/mockup/base_station.h
+++ b/src/libs/mps_comm/mockup/base_station.h
@@ -28,7 +28,7 @@ namespace mps_comm {
 class MockupBaseStation : public virtual MockupMachine, public virtual BaseStation
 {
 public:
-	MockupBaseStation(const std::string &name);
+	MockupBaseStation(const std::string &name, float exec_time);
 	void get_base(llsf_msgs::BaseColor slot) override;
 	void identify() override{};
 };

--- a/src/libs/mps_comm/mockup/cap_station.cpp
+++ b/src/libs/mps_comm/mockup/cap_station.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *  cap_station.cpp - 
+ *  cap_station.cpp -
  *
  *  Created: Sat 01 Feb 2020 17:57:56 CET 17:57
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
@@ -25,7 +25,8 @@
 namespace llsfrb {
 namespace mps_comm {
 
-MockupCapStation::MockupCapStation(const std::string &name) : Machine(name)
+MockupCapStation::MockupCapStation(const std::string &name, float exec_speed)
+: MockupMachine(name, exec_speed)
 {
 }
 

--- a/src/libs/mps_comm/mockup/cap_station.h
+++ b/src/libs/mps_comm/mockup/cap_station.h
@@ -28,7 +28,7 @@ namespace mps_comm {
 class MockupCapStation : public virtual MockupMachine, public virtual CapStation
 {
 public:
-	MockupCapStation(const std::string &name);
+	MockupCapStation(const std::string &name, float exec_speed);
 	void retrieve_cap() override;
 	void mount_cap() override;
 	void identify() override{};

--- a/src/libs/mps_comm/mockup/delivery_station.cpp
+++ b/src/libs/mps_comm/mockup/delivery_station.cpp
@@ -27,7 +27,8 @@
 namespace llsfrb {
 namespace mps_comm {
 
-MockupDeliveryStation::MockupDeliveryStation(const std::string &name) : Machine(name)
+MockupDeliveryStation::MockupDeliveryStation(const std::string &name, float exec_speed)
+: MockupMachine(name, exec_speed)
 {
 }
 

--- a/src/libs/mps_comm/mockup/delivery_station.h
+++ b/src/libs/mps_comm/mockup/delivery_station.h
@@ -29,7 +29,7 @@ namespace mps_comm {
 class MockupDeliveryStation : public virtual MockupMachine, public virtual DeliveryStation
 {
 public:
-	MockupDeliveryStation(const std::string &name);
+	MockupDeliveryStation(const std::string &name, float exec_speed);
 	void deliver_product(int slot) override;
 	void identify() override{};
 };

--- a/src/libs/mps_comm/mockup/machine.cpp
+++ b/src/libs/mps_comm/mockup/machine.cpp
@@ -30,11 +30,9 @@
 namespace llsfrb {
 namespace mps_comm {
 
-MockupMachine::MockupMachine() : shutdown_(false)
+MockupMachine::MockupMachine(const std::string &name, float exec_speed)
+: Machine(name), exec_speed_(exec_speed), shutdown_(false)
 {
-	Configuration *config = new YamlConfiguration(CONFDIR);
-	config->load("config_generated.yaml");
-	exec_speed_    = config->get_float_or_default("llsfrb/simulation/speedup", 1);
 	worker_thread_ = std::thread(&MockupMachine::queue_worker, this);
 }
 

--- a/src/libs/mps_comm/mockup/machine.h
+++ b/src/libs/mps_comm/mockup/machine.h
@@ -33,7 +33,7 @@ namespace mps_comm {
 class MockupMachine : public virtual Machine
 {
 public:
-	MockupMachine();
+	MockupMachine(const std::string &name, float exec_speed);
 	~MockupMachine() override;
 	void         set_light(llsf_msgs::LightColor color,
 	                       llsf_msgs::LightState state = llsf_msgs::ON,

--- a/src/libs/mps_comm/mockup/ring_station.cpp
+++ b/src/libs/mps_comm/mockup/ring_station.cpp
@@ -27,7 +27,8 @@
 namespace llsfrb {
 namespace mps_comm {
 
-MockupRingStation::MockupRingStation(const std::string &name) : Machine(name)
+MockupRingStation::MockupRingStation(const std::string &name, float exec_speed)
+: MockupMachine(name, exec_speed)
 {
 }
 

--- a/src/libs/mps_comm/mockup/ring_station.h
+++ b/src/libs/mps_comm/mockup/ring_station.h
@@ -29,7 +29,7 @@ namespace mps_comm {
 class MockupRingStation : public virtual MockupMachine, public virtual RingStation
 {
 public:
-	MockupRingStation(const std::string &name);
+	MockupRingStation(const std::string &name, float exec_speed);
 	void mount_ring(unsigned int, llsf_msgs::RingColor) override;
 	void register_slide_callback(std::function<void(unsigned int)> callback) override{};
 	void identify() override{};

--- a/src/libs/mps_comm/mockup/storage_station.cpp
+++ b/src/libs/mps_comm/mockup/storage_station.cpp
@@ -27,7 +27,8 @@
 namespace llsfrb {
 namespace mps_comm {
 
-MockupStorageStation::MockupStorageStation(const std::string &name) : Machine(name)
+MockupStorageStation::MockupStorageStation(const std::string &name, float exec_speed)
+: MockupMachine(name, exec_speed)
 {
 }
 

--- a/src/libs/mps_comm/mockup/storage_station.h
+++ b/src/libs/mps_comm/mockup/storage_station.h
@@ -29,7 +29,7 @@ namespace mps_comm {
 class MockupStorageStation : public virtual MockupMachine, public virtual StorageStation
 {
 public:
-	MockupStorageStation(const std::string &name);
+	MockupStorageStation(const std::string &name, float exec_speed);
 	void retrieve(unsigned int shelf, unsigned int slot) override;
 	void store(unsigned int shelf, unsigned int slot) override;
 	void relocate(unsigned int shelf,

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -275,7 +275,7 @@ LLSFRefBox::LLSFRefBox(int argc, char **argv)
 							log_path += "/" + log_suffix;
 						}
 
-						MachineFactory mps_factory;
+						MachineFactory mps_factory(config_);
 						auto           mps = mps_factory.create_machine(
               cfg_name, mpstype, mpsip, port, log_path, connection_string);
 						mps->register_ready_callback([this, cfg_name](bool ready) {
@@ -547,7 +547,7 @@ LLSFRefBox::read_config(int argc, char **argv)
 include:
 )delimiter";
 	}
-	config_ = std::make_unique<YamlConfiguration>(CONFDIR);
+	config_ = std::make_shared<YamlConfiguration>(CONFDIR);
 	for (const auto &std_val : cfg_files_to_include) {
 		if (dump_cfg) {
 			generated_cfg_file << " - " << std_val.second.c_str() << "\n";

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -487,8 +487,9 @@ LLSFRefBox::read_config(int argc, char **argv)
 	// Add custom command line options here
 	std::vector<option> static_options = {{"no-default-cfg", 0, 0, 0},
 	                                      {"cfg-custom", 1, 0, 0},
-	                                      {0, 0, 0, 0}}; // required last option
-	option              options[cfg_files_to_include.size() + static_options.size() + 1];
+	                                      {"dump-cfg", 0, 0, 0},
+	                                      {0, 0, 0, 0}}; // null terminate options
+	option              options[cfg_files_to_include.size() + static_options.size()];
 	// Prepare ArgumentParser
 	for (size_t i = 0; i < gen_options_str.size(); i++) {
 		options[i] = generated_options[i];

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -481,6 +481,8 @@ LLSFRefBox::read_config(int argc, char **argv)
 	for (size_t i = 0; i < gen_options_str.size(); i++) {
 		generated_options[i].name    = gen_options_str[i].c_str();
 		generated_options[i].has_arg = 1;
+		generated_options[i].flag    = 0;
+		generated_options[i].val     = 0;
 	}
 	// Add custom command line options here
 	std::vector<option> static_options = {{"no-default-cfg", 0, 0, 0},

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -151,6 +151,8 @@ private: // methods
 	CLIPS::Values clips_bson_get_time(void *bson, std::string field_name);
 #endif
 
+	void clips_print_fact_list(CLIPS::Values facts, CLIPS::Values fields);
+
 	void clips_mps_move_conveyor(std::string machine,
 	                             std::string goal_position,
 	                             std::string conveyor_direction = "FORWARD");

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -206,7 +206,7 @@ private: // methods
 #endif
 
 private: // members
-	std::unique_ptr<Configuration>                          config_;
+	std::shared_ptr<Configuration>                          config_;
 	std::unique_ptr<MultiLogger>                            logger_;
 	std::unique_ptr<MultiLogger>                            clips_logger_;
 	Logger::LogLevel                                        log_level_;


### PR DESCRIPTION
After intensely testing the changes in https://github.com/robocup-logistics/rcll-refbox/pull/109 some bugs were found which are addressed.

This PR also changes the following.
 - remove config `disable-base-payment-check`, instead use the mps connection mode to determine whether slide payments are mocked up
 - pass configuration to machine factory so that it does not need to rely on a dumped config
 - add configuration to pack all current logs so that they can be easily submitted without the need to manually collect logfiles and mongodumps
 - pass remaining command line options of challenge startup helper to refbox (after ` -- `), this allows to override anything if necessary
 - add grasping challenge option to challenge startup helper
 - add team-specific config option to refbox