### PR TITLE
Remove useless randomization

### DIFF
--- a/cfg/challenges/grasping/grasping_game.yaml
+++ b/cfg/challenges/grasping/grasping_game.yaml
@@ -14,7 +14,7 @@ llsfrb:
     random-machine-down-times: true
     random-machine-setup: false
     random-orders: true
-    random-storage: true
+    default-storage: true
     restore-gamestate:
       enable: false
       phase: PRODUCTION

--- a/cfg/game/default_game.yaml
+++ b/cfg/game/default_game.yaml
@@ -14,7 +14,7 @@ llsfrb:
     random-machine-down-times: true
     random-machine-setup: true
     random-orders: true
-    random-storage: true
+    default-storage: true
     restore-gamestate:
       enable: false
       phase: PRODUCTION

--- a/cfg/game/load_field_layout.yaml
+++ b/cfg/game/load_field_layout.yaml
@@ -15,7 +15,7 @@ llsfrb:
     random-machine-down-times: true
     random-machine-setup: false
     random-orders: true
-    random-storage: false
+    default-storage: false
     restore-gamestate:
       enable: false
       phase: PRODUCTION

--- a/cfg/game/load_game.yaml
+++ b/cfg/game/load_game.yaml
@@ -15,7 +15,7 @@ llsfrb:
     random-machine-down-times: true
     random-machine-setup: false
     random-orders: false
-    random-storage: false
+    default-storage: false
     restore-gamestate:
       enable: false
       phase: PRODUCTION

