### PR TITLE
fix ground truth in challenges

### DIFF
--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -325,8 +325,10 @@
 (defrule exploration-set-ground-truth
 	(machine (name ?n) (team ?team) (rotation ?rotation) (zone ?zone))
 	(not (exploration-report (name ?n) (rtype RECORD) (correctly-reported TRUE)))
-	(gamestate (phase PRODUCTION) (game-time ?game-time&:(>= ?game-time ?*EXPLORATION-TIME*)))
+	(gamestate (phase ?phase))
+	(send-mps-positions (phases $?phases&:(member$ ?phase ?phases)))
 	=>
+	(printout t "Exploration Phase over, sending ground truth of machines" crlf)
 	(do-for-all-facts ((?exp exploration-report))
 		(retract ?exp)
 	)

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -877,6 +877,7 @@
 (defrule production-send-machine-positions
   (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt&:(> ?gt ?*EXPLORATION-TIME*)))
   ?send-pos <- (send-mps-positions (phases $?phases&:(not (member$ PRODUCTION ?phases))))
+  (not (confval (path "/llsfrb/challenges/enable") (type BOOL) (value true)))
   =>
   (modify ?send-pos (phases (append$ ?phases PRODUCTION)))
 )

--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -878,7 +878,6 @@
   (gamestate (state RUNNING) (phase PRODUCTION) (game-time ?gt&:(> ?gt ?*EXPLORATION-TIME*)))
   ?send-pos <- (send-mps-positions (phases $?phases&:(not (member$ PRODUCTION ?phases))))
   =>
-  (printout t "Exploration Phase over, sending ground truth of machines" crlf)
   (modify ?send-pos (phases (append$ ?phases PRODUCTION)))
 )
 


### PR DESCRIPTION
I noticed that the ground-truth settings of the challenge configs was effectively not proessed anymore (due to https://github.com/robocup-logistics/rcll-refbox/pull/120). This PR addresses that issue.