### PR TITLE
combine exploration and production phase and support markerless gameplay

### DIFF
--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -196,7 +196,7 @@
 		(retract ?exp)
 	)
 	(do-for-all-facts ((?m machine))
-		(assert (exploration-report (name ?n) (rtype RECORD) (zone ?zone)
+		(assert (exploration-report (name ?m:name) (rtype RECORD) (zone ?zone)
 		                            (rotation ?rotation) (correctly-reported TRUE)))
 	)
 )

--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -187,9 +187,15 @@
 	                    (team ?team) (host ?from-host) (port ?from-port))
 	?er <- (exploration-report (rtype RECORD) (name ?name) (type ?type) (zone ?zone) (type-state ~WRONG_REPORT))
 	(not (machine (zone ?zone) (mtype ?type)))
+	(gamestate (phase ?phase))
 	=>
 	(modify ?er (type-state WRONG_REPORT))
-	(printout t "Wrong type report: " ?type " (zone " ?zone ") from " ?team "." crlf)
+	(printout t "Wrong partial report: " ?type " in zone " ?zone "). "
+	          "Awarding " ?*EXPLORATION-WRONG-REPORT-ZONE-POINTS* " points" crlf)
+	(assert (points (points ?*EXPLORATION-WRONG-REPORT-ZONE-POINTS*)
+	                (phase ?phase) (team ?team) (game-time ?game-time)
+	                (reason (str-cat "Wrong partial exploration report for type "
+	                        ?type ": zone = " ?zone "."))))
 )
 
 (defrule exploration-report-zone-correct

--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -1,143 +1,93 @@
-
 ;---------------------------------------------------------------------------
-;  exploration.clp - LLSF RefBox CLIPS exploration phase rules
+;  exploration.clp - LLSF RefBox CLIPS exploration report processing
 ;
 ;  Created: Thu Feb 07 19:31:12 2013
 ;  Copyright  2013  Tim Niemueller [www.niemueller.de]
 ;             2017  Tobias Neumann
+;             2022  Tarik Viehmann
 ;  Licensed under BSD license, cf. LICENSE file
 ;---------------------------------------------------------------------------
 
-(defrule exploration-start
-  (declare (salience ?*PRIORITY_HIGH*))
-  ?gf <- (gamestate (phase EXPLORATION) (prev-phase ~EXPLORATION))
-  =>
-  ; Set prev phase to avoid re-firing, reset game time
-  (modify ?gf (prev-phase EXPLORATION) (game-time 0.0))
-
-  ; Retract all existing reports for the new exploration phase
-  (delayed-do-for-all-facts ((?report exploration-report)) TRUE
-    (retract ?report)
-  )
-
-  ; Set lights
-  (delayed-do-for-all-facts ((?machine machine)) TRUE
-		(modify ?machine (desired-lights YELLOW-ON))
-  )
-
-  ;(assert (attention-message (text "Entering Exploration Phase")))
-)
-
-(defrule exploration-pause
-  ?gf <- (gamestate (phase EXPLORATION) (state PAUSED) (prev-state ~PAUSED))
-  =>
-  (modify ?gf (prev-state PAUSED))
-  (delayed-do-for-all-facts ((?machine machine)) TRUE
-    (modify ?machine (desired-lights))
-  )
-)
-
-(defrule exploration-continue
-  ?gf <- (gamestate (phase EXPLORATION) (state RUNNING) (prev-state ~RUNNING))
-  =>
-  (modify ?gf (prev-state RUNNING))
-  (delayed-do-for-all-facts ((?machine machine)) TRUE
-
-		(if (any-factp ((?er exploration-report)) (eq ?er:name ?machine:name))
-		 then
-		  (do-for-fact ((?er exploration-report)) (eq ?er:name ?machine:name)
-				(if (eq ?er:correctly-reported UNKNOWN)
-				 then
-					(modify ?machine (desired-lights YELLOW-ON))
-				 else
-					(modify ?machine (desired-lights (create$ (if ?er:correctly-reported then GREEN-BLINK else RED-BLINK))))
-				)
-			)
-		 else
-		  (modify ?machine (desired-lights YELLOW-ON))
-		)
-	)
-)
 
 (defrule exploration-report-incoming
-  ?gf <- (gamestate (phase EXPLORATION) (game-time ?game-time))
+	(gamestate (phase EXPLORATION|PRODUCTION) (game-time ?game-time))
   ?mf <- (protobuf-msg (type "llsf_msgs.MachineReport") (ptr ?p)
-		       (rcvd-from ?from-host ?from-port) (rcvd-via ?via))
-  =>
-  (retract ?mf)
-  (bind ?team (sym-cat (pb-field-value ?p "team_color")))
-  (foreach ?m (pb-field-list ?p "machines")
-    (bind ?name (sym-cat (pb-field-value ?m "name")))
-    (bind ?zone (if (pb-has-field ?m "zone") then (sym-cat (pb-field-value ?m "zone")) else NOT-REPORTED))
-    (bind ?rotation (if (pb-has-field ?m "rotation") then (pb-field-value ?m "rotation") else -1))
+	                     (rcvd-from ?from-host ?from-port) (rcvd-via ?via))
+	=>
+	(retract ?mf)
+	(bind ?team (sym-cat (pb-field-value ?p "team_color")))
+	(foreach ?m (pb-field-list ?p "machines")
+		(bind ?name (sym-cat (pb-field-value ?m "name")))
+		(bind ?zone (if (pb-has-field ?m "zone") then (sym-cat (pb-field-value ?m "zone")) else NOT-REPORTED))
+		(bind ?rotation (if (pb-has-field ?m "rotation") then (pb-field-value ?m "rotation") else -1))
 		(assert (exploration-report (rtype INCOMING)
-							(name ?name) (zone ?zone) (rotation ?rotation)
-							(game-time ?game-time)
-							(team ?team) (host ?from-host) (port ?from-port)))
-    (pb-destroy ?m)
+		                            (name ?name) (zone ?zone) (rotation ?rotation)
+		                            (game-time ?game-time)
+		                            (team ?team) (host ?from-host) (port ?from-port)))
+		(pb-destroy ?m)
 	)
 )
 
 (defrule exploration-report-incoming-cleanup
 	(declare (salience ?*PRIORITY_CLEANUP*))
 	?ei <- (exploration-report (rtype INCOMING))
-  =>
-  (retract ?ei)
+	=>
+	(retract ?ei)
 )
 
 (defrule exploration-report-new
 	(exploration-report (rtype INCOMING) (name ?name) (zone ?zone) (rotation ?rotation)
-											(game-time ?game-time)
-											(team ?team) (host ?from-host) (port ?from-port))
+	                    (game-time ?game-time)
+	                    (team ?team) (host ?from-host) (port ?from-port))
 	(not (exploration-report (rtype RECORD) (name ?name)))
 	=>
 	(assert (exploration-report (rtype RECORD)
-															(name ?name) (zone NOT-REPORTED) (rotation -1)
-															(game-time ?game-time)
-															(team ?team) (host ?from-host) (port ?from-port)))
+	                            (name ?name) (zone NOT-REPORTED) (rotation -1)
+	                            (game-time ?game-time)
+	                            (team ?team) (host ?from-host) (port ?from-port)))
 )
 
 (defrule exploration-report-rotation-correct
-  ; only triggers after zone-state is CORRECT_REPORT
+	; only triggers after zone-state is CORRECT_REPORT
 	(exploration-report (rtype INCOMING) (name ?name) (rotation ?rotation&~-1)
-											(game-time ?game-time)
-											(team ?team) (host ?from-host) (port ?from-port))
-  ?er <- (exploration-report (rtype RECORD) (name ?name) (zone-state CORRECT_REPORT) (rotation -1))
-	?mf <- (machine (name ?name) (team ?team) (rotation ?rotation))
+	                    (game-time ?game-time)
+	                    (team ?team) (host ?from-host) (port ?from-port))
+	?er <- (exploration-report (rtype RECORD) (name ?name)
+	                           (zone-state CORRECT_REPORT) (rotation -1))
+	(machine (name ?name) (team ?team) (rotation ?rotation))
 	=>
   (modify ?er (rotation ?rotation) (rotation-state CORRECT_REPORT))
 	(printout t "Correct partial report: " ?name " (rotation " ?rotation "). "
-						"Awarding " ?*EXPLORATION-CORRECT-REPORT-ROTATION-POINTS* " points" crlf)
+	            "Awarding " ?*EXPLORATION-CORRECT-REPORT-ROTATION-POINTS* " points" crlf)
 	(assert (points (points ?*EXPLORATION-CORRECT-REPORT-ROTATION-POINTS*)
-									(phase EXPLORATION) (team ?team) (game-time ?game-time)
-									(reason (str-cat "Correct partial exploration report for "
-																	 ?name ": rotation = " ?rotation))))
-  (modify ?mf (desired-lights GREEN-BLINK))
+	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (reason (str-cat "Correct partial exploration report for "
+	                                 ?name ": rotation = " ?rotation))))
 )
 
 (defrule exploration-report-rotation-wrong
-  ; only triggers after zone-state is CORRECT_REPORT
+	; only triggers after zone-state is CORRECT_REPORT
 	(exploration-report (rtype INCOMING) (name ?name) (rotation ?rotation&~-1)
-											(game-time ?game-time)
-											(team ?team) (host ?from-host) (port ?from-port))
-  ?er <- (exploration-report (rtype RECORD) (name ?name) (zone-state CORRECT_REPORT) (rotation -1))
+	                    (game-time ?game-time)
+	                    (team ?team) (host ?from-host) (port ?from-port))
+	?er <- (exploration-report (rtype RECORD) (name ?name)
+	                           (zone-state CORRECT_REPORT) (rotation -1))
 	?mf <- (machine (name ?name) (team ?team) (rotation ?erotation&~?rotation))
 	=>
