### PR TITLE
Update to latest clips 63x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            dnf install -y --nodocs 'dnf-command(copr)' && \
+            dnf -y copr enable thofmann/clips-6.31 && \
             dnf install -y --nodocs \
               apr-util-devel \
               avahi-devel \
@@ -73,7 +75,7 @@ jobs:
               protobuf-compiler \
               rapidjson-dev
       - checkout
-      - run: make all FAIL_ON_WARNING=0
+      - run: make all FAIL_ON_WARNING=0 CLIPS_OLD_63_API=1
 workflows:
   version: 2
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@
 #
 
 FROM fedora:35 as buildenv
-RUN dnf install -y --nodocs \
+RUN   dnf install -y --nodocs 'dnf-command(copr)' && \
+      dnf -y copr enable thofmann/clips-6.31 && \
+      dnf install -y --nodocs \
       avahi-devel \
       boost-devel \
       clips-devel \

--- a/etc/buildsys/clips.mk
+++ b/etc/buildsys/clips.mk
@@ -34,10 +34,13 @@ ifneq ($(PKGCONFIG),)
 else
   CLIPS_ERROR = pkg-config not available
 endif
-
+OLD_CLIPS_OPTS=
+ifdef CLIPS_OLD_63_API
+  OLD_CLIPS_OPTS = -DCLIPS_OLD_63_API
+endif
 ifeq ($(HAVE_CLIPS),1)
   # Filter out "-std=c++0x" for clipsmm <=0.3.4 (it unnecessarily downgrades the std)
-  CFLAGS_CLIPS  = -DHAVE_CLIPS $(CFLAGS_CPP14) \
+  CFLAGS_CLIPS  = -DHAVE_CLIPS $(OLD_CLIPS_OPTS) $(CFLAGS_CPP14) \
                   $(filter-out -std=c++0x,$(shell $(PKGCONFIG) --cflags 'clipsmm-1.0'))
   LDFLAGS_CLIPS = $(shell $(PKGCONFIG) --libs 'clipsmm-1.0')
 

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -162,8 +162,8 @@
   (bind ?free-ring-colors (create$))
   (delayed-do-for-all-facts ((?ring ring-spec))
     (or (eq ?ring:color (nth$ 2 ?ring-colors)) (eq ?ring:color (nth$ 4 ?ring-colors)))
-    (modify ?ring (req-bases 0))
     (bind ?free-ring-colors (append$ ?free-ring-colors ?ring:color))
+    (modify ?ring (req-bases 0))
   )
 
   ; Randomly assign an order to be a competitive order

--- a/src/libs/rest-api/clips-rest-api/clips-rest-api.cpp
+++ b/src/libs/rest-api/clips-rest-api/clips-rest-api.cpp
@@ -22,7 +22,9 @@
 
 #include "clips-rest-api.h"
 
+extern "C" {
 #include <clips/clips.h>
+}
 #include <core/threading/mutex_locker.h>
 
 #include <type_traits>
@@ -171,7 +173,7 @@ ClipsRestApi::gen_fact(CLIPS::Fact::pointer &fact, bool formatted)
 		char tmp[16384];
 		tmp[16383] = 0;
 		OpenStringDestination(env_->cobj(), (char *)"ProcPPForm", tmp, 16383);
-		PrintFact(env_->cobj(), (char *)"ProcPPForm", (struct fact *)fact->cobj(), FALSE, FALSE);
+		PrintFact(env_->cobj(), (const char *)"ProcPPForm", (struct fact *)fact->cobj(), FALSE, FALSE);
 		CloseStringDestination(env_->cobj(), (char *)"ProcPPForm");
 		retf.set_formatted(tmp);
 	} else {

--- a/src/libs/rest-api/clips-rest-api/clips-rest-api.cpp
+++ b/src/libs/rest-api/clips-rest-api/clips-rest-api.cpp
@@ -173,7 +173,11 @@ ClipsRestApi::gen_fact(CLIPS::Fact::pointer &fact, bool formatted)
 		char tmp[16384];
 		tmp[16383] = 0;
 		OpenStringDestination(env_->cobj(), (char *)"ProcPPForm", tmp, 16383);
+#ifdef CLIPS_OLD_63_API
+		PrintFact(env_->cobj(), (char *)"ProcPPForm", (struct fact *)fact->cobj(), FALSE, FALSE);
+#else
 		PrintFact(env_->cobj(), (const char *)"ProcPPForm", (struct fact *)fact->cobj(), FALSE, FALSE);
+#endif
 		CloseStringDestination(env_->cobj(), (char *)"ProcPPForm");
 		retf.set_formatted(tmp);
 	} else {

--- a/src/refbox/clips_logger.cpp
+++ b/src/refbox/clips_logger.cpp
@@ -109,7 +109,11 @@ CLIPSLogger::log(const char *logical_name, const char *str)
 }
 
 static int
+#ifdef CLIPS_OLD_63_API
+log_router_query(void *env, char *logical_name)
+#else
 log_router_query(void *env, const char *logical_name)
+#endif
 {
 	if (strcmp(logical_name, "l") == 0)
 		return TRUE;
@@ -135,7 +139,11 @@ log_router_query(void *env, const char *logical_name)
 }
 
 static int
+#ifdef CLIPS_OLD_63_API
+log_router_print(void *env, char *logical_name, char *str)
+#else
 log_router_print(void *env, const char *logical_name, const char *str)
+#endif
 {
 	void        *rc     = GetEnvironmentRouterContext(env);
 	CLIPSLogger *logger = static_cast<CLIPSLogger *>(rc);

--- a/src/refbox/clips_logger.cpp
+++ b/src/refbox/clips_logger.cpp
@@ -109,7 +109,7 @@ CLIPSLogger::log(const char *logical_name, const char *str)
 }
 
 static int
-log_router_query(void *env, char *logical_name)
+log_router_query(void *env, const char *logical_name)
 {
 	if (strcmp(logical_name, "l") == 0)
 		return TRUE;
@@ -135,7 +135,7 @@ log_router_query(void *env, char *logical_name)
 }
 
 static int
-log_router_print(void *env, char *logical_name, char *str)
+log_router_print(void *env, const char *logical_name, const char *str)
 {
 	void        *rc     = GetEnvironmentRouterContext(env);
 	CLIPSLogger *logger = static_cast<CLIPSLogger *>(rc);


### PR DESCRIPTION
This PR updates the used clips version to the latest 6.3x revision. The required packages are provided through a copr from fedora onwards. Circle-ci and Docker container are updated as well.

Due to changes in the new clang-format version it is required to do a full source tree format, which is also included in this PR.