--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -372,7 +372,7 @@
 	(slot machine-setup (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
 	(slot orders (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
 	(slot gamestate (type SYMBOL) (allowed-values PENDING RECOVERED FRESH) (default PENDING))
-	(slot storage-status (type SYMBOL) (allowed-values PENDING RANDOM STATIC) (default PENDING))
+	(slot storage-status (type SYMBOL) (allowed-values PENDING DEFAULT STATIC) (default PENDING))
 )
 
 ; Machine directions in LLSF arena frame when looking from bird's eye perspective
@@ -450,17 +450,17 @@
 
 (deffacts storage-slots
   (init-storage-slots)
-  (machine-ss-shelf-slot (position 0 0) (description "BASE_RED CAP_GREY") (is-filled TRUE)
+  (machine-ss-shelf-slot (position 0 1) (description "BASE_RED CAP_GREY") (is-filled TRUE)
     (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*))
-  (machine-ss-shelf-slot (position 1 0) (description "BASE_SILVER CAP_GREY") (is-filled TRUE)
+  (machine-ss-shelf-slot (position 1 1) (description "BASE_RED CAP_BLACK") (is-filled TRUE)
     (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*))
-  (machine-ss-shelf-slot (position 2 0) (description "BASE_BLACK CAP_GREY") (is-filled TRUE)
+  (machine-ss-shelf-slot (position 2 1) (description "BASE_SILVER CAP_GREY") (is-filled TRUE)
+    (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*))
+  (machine-ss-shelf-slot (position 3 1) (description "BASE_SILVER CAP_BLACK") (is-filled TRUE)
+    (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*))
+  (machine-ss-shelf-slot (position 4 1) (description "BASE_BLACK CAP_GREY") (is-filled TRUE)
     (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*) )
-  (machine-ss-shelf-slot (position 3 0) (description "BASE_RED CAP_BLACK") (is-filled TRUE)
-    (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*))
-  (machine-ss-shelf-slot (position 4 0) (description "BASE_SILVER CAP_BLACK") (is-filled TRUE)
-    (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*))
-  (machine-ss-shelf-slot (position 5 0) (description "BASE_BLACK CAP_BLACK") (is-filled TRUE)
+  (machine-ss-shelf-slot (position 5 1) (description "BASE_BLACK CAP_BLACK") (is-filled TRUE)
     (num-payments ?*SS-MAX-NUM-PAYMENTS-PER-VOLUME*))
 )
 

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -153,7 +153,7 @@
 	(confval (path "/llsfrb/game/random-field") (type BOOL) (value ?random-field))
 	(confval (path "/llsfrb/game/random-machine-setup") (type BOOL) (value ?random-machine-setup))
 	(confval (path "/llsfrb/game/random-orders") (type BOOL) (value ?random-orders))
-	(confval (path "/llsfrb/game/random-storage") (type BOOL) (value ?random-storage))
+	(confval (path "/llsfrb/game/default-storage") (type BOOL) (value ?default-storage))
 	(confval (path "/llsfrb/mongodb/enable") (type BOOL) (value ?cfg-mongodb-enabled))
 	=>
 	(bind ?m-positions PENDING)
@@ -161,14 +161,14 @@
 	(bind ?orders PENDING)
 	(bind ?s-status PENDING)
 	(bind ?mongodb-enabled (eq ?cfg-mongodb-enabled true))
-	(if (and (not ?mongodb-enabled) (member$ false (create$ ?random-field ?random-machine-setup ?random-orders ?random-storage )))
+	(if (and (not ?mongodb-enabled) (member$ false (create$ ?random-field ?random-machine-setup ?random-orders ?default-storage )))
 	 then
 		(printout warn "Mongodb disabled, randomize all parameters despite configured static settings." crlf)
 	)
 	(if (or (not ?mongodb-enabled) (eq ?random-field  true)) then (bind ?m-positions RANDOM))
 	(if (or (not ?mongodb-enabled) (eq ?random-machine-setup true)) then (bind ?m-setup RANDOM))
 	(if (or (not ?mongodb-enabled) (eq ?random-orders true)) then (bind ?orders RANDOM))
-	(if (or (not ?mongodb-enabled) (eq ?random-storage true)) then (bind ?s-status RANDOM))
+	(if (or (not ?mongodb-enabled) (eq ?default-storage true)) then (bind ?s-status DEFAULT))
 	(modify ?gt (machine-positions ?m-positions)
 	            (machine-setup ?m-setup)
 	            (orders ?orders)
@@ -232,9 +232,11 @@
 	 then
 		(game-randomize-orders)
 	)
-	(if (eq ?s-status RANDOM)
+	; Shelves are not shuffled in default games
+	(if (eq ?s-status DEFAULT)
 	 then
-		(ss-shuffle-shelves)
+		;(ss-shuffle-shelves)
+		(printout t "Using default setup for pre-stored products at SS." crlf)
 	)
 
 	(ss-print-storage C-SS)

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -142,19 +142,31 @@
 
 (deffunction machine-randomize-machine-setup ()
 	; Randomize ring colors per machine
-	(bind ?ring-colors (create$))
-	(do-for-all-facts ((?rs ring-spec)) TRUE
-	  (bind ?ring-colors (append$ ?ring-colors ?rs:color))
-	)
+	;(bind ?ring-colors (create$))
+	;(do-for-all-facts ((?rs ring-spec)) TRUE
+	;  (bind ?ring-colors (append$ ?ring-colors ?rs:color))
+	;)
+	;(do-for-fact ((?m-cyan machine) (?m-magenta machine))
+	;  (and (eq ?m-cyan:name C-RS1) (eq ?m-magenta:name M-RS1))
+	;  (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 1 2)))
+	;  (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 1 2)))
+	;)
+	;(do-for-fact ((?m-cyan machine) (?m-magenta machine))
+	;  (and (eq ?m-cyan:name C-RS2) (eq ?m-magenta:name M-RS2))
+	;  (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+	;  (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+	;)
+	; No need to randomize color assignment, the color costs are randomized
+	; anyways
 	(do-for-fact ((?m-cyan machine) (?m-magenta machine))
 	  (and (eq ?m-cyan:name C-RS1) (eq ?m-magenta:name M-RS1))
-	  (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 1 2)))
-	  (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 1 2)))
+	  (modify ?m-cyan    (rs-ring-colors RING_ORANGE RING_GREEN))
+	  (modify ?m-magenta (rs-ring-colors RING_ORANGE RING_GREEN))
 	)
 	(do-for-fact ((?m-cyan machine) (?m-magenta machine))
 	  (and (eq ?m-cyan:name C-RS2) (eq ?m-magenta:name M-RS2))
-	  (modify ?m-cyan    (rs-ring-colors (subseq$ ?ring-colors 3 4)))
-	  (modify ?m-magenta (rs-ring-colors (subseq$ ?ring-colors 3 4)))
+	  (modify ?m-cyan    (rs-ring-colors RING_BLUE RING_YELLOW))
+	  (modify ?m-magenta (rs-ring-colors RING_BLUE RING_YELLOW))
 	)
 
 	; assign random down times

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -596,7 +596,7 @@
 	(declare (salience ?*PRIORITY_FIRST*))
 	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
 	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
-	(confval (path "/llsfrb/game/random-storage") (type BOOL) (value false))
+	(confval (path "/llsfrb/game/default-storage") (type BOOL) (value false))
 	?gp <- (game-parameters (storage-status PENDING))
 	=>
 	(printout t "Loading storage from database" crlf)


### PR DESCRIPTION
This implements changes discussed in https://github.com/robocup-logistics/rcll-rulebook/pull/54 and should only be merged once that PR is merged.

It is noteworthy that this renames one config value, namely `llsfrb/game/random-storage` to `llsfrb/game/default-storage`.