### PR TITLE
Make exploration time configurable

### DIFF
--- a/cfg/game/default_game.yaml
+++ b/cfg/game/default_game.yaml
@@ -23,3 +23,5 @@ llsfrb:
     load-from-report: ""
     # store game report under a name for later reference
     store-to-report: ""
+
+    exploration-time: 180

--- a/cfg/game/load_field_layout.yaml
+++ b/cfg/game/load_field_layout.yaml
@@ -24,3 +24,5 @@ llsfrb:
     load-from-report: ""
     # store game report under a name for later reference
     store-to-report: ""
+
+    exploration-time: 180

--- a/cfg/game/load_game.yaml
+++ b/cfg/game/load_game.yaml
@@ -24,3 +24,5 @@ llsfrb:
     load-from-report: ""
     # store game report under a name for later reference
     store-to-report: ""
+
+    exploration-time: 180

--- a/src/games/rcll/globals.clp
+++ b/src/games/rcll/globals.clp
@@ -112,7 +112,7 @@
   ?*MAINTENANCE-GRACE-TIME*     =  15
   ; Game phase time; seconds
   ?*SETUP-TIME*           = 300
-  ?*EXPLORATION-TIME*     = 180
+  ?*EXPLORATION-TIME*     = (config-get-int "/llsfrb//game/exploration-time")
   ?*PRODUCTION-TIME*      = 1200
   ?*PRODUCTION-OVERTIME*  = 300
   ?*PRODUCTION-PREPARE-TIMEOUT*  = 5

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -878,6 +878,7 @@
   (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt&:(> ?gt ?*EXPLORATION-TIME*)))
   ?send-pos <- (send-mps-positions (phases $?phases&:(not (member$ PRODUCTION ?phases))))
   =>
+  (printout t "Exploration Phase over, sending ground truth of machines" crlf)
   (modify ?send-pos (phases (append$ ?phases PRODUCTION)))
 )
 


### PR DESCRIPTION
Useful for debugging, also adds a printout to indicate when the exploration time is over.