-  (modify ?er (rotation ?rotation) (rotation-state WRONG_REPORT))
+	(modify ?er (rotation ?rotation) (rotation-state WRONG_REPORT))
 	(printout t "Wrong partial report: " ?name " (rotation " ?rotation "). "
-						"Awarding " ?*EXPLORATION-WRONG-REPORT-ROTATION-POINTS* " points" crlf)
+	          "Awarding " ?*EXPLORATION-WRONG-REPORT-ROTATION-POINTS* " points" crlf)
 	(assert (points (points ?*EXPLORATION-WRONG-REPORT-ROTATION-POINTS*)
-									(phase EXPLORATION) (team ?team) (game-time ?game-time)
-									(reason (str-cat "Wrong partial exploration report for "
-													 ?name ": rotation = " ?rotation " (should be " ?erotation ")"))))
-  (modify ?mf (desired-lights GREEN-ON RED-ON))
+	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (reason (str-cat "Wrong partial exploration report for "
+	                        ?name ": rotation = " ?rotation " (should be " ?erotation ")"))))
 )
 
 (defrule exploration-report-rotation-ignored
-  ; triggers when zone-state is WRONG_REPORT
+	; triggers when zone-state is WRONG_REPORT
 	(exploration-report (rtype INCOMING) (name ?name) (rotation ?rotation&~-1)
-											(game-time ?game-time)
-											(team ?team) (host ?from-host) (port ?from-port))
+	                    (game-time ?game-time)
+	                    (team ?team) (host ?from-host) (port ?from-port))
   ?er <- (exploration-report (rtype RECORD) (name ?name) (zone-state WRONG_REPORT) (rotation -1))
 	(machine (name ?name) (team ?team))
 	=>
@@ -147,165 +97,106 @@
 
 (defrule exploration-report-zone-correct
 	(exploration-report (rtype INCOMING) (name ?name) (zone ?zone&~NOT-REPORTED)
-											(game-time ?game-time)
-											(team ?team) (host ?from-host) (port ?from-port))
-  ?er <- (exploration-report (rtype RECORD) (name ?name) (zone NOT-REPORTED))
+	                    (game-time ?game-time)
+	                    (team ?team) (host ?from-host) (port ?from-port))
+	?er <- (exploration-report (rtype RECORD) (name ?name) (zone NOT-REPORTED))
 	?mf <- (machine (name ?name) (team ?team) (zone ?zone))
 	=>
-  (modify ?er (zone ?zone) (zone-state CORRECT_REPORT))
+	(modify ?er (zone ?zone) (zone-state CORRECT_REPORT))
 	(printout t "Correct partial report: " ?name " (zone " ?zone "). "
-						"Awarding " ?*EXPLORATION-CORRECT-REPORT-ZONE-POINTS* " points." crlf)
+	          "Awarding " ?*EXPLORATION-CORRECT-REPORT-ZONE-POINTS* " points." crlf)
 	(assert (points (points ?*EXPLORATION-CORRECT-REPORT-ZONE-POINTS*)
-									(phase EXPLORATION) (team ?team) (game-time ?game-time)
-									(reason (str-cat "Correct partial exploration report for "
-																	 ?name ": zone = " ?zone))))
-
-	(modify ?mf (desired-lights GREEN-ON))
+	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (reason (str-cat "Correct partial exploration report for "
+	                        ?name ": zone = " ?zone))))
 )
 
 (defrule exploration-report-zone-wrong
 	(exploration-report (rtype INCOMING) (name ?name) (zone ?zone&~NOT-REPORTED)
-											(game-time ?game-time)
-											(team ?team) (host ?from-host) (port ?from-port))
-  ?er <- (exploration-report (rtype RECORD) (name ?name) (zone NOT-REPORTED))
+	                    (game-time ?game-time)
+	                    (team ?team) (host ?from-host) (port ?from-port))
+	?er <- (exploration-report (rtype RECORD) (name ?name) (zone NOT-REPORTED))
 	?mf <- (machine (name ?name) (team ?team) (zone ?mzone&~?zone))
 	=>
