### PR TITLE
adapt benchmark generator script to refbox changes

### DIFF
--- a/etc/scripts/generate_benchmarks.bash
+++ b/etc/scripts/generate_benchmarks.bash
@@ -40,6 +40,14 @@ NUM_BENCHMARKS=$2
 
 tmpconfig=$(mktemp ${LLSF_REFBOX_DIR}/cfg/store_to_report_generated_XXXXXX.yaml)
 
+TRAP_SIGNALS="SIGINT SIGTERM SIGPIPE EXIT"
+cleanup () {
+  trap - $TRAP_SIGNALS
+  rm -f $tmpconfig
+	killall -9 llsf-refbox &>/dev/null &
+}
+trap cleanup $TRAP_SIGNALS
+
 for i in  $(seq 1 $NUM_BENCHMARKS)
 do
 	DOC_COUNT=$(mongo rcll --eval "db.game_report.count({\"report-name\": \"${NAME_PREFIX}_${i}\"})" --quiet)

--- a/etc/scripts/generate_benchmarks.bash
+++ b/etc/scripts/generate_benchmarks.bash
@@ -22,7 +22,6 @@ echo "Generates entries <report name>_<i> where i in [1...<number of reports>]"
 echo "------------------------------------------------------------------------"
 echo " "
 
-CONFIG=${LLSF_REFBOX_DIR}/cfg/config.yaml
 if [ -z "$1" ] || [ -z "$2" ]
 	then
 		echo "expected 2 arguments"
@@ -39,31 +38,31 @@ fi
 NAME_PREFIX=$1
 NUM_BENCHMARKS=$2
 
-echo "Creating Backup of original config"
-cp ${CONFIG} ${CONFIG}.bak
-echo "Setup RefBox config"
-sed -E -n -i '1h;1!H;${g;s/(mongodb:[[:space:]]*\n[[:space:]]*enable:[[:space:]]*)false/\1true/;p;}' ${CONFIG} &>/dev/null
-sed -E -n -i '1h;1!H;${g;s/(time-sync:[[:space:]]*\n[[:space:]]*enable:[[:space:]]*)true/\1false/;p;}' ${CONFIG} &>/dev/null
-sed -i "s/estimate-time: true/estimate-time: false/g" ${CONFIG}
+tmpconfig=$(mktemp ${LLSF_REFBOX_DIR}/cfg/store_to_report_generated_XXXXXX.yaml)
+
 for i in  $(seq 1 $NUM_BENCHMARKS)
 do
 	DOC_COUNT=$(mongo rcll --eval "db.game_report.count({\"report-name\": \"${NAME_PREFIX}_${i}\"})" --quiet)
+
 	# make sure that the report name is fresh
 	if [ ${DOC_COUNT} -ne 0 ]; then
-    echo "Skipping ${NAME_PREFIX}_${i} as a report already exists"
+		echo "Skipping ${NAME_PREFIX}_${i} as a report already exists"
 	else
+		truncate -s 0 ${tmpconfig}
+		echo "llsfrb/game/store-to-report: \"${NAME_PREFIX}_${i}\"" > ${tmpconfig}
 		# in rare occasions the generation fails, hence simply retry when it happens
 		while [ ${DOC_COUNT} -ne 1 ]
 		do
-			sed -i "s/store-to-report: \".*\"/store-to-report: \"${NAME_PREFIX}_${i}\"/g" ${CONFIG}
-			${LLSF_REFBOX_DIR}/bin/./llsf-refbox &>/dev/null &
+			echo "attempt to generate report"
+			${LLSF_REFBOX_DIR}/bin/./llsf-refbox --cfg-mongodb mongodb/enable_mongodb.yaml \
+			                                     --cfg-mps mps/mockup_mps.yaml \
+			                                     --cfg-custom ${tmpconfig} \
+			                                     --dump-cfg &>/dev/null &
 			sleep 1
 			${LLSF_REFBOX_DIR}/bin/./rcll-refbox-instruct -p PRE_GAME -s RUNNING -c Carologistics &>/dev/null
 			sleep 2
-			${LLSF_REFBOX_DIR}/bin/./rcll-refbox-instruct -p SETUP -s RUNNING -c Carologistics &>/dev/null
-			sleep 2
-			${LLSF_REFBOX_DIR}/bin/./rcll-refbox-instruct -p PRODUCTION  &>/dev/null
-			sleep 2
+			${LLSF_REFBOX_DIR}/bin/./rcll-refbox-instruct -p PRODUCTION &>/dev/null
+			sleep 5
 			${LLSF_REFBOX_DIR}/bin/./rcll-refbox-instruct -p POST_GAME &>/dev/null
 			sleep 1
 			killall -15 llsf-refbox  &>/dev/null &
@@ -73,5 +72,3 @@ do
 		echo "Created report for ${NAME_PREFIX}_${i}"
 	fi
 done
-echo "Restoring original config"
-mv ${CONFIG}.bak ${CONFIG}


### PR DESCRIPTION
As the refbox now uses a modular configuration loading process, the benchmark generator script should use that as well.