-  (modify ?er (zone ?zone) (zone-state WRONG_REPORT))
+	(modify ?er (zone ?zone) (zone-state WRONG_REPORT))
 	(printout t "Wrong partial report: " ?name " (zone " ?zone "). "
-						"Awarding " ?*EXPLORATION-WRONG-REPORT-ZONE-POINTS* " points" crlf)
+	          "Awarding " ?*EXPLORATION-WRONG-REPORT-ZONE-POINTS* " points" crlf)
 	(assert (points (points ?*EXPLORATION-WRONG-REPORT-ZONE-POINTS*)
-									(phase EXPLORATION) (team ?team) (game-time ?game-time)
-									(reason (str-cat "Wrong partial exploration report for "
-																	 ?name ": zone = " ?zone " (should be " ?mzone ")"))))
-  (modify ?mf (desired-lights RED-BLINK))
+	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (reason (str-cat "Wrong partial exploration report for "
+	                        ?name ": zone = " ?zone " (should be " ?mzone ")"))))
 )
 
 (defrule exploration-report-complete-correct
-  ?er <- (exploration-report (rtype RECORD) (correctly-reported UNKNOWN)
-														 (name ?name) (zone ?zone&~NOT-REPORTED) (rotation ?rotation&~-1) )
+	?er <- (exploration-report (rtype RECORD) (correctly-reported UNKNOWN)
+	                           (name ?name) (zone ?zone&~NOT-REPORTED) (rotation ?rotation&~-1) )
 	?mf <- (machine (name ?name) (team ?team) (zone ?zone) (rotation ?rotation))
 	=>
-  (modify ?er (correctly-reported TRUE))
-;	(modify ?mf (desired-lights GREEN-BLINK))
+	(modify ?er (correctly-reported TRUE))
 )
 
 (defrule exploration-report-complete-zone-wrong
-  ?er <- (exploration-report (rtype RECORD) (correctly-reported UNKNOWN)
-														 (name ?name) (zone ?zone&~NOT-REPORTED))
+	?er <- (exploration-report (rtype RECORD) (correctly-reported UNKNOWN)
+	                           (name ?name) (zone ?zone&~NOT-REPORTED))
 	?mf <- (machine (name ?name))
 	(or
-	 (machine (name ?name) (team ?team) (zone ~?zone))
+		(machine (name ?name) (team ?team) (zone ~?zone))
 	)
 	=>
-  (modify ?er (correctly-reported FALSE))
-;	(modify ?mf (desired-lights RED-BLINK))
+	(modify ?er (correctly-reported FALSE))
 )
 
-; (defrule exploration-handle-report
-;   ?gf <- (gamestate (phase EXPLORATION) (game-time ?game-time))
-;   ?mf <- (protobuf-msg (type "llsf_msgs.MachineReport") (ptr ?p)
-; 		       (rcvd-from ?from-host ?from-port) (rcvd-via ?via))
-;   =>
-;   (retract ?mf)
-;   (bind ?team (sym-cat (pb-field-value ?p "team_color")))
-;   (foreach ?m (pb-field-list ?p "machines")
-;     (bind ?name (sym-cat (pb-field-value ?m "name")))
-;     (bind ?type (pb-field-value ?m "type"))
-;     (bind ?zone (sym-cat (pb-field-value ?m "zone")))
-;     (if (member$ ?name (deftemplate-slot-allowed-values exploration-report name))
-;     then
-;       (do-for-fact ((?machine machine)) (eq ?machine:name ?name)
-;         (if (neq (sym-cat ?machine:team) ?team)
-; 				 then
-;           (if (not (any-factp ((?report exploration-report))
-; 			      (and (eq ?report:name ?name) (eq ?report:team ?team))))
-; 					 then
-; 					  (printout t "Invalid report: " ?name " of type " ?type " from other team." crlf)
-;              ; "Awarding " ?*EXPLORATION-INVALID-REPORT-POINTS* " points" crlf)
-; 	           ; (assert (points (points ?*EXPLORATION-INVALID-REPORT-POINTS*)
-; 	           ; 		    (phase EXPLORATION) (team ?team) (game-time ?game-time)
-; 	           ; 		    (reason (str-cat "Report for machine of other team"
-; 	           ; 				     ?name "|" ?type))))
-; 	           ; (assert (exploration-report (name ?name) (team ?team) (type ?type)
-; 	           ; 				(game-time ?game-time) (correctly-reported FALSE)
-; 	           ; 				(host ?from-host) (port ?from-port)))
-; 	           ; (modify ?machine (desired-lights RED-BLINK YELLOW-BLINK))
-; 					  )
-; 	         else
-;             ; If it has not been reported, yet
-;             (if (not (any-factp ((?report exploration-report))
-; 			        (and (eq ?report:name ?name) (eq ?report:team ?team))))
-; 	           then
-; 	             (printout t "Comparing T " ?machine:exploration-type " " ?type "  Z " ?machine:zone " " ?zone crlf)
-;                (if (and (eq ?machine:exploration-type ?type) (eq ?machine:zone ?zone))
-;                 then ; correct report
-; 	               (printout t "Correct report: " ?name " (type " ?type ") in zone " ?zone ". "
-; 			              "Awarding " ?*EXPLORATION-CORRECT-REPORT-POINTS* " points" crlf)
-; 	               (assert (points (points ?*EXPLORATION-CORRECT-REPORT-POINTS*)
-; 			      (phase EXPLORATION) (team ?team) (game-time ?game-time)
-; 			      (reason (str-cat "Correct exploration report for "
-; 					       ?name "|" ?type))))
-; 	      (assert (exploration-report (name ?name) (type ?type) (zone ?zone)
-; 					  (game-time ?game-time) (correctly-reported TRUE)
-; 					  (team ?team) (host ?from-host) (port ?from-port)))
-; 	      (modify ?machine (desired-lights GREEN-BLINK))
-;             else ; wrong report
-; 	      (printout t "Wrong report: " ?name " (type " ?type ") in zone " ?zone ". "
-; 			"Penalizing with " ?*EXPLORATION-WRONG-REPORT-POINTS* " points" crlf)
-; 	      (assert (points (points ?*EXPLORATION-WRONG-REPORT-POINTS*)
-; 			      (phase EXPLORATION) (team ?team) (game-time ?game-time)
-; 			      (reason (str-cat "Wrong exploration report for "
-; 					       ?name "|" ?type))))
-; 	      (assert (exploration-report (name ?name) (type ?type) (zone ?zone)
-; 					  (game-time ?game-time) (correctly-reported FALSE)
-; 					  (team ?team) (host ?from-host) (port ?from-port)))
-; 	      (modify ?machine (desired-lights RED-BLINK))
-; 	    )
-;           )
-;         )
-;       )
-;     )
-;     (pb-destroy ?m)
-;   )
-; )
-
 (defrule exploration-cleanup-report
-  (gamestate (phase ~EXPLORATION))
-  ?mf <- (protobuf-msg (type "llsf_msgs.MachineReport") (ptr ?p)
-		       (rcvd-from ?from-host ?from-port) (rcvd-via ?via))
-  =>
-  (retract ?mf)
+	(gamestate (phase ~EXPLORATION))
+	?mf <- (protobuf-msg (type "llsf_msgs.MachineReport") (ptr ?p)
+	       (rcvd-from ?from-host ?from-port) (rcvd-via ?via))
+	=>
+	(retract ?mf)
 )
 
 (defrule exploration-send-MachineReportInfo
-  (time $?now)
-  (gamestate (phase EXPLORATION))
-  ?sf <- (signal (type machine-report-info)
-		 (time $?t&:(timeout ?now ?t ?*BC-MACHINE-REPORT-INFO-PERIOD*)) (seq ?seq))
-  (network-peer (group CYAN) (id ?peer-id-cyan))
-  (network-peer (group MAGENTA) (id ?peer-id-magenta))
-  =>
-  (modify ?sf (time ?now) (seq (+ ?seq 1)))
+	(time $?now)
+	(gamestate (phase EXPLORATION|PRODUCTION) (game-time ?game-time&:(< ?game-time ?*EXPLORATION-TIME)))
+	?sf <- (signal (type machine-report-info)
+	       (time $?t&:(timeout ?now ?t ?*BC-MACHINE-REPORT-INFO-PERIOD*)) (seq ?seq))
+	(network-peer (group CYAN) (id ?peer-id-cyan))
+	(network-peer (group MAGENTA) (id ?peer-id-magenta))
+	=>
+	(modify ?sf (time ?now) (seq (+ ?seq 1)))
 
-  ; CYAN
-  (bind ?s (pb-create "llsf_msgs.MachineReportInfo"))
+	; CYAN
+	(bind ?s (pb-create "llsf_msgs.MachineReportInfo"))
 
-  (pb-set-field ?s "team_color" CYAN)
-  (do-for-all-facts ((?report exploration-report)) (and (eq ?report:team CYAN) (eq ?report:rtype RECORD))
-    (pb-add-list ?s "reported_machines" ?report:name)
-  )
+	(pb-set-field ?s "team_color" CYAN)
+	(do-for-all-facts ((?report exploration-report)) (and (eq ?report:team CYAN) (eq ?report:rtype RECORD))
+		(pb-add-list ?s "reported_machines" ?report:name)
+	)
 
-  (pb-broadcast ?peer-id-cyan ?s)
-  (pb-destroy ?s)
+	(pb-broadcast ?peer-id-cyan ?s)
+	(pb-destroy ?s)
 
-  ; MAGENTA
-  (bind ?s (pb-create "llsf_msgs.MachineReportInfo"))
+	; MAGENTA
+	(bind ?s (pb-create "llsf_msgs.MachineReportInfo"))
 
-  (pb-set-field ?s "team_color" MAGENTA)
-  (do-for-all-facts ((?report exploration-report)) (and (eq ?report:team MAGENTA) (eq ?report:rtype RECORD))
-    (pb-add-list ?s "reported_machines" ?report:name)
-  )
+	(pb-set-field ?s "team_color" MAGENTA)
+	(do-for-all-facts ((?report exploration-report)) (and (eq ?report:team MAGENTA) (eq ?report:rtype RECORD))
+		(pb-add-list ?s "reported_machines" ?report:name)
+	)
 
-  (pb-broadcast ?peer-id-magenta ?s)
-  (pb-destroy ?s)
+	(pb-broadcast ?peer-id-magenta ?s)
+	(pb-destroy ?s)
+)
+
+(defrule exploration-set-ground-truth
+	(machine (name ?n) (team ?team) (rotation ?rotation) (zone ?zone))
+	(not (exploration-report (name ?n) (rtype RECORD) (correctly-reported TRUE)))
+	(gamestate (phase PRODUCTION) (game-time ?game-time&:(>= ?game-time ?*EXPLORATION-TIME)))
+	=>
+	(do-for-all-facts ((?exp exploration-report))
+		(retract ?exp)
+	)
+	(do-for-all-facts ((?m machine))
+		(assert (exploration-report (name ?n) (rtype RECORD) (zone ?zone)
+		                            (rotation ?rotation) (correctly-reported TRUE)))
+	)
 )

--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -177,7 +177,6 @@
 	?er <- (exploration-report (rtype RECORD) (type ?type) (zone ?zone) (team ?team) (type-state ~CORRECT_REPORT))
 	?mf <- (machine (name ?name) (team ?m-team) (zone ?zone) (mtype ?type))
 	=>
-	; % TODO: ignore if prior wrong reports are inbound
 	(modify ?er (type-state CORRECT_REPORT))
 	(printout t "Correct type report: " ?type " (zone " ?zone ") from " ?team " is machine " ?name "." crlf)
 )

--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -156,7 +156,7 @@
 
 (defrule exploration-send-MachineReportInfo
 	(time $?now)
-	(gamestate (phase EXPLORATION|PRODUCTION) (game-time ?game-time&:(< ?game-time ?*EXPLORATION-TIME)))
+	(gamestate (phase EXPLORATION|PRODUCTION) (game-time ?game-time&:(< ?game-time ?*EXPLORATION-TIME*)))
 	?sf <- (signal (type machine-report-info)
 	       (time $?t&:(timeout ?now ?t ?*BC-MACHINE-REPORT-INFO-PERIOD*)) (seq ?seq))
 	(network-peer (group CYAN) (id ?peer-id-cyan))
@@ -190,7 +190,7 @@
 (defrule exploration-set-ground-truth
 	(machine (name ?n) (team ?team) (rotation ?rotation) (zone ?zone))
 	(not (exploration-report (name ?n) (rtype RECORD) (correctly-reported TRUE)))
-	(gamestate (phase PRODUCTION) (game-time ?game-time&:(>= ?game-time ?*EXPLORATION-TIME)))
+	(gamestate (phase PRODUCTION) (game-time ?game-time&:(>= ?game-time ?*EXPLORATION-TIME*)))
 	=>
 	(do-for-all-facts ((?exp exploration-report))
 		(retract ?exp)

--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -128,12 +128,13 @@
 	?er <- (exploration-report (rtype RECORD) (name ?name)
 	                           (zone-state CORRECT_REPORT) (rotation -1))
 	(machine (name ?name) (team ?team) (rotation ?rotation))
+	(gamestate (phase ?phase))
 	=>
   (modify ?er (rotation ?rotation) (rotation-state CORRECT_REPORT))
 	(printout t "Correct partial report: " ?name " (rotation " ?rotation "). "
 	            "Awarding " ?*EXPLORATION-CORRECT-REPORT-ROTATION-POINTS* " points" crlf)
 	(assert (points (points ?*EXPLORATION-CORRECT-REPORT-ROTATION-POINTS*)
-	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (phase ?phase) (team ?team) (game-time ?game-time)
 	                (reason (str-cat "Correct partial exploration report for "
 	                                 ?name ": rotation = " ?rotation))))
 )
@@ -146,12 +147,13 @@
 	?er <- (exploration-report (rtype RECORD) (name ?name)
 	                           (zone-state CORRECT_REPORT) (rotation -1))
 	?mf <- (machine (name ?name) (team ?team) (rotation ?erotation&~?rotation))
+	(gamestate (phase ?phase))
 	=>
 	(modify ?er (rotation ?rotation) (rotation-state WRONG_REPORT))
 	(printout t "Wrong partial report: " ?name " (rotation " ?rotation "). "
 	          "Awarding " ?*EXPLORATION-WRONG-REPORT-ROTATION-POINTS* " points" crlf)
 	(assert (points (points ?*EXPLORATION-WRONG-REPORT-ROTATION-POINTS*)
-	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (phase ?phase) (team ?team) (game-time ?game-time)
 	                (reason (str-cat "Wrong partial exploration report for "
 	                        ?name ": rotation = " ?rotation " (should be " ?erotation ")"))))
 )
@@ -197,12 +199,13 @@
 	                    (team ?team) (host ?from-host) (port ?from-port))
 	?er <- (exploration-report (rtype RECORD) (name ?name) (zone NOT-REPORTED))
 	?mf <- (machine (name ?name) (team ?team) (zone ?zone))
+	(gamestate (phase ?phase))
 	=>
 	(modify ?er (zone ?zone) (zone-state CORRECT_REPORT))
 	(printout t "Correct partial report: " ?name " (zone " ?zone "). "
 	          "Awarding " ?*EXPLORATION-CORRECT-REPORT-ZONE-POINTS* " points." crlf)
 	(assert (points (points ?*EXPLORATION-CORRECT-REPORT-ZONE-POINTS*)
-	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (phase ?phase) (team ?team) (game-time ?game-time)
 	                (reason (str-cat "Correct partial exploration report for "
 	                        ?name ": zone = " ?zone))))
 )
@@ -213,12 +216,13 @@
 	                    (team ?team) (host ?from-host) (port ?from-port))
 	?er <- (exploration-report (rtype RECORD) (name ?name) (zone NOT-REPORTED))
 	?mf <- (machine (name ?name) (team ?team) (zone ?mzone&~?zone))
+	(gamestate (phase ?phase))
 	=>
 	(modify ?er (zone ?zone) (zone-state WRONG_REPORT))
 	(printout t "Wrong partial report: " ?name " (zone " ?zone "). "
 	          "Awarding " ?*EXPLORATION-WRONG-REPORT-ZONE-POINTS* " points" crlf)
 	(assert (points (points ?*EXPLORATION-WRONG-REPORT-ZONE-POINTS*)
-	                (phase EXPLORATION) (team ?team) (game-time ?game-time)
+	                (phase ?phase) (team ?team) (game-time ?game-time)
 	                (reason (str-cat "Wrong partial exploration report for "
 	                        ?name ": zone = " ?zone " (should be " ?mzone ")"))))
 )

--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -309,7 +309,8 @@
 (deftemplate exploration-report
 	(slot rtype (type SYMBOL) (allowed-values INCOMING RECORD))
   (slot name (type SYMBOL)
-	(allowed-values C-BS C-DS C-RS1 C-RS2 C-CS1 C-CS2 M-BS M-DS M-RS1 M-RS2 M-CS1 M-CS2))
+	(allowed-values C-BS C-DS C-RS1 C-RS2 C-CS1 C-CS2 M-BS M-DS M-RS1 M-RS2 M-CS1 M-CS2 UNKNOWN))
+  (slot type (type SYMBOL) (allowed-values UNKNOWN BS CS SS RS DS))
   (slot team (type SYMBOL) (allowed-values CYAN MAGENTA))
   (slot zone (type SYMBOL)
 	  (allowed-values NOT-REPORTED
@@ -338,6 +339,7 @@
   (slot correctly-reported (type SYMBOL) (allowed-values UNKNOWN TRUE FALSE) (default UNKNOWN))
   (slot zone-state (type SYMBOL) (allowed-values NO_REPORT CORRECT_REPORT WRONG_REPORT) (default NO_REPORT))
   (slot rotation-state (type SYMBOL) (allowed-values NO_REPORT CORRECT_REPORT WRONG_REPORT) (default NO_REPORT))
+  (slot type-state (type SYMBOL) (allowed-values NO_REPORT CORRECT_REPORT WRONG_REPORT) (default NO_REPORT))
 )
 
 (deftemplate points

--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -187,7 +187,7 @@
 )
 
 (deftemplate send-mps-positions
-  (multislot phases (type SYMBOL) (allowed-values nil PRE_GAME SETUP EXPLORATION PRODUCTION POST_GAME) (default PRODUCTION))
+  (multislot phases (type SYMBOL) (allowed-values nil PRE_GAME SETUP EXPLORATION PRODUCTION POST_GAME) (default nil))
 )
 
 (deftemplate order

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -335,7 +335,7 @@
 (defrule game-start-training
   ?gs <- (gamestate (teams "" "") (phase PRE_GAME) (state RUNNING))
   =>
-  (modify ?gs (phase EXPLORATION) (prev-phase PRE_GAME) (game-time 0.0) (start-time (now)))
+  (modify ?gs (phase SETUP) (prev-phase PRE_GAME) (game-time 0.0) (start-time (now)))
   (assert (attention-message (text "Starting  *** TRAINING ***  game")))
 )
 
@@ -366,7 +366,7 @@
   ?gs <- (gamestate (phase SETUP) (state RUNNING)
 		    (game-time ?game-time&:(>= ?game-time ?*SETUP-TIME*)))
   =>
-  (modify ?gs (phase EXPLORATION) (prev-phase SETUP) (game-time 0.0))
+  (modify ?gs (phase PRODUCTION) (prev-phase SETUP) (game-time 0.0))
   (assert (attention-message (text "Switching to exploration phase")))
 )
 

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -362,19 +362,11 @@
   (assert (attention-message (text "Setup phase is about to end")))
 )
 
-(defrule game-switch-to-exploration
+(defrule game-switch-from-setup-to-production
   ?gs <- (gamestate (phase SETUP) (state RUNNING)
 		    (game-time ?game-time&:(>= ?game-time ?*SETUP-TIME*)))
   =>
   (modify ?gs (phase PRODUCTION) (prev-phase SETUP) (game-time 0.0))
-  (assert (attention-message (text "Switching to production phase")))
-)
-
-(defrule game-switch-to-production
-  ?gs <- (gamestate (phase EXPLORATION) (state RUNNING)
-		    (game-time ?game-time&:(>= ?game-time ?*EXPLORATION-TIME*)))
-  =>
-  (modify ?gs (phase PRODUCTION) (prev-phase EXPLORATION) (game-time 0.0))
   (assert (attention-message (text "Switching to production phase")))
 )
 

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -367,7 +367,7 @@
 		    (game-time ?game-time&:(>= ?game-time ?*SETUP-TIME*)))
   =>
   (modify ?gs (phase PRODUCTION) (prev-phase SETUP) (game-time 0.0))
-  (assert (attention-message (text "Switching to exploration phase")))
+  (assert (attention-message (text "Switching to production phase")))
 )
 
 (defrule game-switch-to-production

--- a/src/games/rcll/globals.clp
+++ b/src/games/rcll/globals.clp
@@ -113,7 +113,7 @@
   ; Game phase time; seconds
   ?*SETUP-TIME*           = 300
   ?*EXPLORATION-TIME*     = 180
-  ?*PRODUCTION-TIME*      = 1020
+  ?*PRODUCTION-TIME*      = 1200
   ?*PRODUCTION-OVERTIME*  = 300
   ?*PRODUCTION-PREPARE-TIMEOUT*  = 5
   ; Machine distribution

--- a/src/games/rcll/machine-lights.clp
+++ b/src/games/rcll/machine-lights.clp
@@ -18,62 +18,125 @@
 ;
 ; Read the full text in the LICENSE.GPL file in the doc directory.
 ;
+(defrule machine-report-init-lights
+	(declare (salience ?*PRIORITY_HIGH*))
+	?gf <- (gamestate (phase ?PHASE) (prev-phase SETUP))
+	=>
+	; Set prev phase to avoid re-firing, reset game time
+	(modify ?gf (prev-phase ?PHASE) (game-time 0.0))
+
+	; Set lights
+	(delayed-do-for-all-facts ((?machine machine)) TRUE
+		(modify ?machine (desired-lights (create$ YELLOW-ON)))
+	)
+)
+
+(defrule machine-lights-pause
+	(gamestate (phase EXPLORATION|PRODUCTION) (state PAUSED) (prev-state ~PAUSED))
+	?m <- (machine (desired-lights ?some-light))
+	=>
+	(delayed-do-for-all-facts ((?machine machine)) TRUE
+		(modify ?machine (desired-lights))
+	)
+)
+
+(defrule machine-lights-unknown-report
+	(gamestate (phase EXPLORATION|PRODUCTION) (state RUNNING))
+	?m <- (machine (name ?n) (desired-lights ?dl&:(neq $?dl (create$ YELLOW-ON))))
+	(exploration-report (name ?n) (correctly-reported UNKNOWN) (zone NOT-REPORTED))
+	=>
+	(modify ?m (desired-lights (create$ YELLOW-ON)))
+)
+
+(defrule machine-lights-partial-report
+	(gamestate (phase EXPLORATION|PRODUCTION) (state RUNNING))
+	?m <- (machine (name ?n) (desired-lights ?dl&:(neq $?dl YELLOW-BLINK)))
+	(exploration-report (name ?n) (correctly-reported UNKNOWN)
+	                    (zone-state CORRECT_REPORT))
+	=>
+	(printout t (neq ?dl (create$ YELLOW-BLINK)) " and " (neq ?dl YELLOW-BLINK) crlf)
+	(modify ?m (desired-lights (create$ YELLOW-BLINK)))
+)
+
+(defrule machine-lights-wrong-report-zone
+	(gamestate (phase EXPLORATION|PRODUCTION) (state RUNNING))
+	?m <- (machine (name ?n) (desired-lights ?dl&:(neq $?dl (create$ RED-ON YELLOW-ON))))
+	(exploration-report (name ?n) (zone-state WRONG_REPORT))
+	=>
+	(modify ?m (desired-lights (create$ RED-ON YELLOW-ON)))
+)
+
+(defrule machine-lights-wrong-report-rotation
+	(gamestate (phase EXPLORATION|PRODUCTION) (state RUNNING))
+	?m <- (machine (name ?n) (desired-lights ?dl&:(neq $?dl (create$ RED-ON YELLOW-BLINK))))
+	(exploration-report (name ?n) (rotation-state WRONG_REPORT))
+	=>
+	(modify ?m (desired-lights (create$ RED-ON YELLOW-BLINK)))
+)
 
 (defrule machine-lights-idle
 	(gamestate (phase PRODUCTION))
-	?m <- (machine (state IDLE) (desired-lights $?dl&:(neq ?dl (create$ GREEN-ON))))
+	?m <- (machine (state IDLE) (name ?n) (desired-lights $?dl&:(neq ?dl (create$ GREEN-ON))))
+	(exploration-report (name ?n) (correctly-reported TRUE))
 	=>
 	(modify ?m (desired-lights GREEN-ON))
 )
 
 (defrule machine-lights-wait-idle
 	(gamestate (phase PRODUCTION))
-	?m <- (machine (state WAIT-IDLE) (desired-lights $?dl&:(neq ?dl (create$ YELLOW-BLINK))))
+	?m <- (machine (name ?n) (state WAIT-IDLE) (desired-lights $?dl&:(neq ?dl (create$ YELLOW-BLINK GREEN-BLINK))))
+	(exploration-report (name ?n) (correctly-reported TRUE))
 	=>
-	(modify ?m (desired-lights YELLOW-BLINK))
+	(modify ?m (desired-lights (create$ YELLOW-BLINK GREEN-BLINK)))
 )
 
 (defrule machine-lights-down
 	(gamestate (phase PRODUCTION))
-	?m <- (machine (state DOWN) (desired-lights $?dl&:(neq ?dl (create$ RED-ON))))
+	?m <- (machine (name ?n) (state DOWN) (desired-lights $?dl&:(neq ?dl (create$ RED-ON))))
+	(exploration-report (name ?n) (correctly-reported TRUE))
 	=>
-	(modify ?m (desired-lights RED-ON))
+	(modify ?m (desired-lights (create$ RED-ON)))
 )
 
-(defrule machine-lights-prepared-stop-blinking
-  "The machine is PREPARED and has been blinking, change the light signal to GREEN (non-blinking)"
-  (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt))
-  ?m <- (machine (name ?n) (state PREPARED|PROCESSING)
-		 (actual-lights GREEN-BLINK) (desired-lights GREEN-BLINK)
-		 (prep-blink-start ?bs&:(timeout-sec ?gt ?bs ?*PREPARED-BLINK-TIME*)))
-  =>
-  (modify ?m (desired-lights GREEN-ON))
-)
+; (defrule machine-lights-prepared-stop-blinking
+; 	"The machine (name ?n) is PREPARED and has been blinking, change the light signal to GREEN (non-blinking)"
+; 	(gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt))
+; 	?m <- (machine (name ?n) (state PREPARED|PROCESSING)
+; 		 (actual-lights GREEN-BLINK) (desired-lights GREEN-BLINK)
+; 		 (prep-blink-start ?bs&:(timeout-sec ?gt ?bs ?*PREPARED-BLINK-TIME*)))
+; 	(exploration-report (name ?n) (correctly-reported TRUE))
+; 	=>
+; 	(modify ?m (desired-lights GREEN-ON))
+; )
 
 (defrule machine-lights-processing
 	(gamestate (phase PRODUCTION))
-	?m <- (machine (state PROCESSING) (desired-lights $?dl&:(neq ?dl (create$ GREEN-ON YELLOW-ON))))
+	?m <- (machine (name ?n) (state PROCESSING) (desired-lights $?dl&:(neq ?dl (create$ YELLOW-ON GREEN-ON))))
+	(exploration-report (name ?n) (correctly-reported TRUE))
 	=>
-	(modify ?m (desired-lights GREEN-ON YELLOW-ON))
+	(modify ?m (desired-lights YELLOW-ON GREEN-ON))
 )
 
 (defrule machine-lights-prepared
 	(gamestate (phase PRODUCTION) (game-time ?gt))
-	?m <- (machine (state PREPARED) (desired-lights $?dl&:(neq ?dl (create$ GREEN-BLINK))))
+	?m <- (machine (name ?n) (state PREPARED) (desired-lights $?dl&:(neq ?dl (create$ GREEN-BLINK))))
+	(exploration-report (name ?n) (correctly-reported TRUE))
 	=>
 	(modify ?m (desired-lights GREEN-BLINK) (prep-blink-start ?gt))
 )
 
 (defrule machine-lights-ready-at-output
-  (gamestate (phase PRODUCTION))
-  ?m <- (machine (state READY-AT-OUTPUT) (desired-lights $?dl&:(neq ?dl (create$ YELLOW-ON))))
-  =>
-  (modify ?m (desired-lights YELLOW-ON))
+	(gamestate (phase PRODUCTION))
+	?m <- (machine (name ?n) (state READY-AT-OUTPUT) (desired-lights $?dl&:(neq ?dl (create$ YELLOW-ON GREEN-BLINK))))
+	(exploration-report (name ?n) (correctly-reported TRUE))
+	=>
+	(modify ?m (desired-lights YELLOW-ON GREEN-BLINK))
 )
 
 (defrule machine-lights-broken
-  (gamestate (phase PRODUCTION))
-  ?m <- (machine (state BROKEN) (desired-lights $?dl&:(neq ?dl (create$ RED-BLINK YELLOW-BLINK))))
-  =>
-  (modify ?m (desired-lights RED-BLINK YELLOW-BLINK))
+	(gamestate (phase PRODUCTION))
+	?m <- (machine (name ?n) (state BROKEN) (desired-lights $?dl&:(neq ?dl (create$ RED-BLINK YELLOW-BLINK))))
+	(exploration-report (name ?n) (correctly-reported TRUE))
+	=>
+	(modify ?m (desired-lights RED-BLINK YELLOW-BLINK))
 )

--- a/src/games/rcll/machine-lights.clp
+++ b/src/games/rcll/machine-lights.clp
@@ -98,17 +98,6 @@
 	(modify ?m (desired-lights (create$ RED-ON)))
 )
 
-; (defrule machine-lights-prepared-stop-blinking
-; 	"The machine (name ?n) is PREPARED and has been blinking, change the light signal to GREEN (non-blinking)"
-; 	(gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt))
-; 	?m <- (machine (name ?n) (state PREPARED|PROCESSING)
-; 		 (actual-lights GREEN-BLINK) (desired-lights GREEN-BLINK)
-; 		 (prep-blink-start ?bs&:(timeout-sec ?gt ?bs ?*PREPARED-BLINK-TIME*)))
-; 	(exploration-report (name ?n) (correctly-reported TRUE))
-; 	=>
-; 	(modify ?m (desired-lights GREEN-ON))
-; )
-
 (defrule machine-lights-processing
 	(gamestate (phase PRODUCTION))
 	?m <- (machine (name ?n) (state PROCESSING) (desired-lights $?dl&:(neq ?dl (create$ YELLOW-ON GREEN-ON))))

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -172,7 +172,7 @@
 
 		(foreach ?c ?candidates
 			(bind ?duration (random ?*DOWN-TIME-MIN* ?*DOWN-TIME-MAX*))
-			(bind ?start-time (random 1 (- ?*PRODUCTION-TIME* ?duration)))
+			(bind ?start-time (random ?*EXPLORATION-TIME* (- ?*PRODUCTION-TIME* ?duration)))
 			(bind ?end-time (+ ?start-time ?duration))
 
 			; Copy to magenta machine

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -239,6 +239,14 @@
 			 then
 				(printout t "Prepare message received that is older than " ?*PRODUCTION-PREPARE-TIMEOUT* " sec (" (time-diff-sec ?now (time-from-sec (pb-field-value ?p "sent_at"))) ") ignoring it" crlf)
 			 else
+				(if (not (any-factp ((?exp exploration-report)) (and (eq ?exp:name ?mname)
+				                                                     (eq ?exp:rtype RECORD)
+				                                                     ?exp:correctly-reported)))
+				 then
+						(assert (attention-message (team ?team)
+						        (text (str-cat "Prepare received for machine that was not correctly reported yet: " ?mname))))
+						(return)
+				)
 				(do-for-fact ((?m machine)) (and (eq ?m:name ?mname) (eq ?m:team ?team))
 					(if (eq ?m:state IDLE) then
 						(printout t ?mname " is IDLE, processing prepare" crlf)

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -874,6 +874,12 @@
   (assert (production-MachineAddBase ?mname))
 )
 
+(defrule production-send-machine-positions
+  (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt&:(> ?gt ?*EXPLORATION-TIME*)))
+  ?send-pos <- (send-mps-positions (phases $?phases&:(not (member$ PRODUCTION ?phases))))
+  =>
+  (modify ?send-pos (phases (append$ ?phases PRODUCTION)))
+)
 
 (defrule production-proc-MachineAddBase
   (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt))

--- a/src/msgs/MachineReport.proto
+++ b/src/msgs/MachineReport.proto
@@ -53,7 +53,8 @@ message MachineReportEntry {
 
   // Machine name and recognized type
   // and zone the machine is in
-  required string name = 1;
+  optional string name = 1;
+  optional string type = 2;
   optional Zone   zone = 3;
   optional uint32 rotation = 4; // [0-360] in deg
 }
@@ -90,4 +91,24 @@ message MachineReportInfo {
 
   // Team for which the report is sent
   required Team team_color = 2;
+
+  // Responses to reports that were received by the refbox and
+  // that contained machine types and zones
+  repeated  MachineTypeFeedback reported_types = 3;
+}
+
+message MachineTypeFeedback {
+  enum CompType {
+    COMP_ID  = 2000;
+    MSG_TYPE = 63;
+  }
+
+  // Feedback about whether a reported type in a zone is correct
+  // "name" and "team_color" are only set if the reported type is
+  // located in the zone  and if the number of reported types did not
+  // exceed the number of machines with the types
+  required string type = 1;
+  required Zone zone = 2;
+  optional string name = 3;
+  optional Team team_color = 4;
 }


### PR DESCRIPTION
This PR implements the changes required for https://github.com/robocup-logistics/rcll-rulebook/pull/50 and should be merged only if the rule changes are accepted.
It takes care about 2 major things:
### 1. Markerless Machine Reporting
If a team decides to play without AR Tags, then they need to be able to report machines based on the type, zone and rotation. This will be possible through minor changes to the MachineReport messages:
    1. The name is not a required field anymore in the reported machine, instead a type might be provided. https://github.com/robocup-logistics/rcll-refbox/blob/bdd9069416f460f022a048e32efe58916bade4f0/src/msgs/MachineReport.proto#L54-L59
    2. The MachineReportInfo that is returned will now contain feedback about a machine name and the belonging team, if a report with a correct type + zone was received https://github.com/robocup-logistics/rcll-refbox/blob/bdd9069416f460f022a048e32efe58916bade4f0/src/msgs/MachineReport.proto#L95-L114

The procedure to report a machine based on the machine type is now:
  1. Report type + zone (this does not give any points)
  2. Retrieve name + team
  3. Report name + zone + rotation (or use symmetry to report the machine if the retrieved name belongs to the opposing team)
. This gives the usual points for machine reports.

Therefore, the refbox distinguishes between reports where the name is set and those, where the name is not set, but the type and the zone is set.
As before, once information about a machine name (zone, orientation) is reported, all attempts to re-report that info are ignored.
For reports only containing a machine type similar measurements are taken to prevent abuse by spamming report attempts:
 - Wrong reports about a machine type in a zone lead to a point deduction of the same amount as a wrongly reported zone would give. This prevents that teams can "probe" for a correct zone, even tho they know the machine name (because they play with tags) by first reporting a machine type in that zone before actually reporting using the name.
 - The number of attempts to report a machine type is limited to the number of machines of that type that belong to the reporting team, further reports towards that machine type are ignored. https://github.com/robocup-logistics/rcll-refbox/blob/ac99f29f4850dc23494032e101677122db554f0c/src/games/rcll/exploration.clp#L11-L19
 - Attempts to report a machine by its name are ignored, if the number of previously reported machines from that type are not exceeding the actual available machines (not counting successful type-reports, those are already limited through the point above). https://github.com/robocup-logistics/rcll-refbox/blob/ac99f29f4850dc23494032e101677122db554f0c/src/games/rcll/exploration.clp#L21-L34
 To give a few example scenarios, where C-CS1 is at C_Z22 and C-CS2 is at C_Z44:
 - report `CS` in `M_Z22` -> report `C-CS1` in `C_Z22` -> report `CS` in `C_Z44` -> report `C-CS2` in `C_Z44`. This results in 2 correct zone reports (+2 for the 2 correct partial reports)
 - report `CS` in `M_Z55` -> wrong zone report -> report `CS` in `C_Z44` -> report `C-CS2` in `C_Z44`. This results in 1 correct zone report (+1), one deduction for a wrong zone report (-1), all further attempts to report the machine C-CS1 are ignored, but the team could still report the type CS once, which would lead to either of the two scenarios:
     -  either report `CS` in a correct zone, e.g., `C_Z22` (feedback that `C-CS1` is in that zone is given, but no points are awarded and reports about C-CS1 are still ignored)
     - or report `CS` in a wrong zone, e.g., `C_Z23` (-1 point for a wrong zone report is given)
     - in either case, all further reports for C-CS1 or reports for type CS are ignored.
 - report `CS` in `M_Z55` -> wrong zone report -> report `CS` in `C_Z66` -> wrong zone report. This results in 0 correct reports,  deductions for the two wrongly reported zones (-2), all further attempts to report the machine C-CS1, C-CS2 or a machine of type CS are ignored.
 
### 2. Combined Exploration + Production
A regular production phase now spans 20 minutes. If a machine is fully correctly reported, it can be used for production right away (before minute 3).  Machine positions are only revealed after 3 minutes, which is also where all machines become usable for production (even if they were not or wrongly reported before).
The refbox also will switch from Setup to Production instead of Exploration now after 5 minutes of Setup.