### PR TITLE
Switch to fedora 35 and clang-format 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_fedora:
     docker:
-      - image: fedora:33
+      - image: fedora:35
     steps:
       - run:
           name: Install dependencies
@@ -13,6 +13,7 @@ jobs:
               avahi-devel \
               boost-devel \
               clang \
+              clang-tools-extra \
               clips-devel \
               clipsmm-devel \
               diffutils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #   (at your option) any later version.
 #
 
-FROM fedora:33 as buildenv
+FROM fedora:35 as buildenv
 RUN dnf install -y --nodocs \
       avahi-devel \
       boost-devel \
@@ -46,7 +46,7 @@ RUN shopt -s globstar; \
     /usr/lib/rpm/rpmdeps -P lib/** bin/** > provides.txt && \
     /usr/lib/rpm/rpmdeps -R lib/** bin/** | grep -v -f provides.txt > requires.txt
 
-FROM fedora:33
+FROM fedora:35
 COPY --from=buildenv /buildenv/bin/* /usr/local/bin/
 COPY --from=buildenv /buildenv/lib/* /usr/local/lib64/
 COPY --from=buildenv /buildenv/src/games /usr/local/share/rcll-refbox/games

--- a/src/2014-shell/menus.cpp
+++ b/src/2014-shell/menus.cpp
@@ -163,7 +163,7 @@ GenericItemsMenu::max_cols(int n_items, NCursesMenuItem **items)
 	return rv;
 }
 
-MachineWithPuckMenu::MachineWithPuckMenu(NCursesWindow *                         parent,
+MachineWithPuckMenu::MachineWithPuckMenu(NCursesWindow                          *parent,
                                          Team                                    team,
                                          std::shared_ptr<llsf_msgs::MachineInfo> minfo)
 : Menu(det_lines(team, minfo) + 1 + 2,
@@ -276,7 +276,7 @@ MachineWithPuckMenu::det_lines(Team team, std::shared_ptr<llsf_msgs::MachineInfo
 }
 
 MachineThatCanTakePuckMenu::MachineThatCanTakePuckMenu(
-  NCursesWindow *                         parent,
+  NCursesWindow                          *parent,
   Team                                    team,
   std::shared_ptr<llsf_msgs::MachineInfo> minfo)
 : Menu(det_lines(team, minfo) + 1 + 2,
@@ -410,11 +410,11 @@ MachineThatCanTakePuckMenu::operator bool() const
 	return machine_selected_;
 }
 
-PuckForMachineMenu::PuckForMachineMenu(NCursesWindow *                         parent,
+PuckForMachineMenu::PuckForMachineMenu(NCursesWindow                          *parent,
                                        Team                                    team,
                                        std::shared_ptr<llsf_msgs::PuckInfo>    pinfo,
                                        std::shared_ptr<llsf_msgs::MachineInfo> minfo,
-                                       const llsf_msgs::Machine &              machine)
+                                       const llsf_msgs::Machine               &machine)
 : Menu(det_lines(pinfo, minfo, machine, team) + 1 + 2,
        14 + 2,
        (parent->lines() - (det_lines(pinfo, minfo, machine, team) + 1)) / 2,
@@ -425,7 +425,7 @@ PuckForMachineMenu::PuckForMachineMenu(NCursesWindow *                         p
 	std::list<int> rel_pucks = relevant_pucks(pinfo, minfo, machine, team);
 	items_.resize(rel_pucks.size() + 1);
 	int                      ni     = 0;
-	NCursesMenuItem **       mitems = new NCursesMenuItem *[2 + rel_pucks.size()];
+	NCursesMenuItem        **mitems = new NCursesMenuItem *[2 + rel_pucks.size()];
 	std::list<int>::iterator i;
 	for (i = rel_pucks.begin(); i != rel_pucks.end(); ++i) {
 		const llsf_msgs::Puck &p = pinfo->pucks(*i);
@@ -473,9 +473,9 @@ PuckForMachineMenu::On_Menu_Init()
 }
 
 std::list<int>
-PuckForMachineMenu::relevant_pucks(std::shared_ptr<llsf_msgs::PuckInfo> &   pinfo,
+PuckForMachineMenu::relevant_pucks(std::shared_ptr<llsf_msgs::PuckInfo>    &pinfo,
                                    std::shared_ptr<llsf_msgs::MachineInfo> &minfo,
-                                   const llsf_msgs::Machine &               machine,
+                                   const llsf_msgs::Machine                &machine,
                                    Team                                     team)
 {
 	std::list<int> rv;
@@ -531,9 +531,9 @@ PuckForMachineMenu::relevant_pucks(std::shared_ptr<llsf_msgs::PuckInfo> &   pinf
 }
 
 int
-PuckForMachineMenu::det_lines(std::shared_ptr<llsf_msgs::PuckInfo> &   pinfo,
+PuckForMachineMenu::det_lines(std::shared_ptr<llsf_msgs::PuckInfo>    &pinfo,
                               std::shared_ptr<llsf_msgs::MachineInfo> &minfo,
-                              const llsf_msgs::Machine &               machine,
+                              const llsf_msgs::Machine                &machine,
                               Team                                     team)
 {
 	return relevant_pucks(pinfo, minfo, machine, team).size();
@@ -679,7 +679,7 @@ TeamSelectMenu::det_lines(std::shared_ptr<llsf_msgs::GameInfo> &gameinfo)
 	return gameinfo->known_teams_size();
 }
 
-RobotMaintenanceMenu::RobotMaintenanceMenu(NCursesWindow *                       parent,
+RobotMaintenanceMenu::RobotMaintenanceMenu(NCursesWindow                        *parent,
                                            Team                                  team,
                                            std::shared_ptr<llsf_msgs::RobotInfo> rinfo)
 : Menu(det_lines(team, rinfo) + 1 + 2,

--- a/src/2014-shell/menus.h
+++ b/src/2014-shell/menus.h
@@ -119,7 +119,7 @@ private:
 class MachineWithPuckMenu : public Menu
 {
 public:
-	MachineWithPuckMenu(NCursesWindow *                         parent,
+	MachineWithPuckMenu(NCursesWindow                          *parent,
 	                    Team                                    team,
 	                    std::shared_ptr<llsf_msgs::MachineInfo> minfo);
 
@@ -146,7 +146,7 @@ private:
 class RobotMaintenanceMenu : public Menu
 {
 public:
-	RobotMaintenanceMenu(NCursesWindow *                       parent,
+	RobotMaintenanceMenu(NCursesWindow                        *parent,
 	                     Team                                  team,
 	                     std::shared_ptr<llsf_msgs::RobotInfo> minfo);
 
@@ -174,7 +174,7 @@ private:
 class MachineThatCanTakePuckMenu : public Menu
 {
 public:
-	MachineThatCanTakePuckMenu(NCursesWindow *                         parent,
+	MachineThatCanTakePuckMenu(NCursesWindow                          *parent,
 	                           Team                                    team,
 	                           std::shared_ptr<llsf_msgs::MachineInfo> minfo);
 
@@ -198,11 +198,11 @@ private:
 class PuckForMachineMenu : public Menu
 {
 public:
-	PuckForMachineMenu(NCursesWindow *                         parent,
+	PuckForMachineMenu(NCursesWindow                          *parent,
 	                   Team                                    team,
 	                   std::shared_ptr<llsf_msgs::PuckInfo>    pinfo,
 	                   std::shared_ptr<llsf_msgs::MachineInfo> minfo,
-	                   const llsf_msgs::Machine &              machine);
+	                   const llsf_msgs::Machine               &machine);
 
 	const llsf_msgs::Puck &puck();
 	                       operator bool() const;
@@ -210,13 +210,13 @@ public:
 private:
 	void           puck_selected(int i);
 	virtual void   On_Menu_Init();
-	std::list<int> relevant_pucks(std::shared_ptr<llsf_msgs::PuckInfo> &   pinfo,
+	std::list<int> relevant_pucks(std::shared_ptr<llsf_msgs::PuckInfo>    &pinfo,
 	                              std::shared_ptr<llsf_msgs::MachineInfo> &minfo,
-	                              const llsf_msgs::Machine &               machine,
+	                              const llsf_msgs::Machine                &machine,
 	                              Team                                     team);
-	int            det_lines(std::shared_ptr<llsf_msgs::PuckInfo> &   pinfo,
+	int            det_lines(std::shared_ptr<llsf_msgs::PuckInfo>    &pinfo,
 	                         std::shared_ptr<llsf_msgs::MachineInfo> &minfo,
-	                         const llsf_msgs::Machine &               machine,
+	                         const llsf_msgs::Machine                &machine,
 	                         Team                                     team);
 
 private:

--- a/src/2014-shell/shell.cpp
+++ b/src/2014-shell/shell.cpp
@@ -329,7 +329,7 @@ LLSFRefBoxShell::handle_keyboard(const boost::system::error_code &error)
 							if (pfmm) {
 								//rb_log_->printw("Valid puck selected\n");
 								const llsf_msgs::Machine &m                        = mtctpm.machine();
-								const llsf_msgs::Puck &   p                        = pfmm.puck();
+								const llsf_msgs::Puck    &p                        = pfmm.puck();
 								bool                      can_be_placed_under_rfid = !m.has_puck_under_rfid();
 								bool can_be_loaded_with = (m.inputs_size() - m.loaded_with_size()) > 1;
 								for (int i = 0; i < m.loaded_with_size(); ++i) {
@@ -859,7 +859,7 @@ LLSFRefBoxShell::client_msg(uint16_t                                   comp_id,
 		last_minfo_ = minfo;
 		for (int i = 0; i < minfo->machines_size(); ++i) {
 			std::map<std::string, LLSFRefBoxShellMachine *>::iterator mpanel;
-			const llsf_msgs::Machine &                                mspec = minfo->machines(i);
+			const llsf_msgs::Machine                                 &mspec = minfo->machines(i);
 			//logf("Adding %s @ (%f, %f, %f)\n", mspec.name().c_str(),
 			//     mspec.pose().x(), mspec.pose().y(), mspec.pose().ori());
 			if ((mpanel = machines_.find(mspec.name())) != machines_.end()) {
@@ -1005,8 +1005,8 @@ void
 LLSFRefBoxShell::log(llsf_log_msgs::LogMessage::LogLevel log_level,
                      long int                            ts_sec,
                      long int                            ts_nsec,
-                     const std::string &                 component,
-                     const std::string &                 message)
+                     const std::string                  &component,
+                     const std::string                  &message)
 {
 	rb_log_->standend();
 	rb_log_->attron(' ' | COLOR_PAIR(COLOR_DEFAULT));
@@ -1040,8 +1040,8 @@ LLSFRefBoxShell::log(llsf_log_msgs::LogMessage::LogLevel log_level,
 
 void
 LLSFRefBoxShell::log(llsf_log_msgs::LogMessage::LogLevel log_level,
-                     const std::string &                 component,
-                     const char *                        format,
+                     const std::string                  &component,
+                     const char                         *format,
                      ...)
 {
 	va_list arg;
@@ -1268,7 +1268,7 @@ LLSFRefBoxShell::run()
 	// State menu
 	const google::protobuf::EnumDescriptor *state_enum_desc = llsf_msgs::GameState_State_descriptor();
 	const int                               num_state_values = state_enum_desc->value_count() - 1;
-	NCursesMenuItem **                      state_items = new NCursesMenuItem *[2 + num_state_values];
+	NCursesMenuItem                       **state_items = new NCursesMenuItem *[2 + num_state_values];
 	int                                     item_i      = 0;
 	for (int i = 0; i < state_enum_desc->value_count(); ++i) {
 		if (state_enum_desc->value(i)->name() == "INIT")
@@ -1294,7 +1294,7 @@ LLSFRefBoxShell::run()
 	// Phase menu
 	const google::protobuf::EnumDescriptor *phase_enum_desc = llsf_msgs::GameState_Phase_descriptor();
 	const int                               num_phase_values = phase_enum_desc->value_count();
-	NCursesMenuItem **                      phase_items = new NCursesMenuItem *[2 + num_phase_values];
+	NCursesMenuItem                       **phase_items = new NCursesMenuItem *[2 + num_phase_values];
 	size_t                                  max_length  = 0;
 	for (int i = 0; i < phase_enum_desc->value_count(); ++i) {
 		SignalItem *item = new SignalItem(phase_enum_desc->value(i)->name());
@@ -1325,7 +1325,7 @@ LLSFRefBoxShell::run()
 	// Team color menu
 	const google::protobuf::EnumDescriptor *team_enum_desc  = llsf_msgs::Team_descriptor();
 	const int                               num_team_values = team_enum_desc->value_count();
-	NCursesMenuItem **                      team_items = new NCursesMenuItem *[2 + num_team_values];
+	NCursesMenuItem                       **team_items = new NCursesMenuItem *[2 + num_team_values];
 	for (int i = 0; i < team_enum_desc->value_count(); ++i) {
 		SignalItem *item = new SignalItem(team_enum_desc->value(i)->name());
 		item->signal().connect(

--- a/src/2014-shell/shell.h
+++ b/src/2014-shell/shell.h
@@ -121,12 +121,12 @@ private: // methods
 	void log(llsf_log_msgs::LogMessage::LogLevel log_level,
 	         long int                            ts_sec,
 	         long int                            ts_nsec,
-	         const std::string &                 component,
-	         const std::string &                 message);
+	         const std::string                  &component,
+	         const std::string                  &message);
 
 	void log(llsf_log_msgs::LogMessage::LogLevel log_level,
-	         const std::string &                 component,
-	         const char *                        format,
+	         const std::string                  &component,
+	         const char                         *format,
 	         ...);
 
 	void logf(const char *format, ...);

--- a/src/examples/peer.cpp
+++ b/src/examples/peer.cpp
@@ -76,7 +76,7 @@ private:
 	}
 
 	void
-	peer_msg(boost::asio::ip::udp::endpoint &           endpoint,
+	peer_msg(boost::asio::ip::udp::endpoint            &endpoint,
 	         uint16_t                                   comp_id,
 	         uint16_t                                   msg_type,
 	         std::shared_ptr<google::protobuf::Message> msg)
@@ -116,7 +116,7 @@ private:
 
 private:
 	std::string            host_;
-	MessageRegister *      mr_;
+	MessageRegister       *mr_;
 	ProtobufBroadcastPeer *peer_public_;
 	ProtobufBroadcastPeer *peer_team_;
 };

--- a/src/libs/config/config.cpp
+++ b/src/libs/config/config.cpp
@@ -684,7 +684,7 @@ Configuration::get_bools_or_defaults(const char *path, const std::vector<bool> &
 }
 
 std::vector<std::string>
-Configuration::get_strings_or_defaults(const char *                    path,
+Configuration::get_strings_or_defaults(const char                     *path,
                                        const std::vector<std::string> &default_val)
 {
 	try {

--- a/src/libs/config/config.h
+++ b/src/libs/config/config.h
@@ -132,13 +132,13 @@ public:
 	virtual std::vector<int>          get_ints(const char *path)    = 0;
 	virtual std::vector<bool>         get_bools(const char *path)   = 0;
 	virtual std::vector<std::string>  get_strings(const char *path) = 0;
-	virtual std::vector<float>        get_floats_or_defaults(const char *              path,
+	virtual std::vector<float>        get_floats_or_defaults(const char               *path,
 	                                                         const std::vector<float> &default_val);
 	virtual std::vector<unsigned int>
 	get_uints_or_defaults(const char *path, const std::vector<unsigned int> &default_val);
-	virtual std::vector<int>  get_ints_or_defaults(const char *            path,
+	virtual std::vector<int>  get_ints_or_defaults(const char             *path,
 	                                               const std::vector<int> &default_val);
-	virtual std::vector<bool> get_bools_or_defaults(const char *             path,
+	virtual std::vector<bool> get_bools_or_defaults(const char              *path,
 	                                                const std::vector<bool> &default_val);
 	virtual std::vector<std::string>
 	get_strings_or_defaults(const char *path, const std::vector<std::string> &default_val);

--- a/src/libs/config/yaml.cpp
+++ b/src/libs/config/yaml.cpp
@@ -408,7 +408,7 @@ std::shared_ptr<YamlConfigurationNode>
 YamlConfiguration::read_yaml_file(std::string                 filename,
                                   bool                        ignore_missing,
                                   std::queue<LoadQueueEntry> &load_queue,
-                                  std::string &               host_file)
+                                  std::string                &host_file)
 {
 	if (access(filename.c_str(), R_OK) == -1) {
 		if (ignore_missing) {
@@ -452,11 +452,11 @@ YamlConfiguration::read_yaml_file(std::string                 filename,
 
 void
 YamlConfiguration::read_yaml_config(std::string                             filename,
-                                    std::string &                           host_file,
+                                    std::string                            &host_file,
                                     std::shared_ptr<YamlConfigurationNode> &root,
                                     std::shared_ptr<YamlConfigurationNode> &host_root,
-                                    std::list<std::string> &                files,
-                                    std::list<std::string> &                dirs)
+                                    std::list<std::string>                 &files,
+                                    std::list<std::string>                 &dirs)
 {
 	std::queue<LoadQueueEntry> load_queue;
 	load_queue.push(LoadQueueEntry(filename, false));
@@ -527,7 +527,7 @@ static std::string
 insert_hostname(std::string prelim)
 {
 	const std::string to_replace = "$host";
-	static char *     hostname   = NULL;
+	static char      *hostname   = NULL;
 	if (hostname == NULL) {
 		hostname = new char[256];
 		gethostname(hostname, 256);
@@ -541,9 +541,9 @@ insert_hostname(std::string prelim)
 }
 
 void
-YamlConfiguration::read_meta_doc(YAML::Node &                doc,
+YamlConfiguration::read_meta_doc(YAML::Node                 &doc,
                                  std::queue<LoadQueueEntry> &load_queue,
-                                 std::string &               host_file)
+                                 std::string                &host_file)
 {
 	try {
 		const YAML::Node &includes = doc["include"];

--- a/src/libs/config/yaml.h
+++ b/src/libs/config/yaml.h
@@ -68,7 +68,7 @@ public:
 	virtual std::vector<int>          get_ints(const char *path);
 	virtual std::vector<bool>         get_bools(const char *path);
 	virtual std::vector<std::string>  get_strings(const char *path);
-	virtual ValueIterator *           get_value(const char *path);
+	virtual ValueIterator            *get_value(const char *path);
 	virtual std::string               get_comment(const char *path);
 	virtual std::string               get_default_comment(const char *path);
 
@@ -178,13 +178,13 @@ private:
 	std::shared_ptr<YamlConfigurationNode> read_yaml_file(std::string                 filename,
 	                                                      bool                        ignore_missing,
 	                                                      std::queue<LoadQueueEntry> &load_queue,
-	                                                      std::string &               host_file);
+	                                                      std::string                &host_file);
 	void                                   read_yaml_config(std::string                             filename,
-	                                                        std::string &                           host_file,
+	                                                        std::string                            &host_file,
 	                                                        std::shared_ptr<YamlConfigurationNode> &root,
 	                                                        std::shared_ptr<YamlConfigurationNode> &host_root,
-	                                                        std::list<std::string> &                files,
-	                                                        std::list<std::string> &                dirs);
+	                                                        std::list<std::string>                 &files,
+	                                                        std::list<std::string>                 &dirs);
 	void                                   write_host_file();
 
 	std::string config_file_;

--- a/src/libs/config/yaml_node.h
+++ b/src/libs/config/yaml_node.h
@@ -165,7 +165,7 @@ inline bool
 convert(const std::string &input, unsigned int &rhs)
 {
 	errno = 0;
-	char *   endptr;
+	char    *endptr;
 	long int l = strtol(input.c_str(), &endptr, 0);
 
 	if ((errno == ERANGE && (l == LONG_MAX || l == LONG_MIN)) || (errno != 0 && l == 0)) {

--- a/src/libs/core/exception.cpp
+++ b/src/libs/core/exception.cpp
@@ -547,7 +547,7 @@ void
 Exception::print_backtrace() const throw()
 {
 #ifdef HAVE_EXECINFO
-	void * array[25];
+	void  *array[25];
 	int    size    = backtrace(array, 25);
 	char **symbols = backtrace_symbols(array, size);
 
@@ -569,7 +569,7 @@ char *
 Exception::generate_backtrace() const throw()
 {
 #ifdef HAVE_BACKTRACE
-	void * array[25];
+	void  *array[25];
 	int    size    = backtrace(array, 25);
 	char **symbols = backtrace_symbols(array, size);
 
@@ -770,7 +770,8 @@ Exception::iterator::operator!=(const iterator &i) const
  * Get message at current position. Returns NULL for the invalid ieterator.
  * @return message or NULL if iterator is invalid
  */
-const char *Exception::iterator::operator*() const
+const char *
+Exception::iterator::operator*() const
 {
 	if (mlist != NULL) {
 		return mlist->msg;

--- a/src/libs/core/exception.h
+++ b/src/libs/core/exception.h
@@ -47,7 +47,7 @@ public:
 	void         append(const Exception &e) throw();
 	void         print_trace() throw();
 	void         print_backtrace() const throw();
-	char *       generate_backtrace() const throw();
+	char        *generate_backtrace() const throw();
 
 	int get_errno() throw();
 
@@ -64,7 +64,7 @@ protected:
 	struct message_list_t
 	{
 		message_list_t *next; /**< pointer to next element, NULL if last element */
-		char *          msg;  /**< pointer to message, may not be NULL, will be freed
+		char           *msg;  /**< pointer to message, may not be NULL, will be freed
 			       *   in dtor */
 	};
 
@@ -87,7 +87,7 @@ public:
 		bool operator!=(const iterator &i) const;
 
 		const char *operator*() const;
-		iterator &  operator=(const iterator &i);
+		iterator   &operator=(const iterator &i);
 
 	private:
 		message_list_t *mlist;
@@ -108,7 +108,7 @@ protected:
 	message_list_t *messages;
 	message_list_t *messages_iterator;
 	message_list_t *messages_end;
-	Mutex *         messages_mutex;
+	Mutex          *messages_mutex;
 
 	int _errno;
 

--- a/src/libs/core/plugin.h
+++ b/src/libs/core/plugin.h
@@ -58,7 +58,7 @@ protected:
 	Configuration *config;
 
 private:
-	char *      _name_alloc;
+	char	     *_name_alloc;
 	const char *_name;
 };
 

--- a/src/libs/core/qa/qa_barrier.cpp
+++ b/src/libs/core/qa/qa_barrier.cpp
@@ -53,7 +53,7 @@ public:
 	}
 
 private:
-	Barrier *    barrier;
+	Barrier     *barrier;
 	unsigned int sleep_time;
 	string       pp;
 };

--- a/src/libs/core/qa/qa_mutex_count.cpp
+++ b/src/libs/core/qa/qa_mutex_count.cpp
@@ -53,7 +53,7 @@ public:
    * @param sleep_time Variable sleep time at end of thread
    */
 	ExampleMutexCountThread(string        s,
-	                        Mutex *       m,
+	                        Mutex        *m,
 	                        unsigned int *mutex_count,
 	                        unsigned int *non_mutex_count,
 	                        unsigned int  sleep_time)
@@ -105,7 +105,7 @@ private:
 	string        s;
 	bool          sl;
 	unsigned int  slt;
-	Mutex *       m;
+	Mutex	      *m;
 	unsigned int *mc;
 	unsigned int *nmc;
 };

--- a/src/libs/core/qa/qa_rwlock.cpp
+++ b/src/libs/core/qa/qa_rwlock.cpp
@@ -66,7 +66,7 @@ public:
 
 private:
 	ReadWriteLock *rwlock;
-	int *          val;
+	int           *val;
 	unsigned int   sleep_time;
 };
 
@@ -103,7 +103,7 @@ public:
 private:
 	string         pp;
 	ReadWriteLock *rwlock;
-	int *          val;
+	int           *val;
 	unsigned int   sleep_time;
 };
 

--- a/src/libs/core/qa/qa_waitcond_serialize.cpp
+++ b/src/libs/core/qa/qa_waitcond_serialize.cpp
@@ -80,7 +80,7 @@ public:
 
 private:
 	WaitCondition *wc;
-	Mutex *        m;
+	Mutex         *m;
 
 	int *val;
 	int  actval;
@@ -95,7 +95,7 @@ main(int argc, char **argv)
 {
 	int val = 0;
 
-	Mutex *        m  = new Mutex();
+	Mutex         *m  = new Mutex();
 	WaitCondition *wc = new WaitCondition(m);
 
 	ExampleWaitCondThread *t1 = new ExampleWaitCondThread(wc, m, &val, 0, 4);

--- a/src/libs/core/threading/interruptible_barrier.cpp
+++ b/src/libs/core/threading/interruptible_barrier.cpp
@@ -38,7 +38,7 @@ class InterruptibleBarrierData
 {
 public:
 	unsigned int   threads_left;
-	Mutex *        mutex;
+	Mutex         *mutex;
 	WaitCondition *waitcond;
 	bool           own_mutex;
 

--- a/src/libs/core/threading/mutex_locker.h
+++ b/src/libs/core/threading/mutex_locker.h
@@ -43,7 +43,7 @@ public:
 private:
 	bool          __locked;
 	RefPtr<Mutex> __refmutex;
-	Mutex *       __rawmutex;
+	Mutex	      *__rawmutex;
 };
 
 } // end namespace fawkes

--- a/src/libs/core/threading/scoped_rwlock.cpp
+++ b/src/libs/core/threading/scoped_rwlock.cpp
@@ -114,7 +114,7 @@ ScopedRWLock::ScopedRWLock(RefPtr<ReadWriteLock>  rwlock,
  * false to not lock
  * @param lock_type locking type, lock either for writing or for reading
  */
-ScopedRWLock::ScopedRWLock(ReadWriteLock *        rwlock,
+ScopedRWLock::ScopedRWLock(ReadWriteLock         *rwlock,
                            ScopedRWLock::LockType lock_type,
                            bool                   initially_lock)
 {

--- a/src/libs/core/threading/scoped_rwlock.h
+++ b/src/libs/core/threading/scoped_rwlock.h
@@ -52,7 +52,7 @@ private:
 	LockType              __lock_type;
 	bool                  __locked;
 	RefPtr<ReadWriteLock> __refrwlock;
-	ReadWriteLock *       __rawrwlock;
+	ReadWriteLock        *__rawrwlock;
 };
 
 } // end namespace fawkes

--- a/src/libs/core/threading/thread.h
+++ b/src/libs/core/threading/thread.h
@@ -105,8 +105,8 @@ public:
 	void unset_flag(uint32_t flag);
 	bool flagged_bad() const;
 
-	static Thread *  current_thread();
-	static Thread *  current_thread_noexc() throw();
+	static Thread   *current_thread();
+	static Thread   *current_thread_noexc() throw();
 	static pthread_t current_thread_id();
 
 	static void init_main();
@@ -141,12 +141,12 @@ protected:
 
 	bool           finalize_prepared;
 	mutable Mutex *loop_mutex;
-	Mutex *        loopinterrupt_antistarve_mutex;
+	Mutex         *loopinterrupt_antistarve_mutex;
 
 private:
 	Thread(const Thread &t);
 	Thread(const char *name, pthread_t id);
-	Thread &     operator=(const Thread &t);
+	Thread      &operator=(const Thread &t);
 	static void *entry(void *pthis);
 	void         __constructor(const char *name, OpMode op_mode);
 	void         notify_of_failed_init();
@@ -158,18 +158,18 @@ private:
 
 	pthread_t __thread_id;
 
-	Barrier *      __startup_barrier;
+	Barrier       *__startup_barrier;
 	mutable Mutex *__sleep_mutex;
 	WaitCondition *__sleep_condition;
 	unsigned int   __pending_wakeups;
-	Barrier *      __barrier;
+	Barrier       *__barrier;
 
 	bool           __loop_done;
-	Mutex *        __loop_done_mutex;
+	Mutex         *__loop_done_mutex;
 	WaitCondition *__loop_done_waitcond;
 
 	bool           __prepfin_hold;
-	Mutex *        __prepfin_hold_mutex;
+	Mutex         *__prepfin_hold_mutex;
 	WaitCondition *__prepfin_hold_waitcond;
 
 	bool  __started;

--- a/src/libs/core/threading/thread_list.cpp
+++ b/src/libs/core/threading/thread_list.cpp
@@ -198,7 +198,7 @@ ThreadList::wakeup(Barrier *barrier)
 void
 ThreadList::wakeup_unlocked(Barrier *barrier)
 {
-	Exception *  exc   = NULL;
+	Exception   *exc   = NULL;
 	unsigned int count = 1;
 	for (iterator i = begin(); i != end(); ++i) {
 		if (!(*i)->flagged_bad()) {

--- a/src/libs/core/threading/thread_list.h
+++ b/src/libs/core/threading/thread_list.h
@@ -121,9 +121,9 @@ private:
 	void update_barrier();
 
 private:
-	char *                __name;
+	char                 *__name;
 	bool                  __sealed;
-	Mutex *               __finalize_mutex;
+	Mutex                *__finalize_mutex;
 	InterruptibleBarrier *__wnw_barrier;
 
 	std::list<std::pair<InterruptibleBarrier *, ThreadList>>           __wnw_bad_barriers;

--- a/src/libs/core/threading/wait_condition.h
+++ b/src/libs/core/threading/wait_condition.h
@@ -44,7 +44,7 @@ public:
 
 private:
 	WaitConditionData *__cond_data;
-	Mutex *            __mutex;
+	Mutex             *__mutex;
 	bool               __own_mutex;
 };
 

--- a/src/libs/core/utils/lockptr.h
+++ b/src/libs/core/utils/lockptr.h
@@ -264,9 +264,9 @@ public:
 	}
 
 private:
-	T_CppObject *  __cpp_object;
+	T_CppObject   *__cpp_object;
 	mutable Mutex *__obj_mutex;
-	mutable int *  __ref_count;
+	mutable int   *__ref_count;
 	mutable Mutex *__ref_mutex;
 };
 
@@ -274,13 +274,15 @@ private:
 // If it would come after them it wouldn't be inlined.
 
 template <class T_CppObject>
-inline T_CppObject *LockPtr<T_CppObject>::operator->() const
+inline T_CppObject *
+LockPtr<T_CppObject>::operator->() const
 {
 	return __cpp_object;
 }
 
 template <class T_CppObject>
-inline T_CppObject *LockPtr<T_CppObject>::operator*() const
+inline T_CppObject *
+LockPtr<T_CppObject>::operator*() const
 {
 	return __cpp_object;
 }
@@ -331,9 +333,9 @@ inline LockPtr<T_CppObject>::LockPtr(T_CppObject *cpp_object)
 //Used by cast_*() implementations:
 template <class T_CppObject>
 inline LockPtr<T_CppObject>::LockPtr(T_CppObject *cpp_object,
-                                     Mutex *      objmutex,
-                                     int *        refcount,
-                                     Mutex *      refmutex)
+                                     Mutex       *objmutex,
+                                     int         *refcount,
+                                     Mutex       *refmutex)
 : __cpp_object(cpp_object), __obj_mutex(objmutex), __ref_count(refcount), __ref_mutex(refmutex)
 {
 	if (__cpp_object && __obj_mutex && __ref_count && __ref_mutex) {
@@ -383,9 +385,9 @@ inline void
 LockPtr<T_CppObject>::swap(LockPtr<T_CppObject> &other)
 {
 	T_CppObject *const temp           = __cpp_object;
-	int *              temp_count     = __ref_count;
-	Mutex *            temp_ref_mutex = __ref_mutex;
-	Mutex *            temp_obj_mutex = __obj_mutex;
+	int               *temp_count     = __ref_count;
+	Mutex             *temp_ref_mutex = __ref_mutex;
+	Mutex             *temp_obj_mutex = __obj_mutex;
 
 	__cpp_object = other.__cpp_object;
 	__obj_mutex  = other.__obj_mutex;

--- a/src/libs/core/utils/refcount.h
+++ b/src/libs/core/utils/refcount.h
@@ -40,7 +40,7 @@ public:
 
 private:
 	unsigned int refc;
-	Mutex *      ref_mutex;
+	Mutex       *ref_mutex;
 };
 
 } // end namespace fawkes

--- a/src/libs/core/utils/refptr.h
+++ b/src/libs/core/utils/refptr.h
@@ -226,8 +226,8 @@ public:
 	}
 
 private:
-	T_CppObject *  __cpp_object;
-	mutable int *  __ref_count;
+	T_CppObject   *__cpp_object;
+	mutable int   *__ref_count;
 	mutable Mutex *__ref_mutex;
 };
 
@@ -235,13 +235,15 @@ private:
 // If it would come after them it wouldn't be inlined.
 
 template <class T_CppObject>
-inline T_CppObject *RefPtr<T_CppObject>::operator->() const
+inline T_CppObject *
+RefPtr<T_CppObject>::operator->() const
 {
 	return __cpp_object;
 }
 
 template <class T_CppObject>
-inline T_CppObject *RefPtr<T_CppObject>::operator*() const
+inline T_CppObject *
+RefPtr<T_CppObject>::operator*() const
 {
 	return __cpp_object;
 }
@@ -334,8 +336,8 @@ inline void
 RefPtr<T_CppObject>::swap(RefPtr<T_CppObject> &other)
 {
 	T_CppObject *const temp       = __cpp_object;
-	int *              temp_count = __ref_count;
-	Mutex *            temp_mutex = __ref_mutex;
+	int               *temp_count = __ref_count;
+	Mutex             *temp_mutex = __ref_mutex;
 
 	__cpp_object = other.__cpp_object;
 	__ref_count  = other.__ref_count;

--- a/src/libs/logging/cache.cpp
+++ b/src/libs/logging/cache.cpp
@@ -289,8 +289,8 @@ CacheLogger::log_error(const char *component, fawkes::Exception &e)
 void
 CacheLogger::tlog_push_message(LogLevel        ll,
                                struct timeval *t,
-                               const char *    component,
-                               const char *    format,
+                               const char     *component,
+                               const char     *format,
                                va_list         va)
 {
 	if (log_level <= ll) {
@@ -334,8 +334,8 @@ CacheLogger::tlog_push_message(LogLevel        ll,
 
 void
 CacheLogger::tlog_push_message(LogLevel           ll,
-                               struct timeval *   t,
-                               const char *       component,
+                               struct timeval    *t,
+                               const char        *component,
                                fawkes::Exception &e)
 {
 	if (log_level <= ll) {

--- a/src/libs/logging/cache.h
+++ b/src/libs/logging/cache.h
@@ -71,7 +71,7 @@ public:
 	virtual void tlog_error(struct timeval *t, const char *component, fawkes::Exception &e);
 
 	virtual void
-	             vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
+	vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_info(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_warn(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void
@@ -106,14 +106,14 @@ private:
 	void push_message(LogLevel ll, const char *component, fawkes::Exception &e);
 	void tlog_push_message(LogLevel        ll,
 	                       struct timeval *t,
-	                       const char *    component,
-	                       const char *    format,
+	                       const char     *component,
+	                       const char     *format,
 	                       va_list         va);
 	void
 	tlog_push_message(LogLevel ll, struct timeval *t, const char *component, fawkes::Exception &);
 
 private:
-	struct ::tm *  now_s;
+	struct ::tm   *now_s;
 	fawkes::Mutex *mutex;
 
 	std::list<CacheEntry> __messages;

--- a/src/libs/logging/console.h
+++ b/src/libs/logging/console.h
@@ -64,14 +64,14 @@ public:
 	virtual void tlog_error(struct timeval *t, const char *component, fawkes::Exception &e);
 
 	virtual void
-	             vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
+	vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_info(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_warn(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void
 	vtlog_error(struct timeval *t, const char *component, const char *format, va_list va);
 
 private:
-	struct ::tm *  now_s;
+	struct ::tm   *now_s;
 	fawkes::Mutex *mutex;
 };
 

--- a/src/libs/logging/file.h
+++ b/src/libs/logging/file.h
@@ -66,7 +66,7 @@ public:
 	virtual void tlog_error(struct timeval *t, const char *component, fawkes::Exception &e);
 
 	virtual void
-	             vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
+	vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_info(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_warn(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void
@@ -75,7 +75,7 @@ public:
 private:
 	struct ::tm *now_s;
 
-	FILE *         log_file;
+	FILE          *log_file;
 	fawkes::Mutex *mutex;
 };
 

--- a/src/libs/logging/logger.cpp
+++ b/src/libs/logging/logger.cpp
@@ -285,8 +285,8 @@ Logger::vlog(LogLevel level, const char *component, const char *format, va_list 
 void
 Logger::vtlog(LogLevel        level,
               struct timeval *t,
-              const char *    component,
-              const char *    format,
+              const char     *component,
+              const char     *format,
               va_list         va)
 {
 	if (log_level <= level) {

--- a/src/libs/logging/logger.h
+++ b/src/libs/logging/logger.h
@@ -78,7 +78,7 @@ public:
 	virtual void vlog_error(const char *component, const char *format, va_list va) = 0;
 
 	virtual void
-	             tlog(LogLevel level, struct timeval *t, const char *component, const char *format, ...);
+	tlog(LogLevel level, struct timeval *t, const char *component, const char *format, ...);
 	virtual void tlog_debug(struct timeval *t, const char *component, const char *format, ...) = 0;
 	virtual void tlog_info(struct timeval *t, const char *component, const char *format, ...)  = 0;
 	virtual void tlog_warn(struct timeval *t, const char *component, const char *format, ...)  = 0;

--- a/src/libs/logging/multi.cpp
+++ b/src/libs/logging/multi.cpp
@@ -48,7 +48,7 @@ public:
 
 	fawkes::LockList<Logger *>           loggers;
 	fawkes::LockList<Logger *>::iterator logit;
-	fawkes::Mutex *                      mutex;
+	fawkes::Mutex                       *mutex;
 	fawkes::Thread::CancelState          old_state;
 };
 /// @endcond
@@ -574,8 +574,8 @@ MultiLogger::tlog_error(struct timeval *t, const char *component, fawkes::Except
 void
 MultiLogger::vtlog(LogLevel        level,
                    struct timeval *t,
-                   const char *    component,
-                   const char *    format,
+                   const char     *component,
+                   const char     *format,
                    va_list         va)
 {
 	data->mutex->lock();

--- a/src/libs/logging/multi.h
+++ b/src/libs/logging/multi.h
@@ -62,7 +62,7 @@ public:
 	virtual void vlog_error(const char *component, const char *format, va_list va);
 
 	virtual void
-	             tlog(LogLevel level, struct timeval *t, const char *component, const char *format, ...);
+	tlog(LogLevel level, struct timeval *t, const char *component, const char *format, ...);
 	virtual void tlog_debug(struct timeval *t, const char *component, const char *format, ...);
 	virtual void tlog_info(struct timeval *t, const char *component, const char *format, ...);
 	virtual void tlog_warn(struct timeval *t, const char *component, const char *format, ...);
@@ -77,7 +77,7 @@ public:
 	virtual void
 	vtlog(LogLevel level, struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void
-	             vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
+	vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_info(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_warn(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void

--- a/src/libs/logging/network.cpp
+++ b/src/libs/logging/network.cpp
@@ -57,10 +57,10 @@ NetworkLogger::~NetworkLogger()
 
 void
 NetworkLogger::send_message(Logger::LogLevel level,
-                            struct timeval * t,
-                            const char *     component,
+                            struct timeval  *t,
+                            const char      *component,
                             bool             is_exception,
-                            const char *     format,
+                            const char      *format,
                             va_list          va)
 {
 	struct timeval now;
@@ -92,10 +92,10 @@ NetworkLogger::send_message(Logger::LogLevel level,
 
 void
 NetworkLogger::send_message(Logger::LogLevel level,
-                            struct timeval * t,
-                            const char *     component,
+                            struct timeval  *t,
+                            const char      *component,
                             bool             is_exception,
-                            const char *     message)
+                            const char      *message)
 {
 	struct timeval now;
 	if (t == NULL) {

--- a/src/libs/logging/network.h
+++ b/src/libs/logging/network.h
@@ -64,7 +64,7 @@ public:
 	virtual void tlog_error(struct timeval *t, const char *component, fawkes::Exception &e);
 
 	virtual void
-	             vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
+	vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_info(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_warn(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void
@@ -72,16 +72,16 @@ public:
 
 private:
 	void send_message(Logger::LogLevel level,
-	                  struct timeval * t,
-	                  const char *     component,
+	                  struct timeval  *t,
+	                  const char      *component,
 	                  bool             is_exception,
-	                  const char *     format,
+	                  const char      *format,
 	                  va_list          va);
 	void send_message(Logger::LogLevel level,
-	                  struct timeval * t,
-	                  const char *     component,
+	                  struct timeval  *t,
+	                  const char      *component,
 	                  bool             is_exception,
-	                  const char *     message);
+	                  const char      *message);
 
 	protobuf_comm::ProtobufStreamServer *pb_server_;
 };

--- a/src/libs/logging/websocket.cpp
+++ b/src/libs/logging/websocket.cpp
@@ -77,7 +77,7 @@ WebsocketLogger::~WebsocketLogger()
 std::string
 WebsocketLogger::formatter(const char *format, va_list va)
 {
-	char *      tmp;
+	char	     *tmp;
 	std::string str_message;
 	if (vasprintf(&tmp, format, va) != -1) {
 		str_message = std::string(tmp);
@@ -96,7 +96,7 @@ WebsocketLogger::formatter(const char *format, va_list va)
 std::string
 WebsocketLogger::formatter(const char *format, const char *text)
 {
-	char *      tmp;
+	char	     *tmp;
 	std::string str_message;
 	if (asprintf(&tmp, format, text) != -1) {
 		str_message = std::string(tmp);
@@ -117,7 +117,7 @@ WebsocketLogger::formatter(const char *format, const char *text)
  */
 void
 WebsocketLogger::build_document(rapidjson::Document *d,
-                                const char *         component,
+                                const char          *component,
                                 std::string          level,
                                 std::string          time,
                                 std::string          message,
@@ -158,10 +158,10 @@ WebsocketLogger::build_document(rapidjson::Document *d,
  */
 void
 WebsocketLogger::build_document(rapidjson::Document *d,
-                                const char *         component,
+                                const char          *component,
                                 std::string          level,
                                 std::string          time,
-                                rapidjson::Value &   messages,
+                                rapidjson::Value    &messages,
                                 bool                 exception)
 {
 	rapidjson::Document::AllocatorType &alloc = d->GetAllocator();
@@ -607,8 +607,8 @@ WebsocketLogger::tlog_error(struct timeval *t, const char *component, fawkes::Ex
 
 void
 WebsocketLogger::vtlog_debug(struct timeval *t,
-                             const char *    component,
-                             const char *    format,
+                             const char     *component,
+                             const char     *format,
                              va_list         va)
 {
 	if (log_level <= LL_DEBUG) {
@@ -632,8 +632,8 @@ WebsocketLogger::vtlog_debug(struct timeval *t,
 
 void
 WebsocketLogger::vtlog_info(struct timeval *t,
-                            const char *    component,
-                            const char *    format,
+                            const char     *component,
+                            const char     *format,
                             va_list         va)
 {
 	if (log_level <= LL_INFO) {
@@ -657,8 +657,8 @@ WebsocketLogger::vtlog_info(struct timeval *t,
 
 void
 WebsocketLogger::vtlog_warn(struct timeval *t,
-                            const char *    component,
-                            const char *    format,
+                            const char     *component,
+                            const char     *format,
                             va_list         va)
 {
 	if (log_level <= LL_WARN) {
@@ -682,8 +682,8 @@ WebsocketLogger::vtlog_warn(struct timeval *t,
 
 void
 WebsocketLogger::vtlog_error(struct timeval *t,
-                             const char *    component,
-                             const char *    format,
+                             const char     *component,
+                             const char     *format,
                              va_list         va)
 {
 	if (log_level <= LL_ERROR) {

--- a/src/libs/logging/websocket.h
+++ b/src/libs/logging/websocket.h
@@ -66,30 +66,30 @@ public:
 	virtual void tlog_error(struct timeval *t, const char *component, fawkes::Exception &e);
 
 	virtual void
-	             vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
+	vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_info(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_warn(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void
 	vtlog_error(struct timeval *t, const char *component, const char *format, va_list va);
 
 private:
-	struct ::tm *                    now_s;
-	fawkes::Mutex *                  mutex;
+	struct ::tm                     *now_s;
+	fawkes::Mutex                   *mutex;
 	std::shared_ptr<websocket::Data> data_;
 	boost::format                    fmt_time;
 	std::string                      formatter(const char *format, va_list va);
 	std::string                      formatter(const char *format, const char *text);
 	void                             build_document(rapidjson::Document *d,
-	                                                const char *         component,
+	                                                const char          *component,
 	                                                std::string          level,
 	                                                std::string          time,
 	                                                std::string          message,
 	                                                bool                 exception = false);
 	void                             build_document(rapidjson::Document *d,
-	                                                const char *         component,
+	                                                const char          *component,
 	                                                std::string          level,
 	                                                std::string          time,
-	                                                rapidjson::Value &   messages,
+	                                                rapidjson::Value    &messages,
 	                                                bool                 exception = false);
 };
 

--- a/src/libs/mongodb_log/mongodb_log_logger.cpp
+++ b/src/libs/mongodb_log/mongodb_log_logger.cpp
@@ -204,13 +204,13 @@ MongoDBLogLogger::log_error(const char *component, Exception &e)
 void
 MongoDBLogLogger::tlog_insert_message(LogLevel        ll,
                                       struct timeval *t,
-                                      const char *    component,
-                                      const char *    format,
+                                      const char     *component,
+                                      const char     *format,
                                       va_list         va)
 {
 	if (log_level <= ll) {
 		MutexLocker lock(mutex_);
-		char *      msg;
+		char       *msg;
 		if (vasprintf(&msg, format, va) == -1) {
 			return;
 		}
@@ -239,8 +239,8 @@ MongoDBLogLogger::tlog_insert_message(LogLevel        ll,
 void
 MongoDBLogLogger::tlog_insert_message(LogLevel        ll,
                                       struct timeval *t,
-                                      const char *    component,
-                                      Exception &     e)
+                                      const char     *component,
+                                      Exception      &e)
 {
 	if (log_level <= ll) {
 		MutexLocker lock(mutex_);
@@ -326,8 +326,8 @@ MongoDBLogLogger::tlog_error(struct timeval *t, const char *component, Exception
 
 void
 MongoDBLogLogger::vtlog_debug(struct timeval *t,
-                              const char *    component,
-                              const char *    format,
+                              const char     *component,
+                              const char     *format,
                               va_list         va)
 {
 	tlog_insert_message(LL_DEBUG, t, component, format, va);
@@ -335,8 +335,8 @@ MongoDBLogLogger::vtlog_debug(struct timeval *t,
 
 void
 MongoDBLogLogger::vtlog_info(struct timeval *t,
-                             const char *    component,
-                             const char *    format,
+                             const char     *component,
+                             const char     *format,
                              va_list         va)
 {
 	tlog_insert_message(LL_INFO, t, component, format, va);
@@ -344,8 +344,8 @@ MongoDBLogLogger::vtlog_info(struct timeval *t,
 
 void
 MongoDBLogLogger::vtlog_warn(struct timeval *t,
-                             const char *    component,
-                             const char *    format,
+                             const char     *component,
+                             const char     *format,
                              va_list         va)
 {
 	tlog_insert_message(LL_WARN, t, component, format, va);
@@ -353,8 +353,8 @@ MongoDBLogLogger::vtlog_warn(struct timeval *t,
 
 void
 MongoDBLogLogger::vtlog_error(struct timeval *t,
-                              const char *    component,
-                              const char *    format,
+                              const char     *component,
+                              const char     *format,
                               va_list         va)
 {
 	tlog_insert_message(LL_ERROR, t, component, format, va);

--- a/src/libs/mongodb_log/mongodb_log_logger.h
+++ b/src/libs/mongodb_log/mongodb_log_logger.h
@@ -70,7 +70,7 @@ public:
 	virtual void tlog_error(struct timeval *t, const char *component, fawkes::Exception &e);
 
 	virtual void
-	             vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
+	vtlog_debug(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_info(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void vtlog_warn(struct timeval *t, const char *component, const char *format, va_list va);
 	virtual void
@@ -81,14 +81,14 @@ private:
 	void insert_message(LogLevel ll, const char *component, fawkes::Exception &e);
 	void tlog_insert_message(LogLevel        ll,
 	                         struct timeval *t,
-	                         const char *    component,
-	                         const char *    format,
+	                         const char     *component,
+	                         const char     *format,
 	                         va_list         va);
 	void
 	tlog_insert_message(LogLevel ll, struct timeval *t, const char *component, fawkes::Exception &);
 
 private:
-	fawkes::Mutex *      mutex_;
+	fawkes::Mutex       *mutex_;
 	mongocxx::client     client_;
 	mongocxx::collection collection_;
 };

--- a/src/libs/mongodb_log/mongodb_log_protobuf.cpp
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.cpp
@@ -59,9 +59,9 @@ MongoDBLogProtobuf::~MongoDBLogProtobuf()
 }
 
 void
-MongoDBLogProtobuf::add_field(const FieldDescriptor *            field,
+MongoDBLogProtobuf::add_field(const FieldDescriptor             *field,
                               const ::google::protobuf::Message &m,
-                              document *                         doc)
+                              document                          *doc)
 {
 	const Reflection *refl = m.GetReflection();
 

--- a/src/libs/mongodb_log/mongodb_log_protobuf.h
+++ b/src/libs/mongodb_log/mongodb_log_protobuf.h
@@ -44,12 +44,12 @@ public:
 
 private:
 	void                              add_field(const ::google::protobuf::FieldDescriptor *field,
-	                                            const ::google::protobuf::Message &        m,
-	                                            bsoncxx::builder::basic::document *        doc);
+	                                            const ::google::protobuf::Message         &m,
+	                                            bsoncxx::builder::basic::document         *doc);
 	bsoncxx::builder::basic::document add_message(const google::protobuf::Message &m);
 
 private:
-	fawkes::Mutex *      mutex_;
+	fawkes::Mutex       *mutex_;
 	mongocxx::client     client_;
 	mongocxx::collection collection_;
 };

--- a/src/libs/mps_comm/opcua/machine.cpp
+++ b/src/libs/mps_comm/opcua/machine.cpp
@@ -367,7 +367,7 @@ OpcUaMachine::cancelAllSubscriptions(bool log)
 
 	for (SubscriptionClient::map::iterator it = subscriptions.begin(); it != subscriptions.end();) {
 		OpcUtils::MPSRegister reg = it->first;
-		SubscriptionClient *  sub = it->second;
+		SubscriptionClient   *sub = it->second;
 		sub->subscription->UnSubscribe(sub->handle);
 		logger->info("Unsubscribed from {} (name: {}, handle: {})",
 		             OpcUtils::REGISTER_NAMES[reg],

--- a/src/libs/mps_comm/opcua/opc_utils.cpp
+++ b/src/libs/mps_comm/opcua/opc_utils.cpp
@@ -721,7 +721,7 @@ OpcUtils::logNodeValue(OpcUa::Node                     node,
 
 void
 OpcUtils::logNodeValue(OpcUa::Variant                  val,
-                       const char *                    msg,
+                       const char                     *msg,
                        std::string                     nodeName,
                        std::shared_ptr<spdlog::logger> logger,
                        int                             indent)
@@ -760,7 +760,7 @@ OpcUtils::logNodeValueArray(OpcUa::Node                     node,
 
 std::string
 OpcUtils::logNodeValueArray(OpcUa::Variant                  val,
-                            const char *                    msg,
+                            const char                     *msg,
                             std::string                     nodeName,
                             std::shared_ptr<spdlog::logger> logger,
                             int                             indent)
@@ -832,7 +832,7 @@ OpcUtils::logNodeValueArray(OpcUa::Variant                  val,
 }
 
 bool
-OpcUtils::logReturnValue(ReturnValue *                   val,
+OpcUtils::logReturnValue(ReturnValue                    *val,
                          std::shared_ptr<spdlog::logger> logger,
                          OpcUtils::MPSRegister           reg,
                          std::string                     msg)

--- a/src/libs/mps_comm/opcua/opc_utils.h
+++ b/src/libs/mps_comm/opcua/opc_utils.h
@@ -190,7 +190,7 @@ public:
 	                         int                             indent);
 	// Log node value by OPC UA Variant
 	static void logNodeValue(OpcUa::Variant                  val,
-	                         const char *                    msg,
+	                         const char                     *msg,
 	                         std::string                     nodeName,
 	                         std::shared_ptr<spdlog::logger> logger,
 	                         int                             indent = -1);
@@ -201,12 +201,12 @@ public:
 	                                     int                             indent);
 	// Log node array value
 	static std::string logNodeValueArray(OpcUa::Variant                  val,
-	                                     const char *                    msg,
+	                                     const char                     *msg,
 	                                     std::string                     nodeName,
 	                                     std::shared_ptr<spdlog::logger> logger,
 	                                     int                             indent = -1);
 	// Log return value
-	static bool logReturnValue(ReturnValue *                   val,
+	static bool logReturnValue(ReturnValue                    *val,
 	                           std::shared_ptr<spdlog::logger> logger,
 	                           MPSRegister                     reg,
 	                           std::string                     msg = "");

--- a/src/libs/mps_comm/opcua/subscription_client.h
+++ b/src/libs/mps_comm/opcua/subscription_client.h
@@ -37,7 +37,7 @@ public:
 	typedef std::pair<OpcUtils::MPSRegister, SubscriptionClient *> pair;
 	typedef std::map<OpcUtils::MPSRegister, SubscriptionClient *>  map;
 	OpcUa::Subscription::SharedPtr                                 subscription;
-	OpcUtils::ReturnValue *                                        mpsValue = nullptr;
+	OpcUtils::ReturnValue                                         *mpsValue = nullptr;
 	uint32_t                                                       handle;
 	OpcUtils::MPSRegister                                          reg;
 	OpcUa::Node                                                    node;
@@ -69,7 +69,7 @@ protected:
 
 	void
 	DataChange(uint32_t              handle,
-	           const OpcUa::Node &   node,
+	           const OpcUa::Node    &node,
 	           const OpcUa::Variant &val,
 	           OpcUa::AttributeId    attr) override
 	{

--- a/src/libs/mps_placing_clips/mps_placing.h
+++ b/src/libs/mps_placing_clips/mps_placing.h
@@ -613,11 +613,11 @@ public:
 	int                                           height_;
 	int                                           width_;
 	std::set<int>                                 machines_;
-	Gecode::DFS<MPSPlacing> *                     search_;
-	MPSPlacing *                                  solution;
+	Gecode::DFS<MPSPlacing>                      *search_;
+	MPSPlacing                                   *solution;
 	Gecode::Rnd                                   rg_;
 	Gecode::Search::Options                       options_;
-	Gecode::Search::TimeStop *                    stop_;
+	Gecode::Search::TimeStop                     *stop_;
 };
 
 #endif // MPS_PLACING_H

--- a/src/libs/mps_placing_clips/mps_placing_clips.h
+++ b/src/libs/mps_placing_clips/mps_placing_clips.h
@@ -72,7 +72,7 @@ public:
 private:
 	void                setup_clips();
 	CLIPS::Environment *clips_;
-	fawkes::Mutex &     clips_mutex_;
+	fawkes::Mutex      &clips_mutex_;
 	std::set<int>       machines_;
 	int                 width_;
 	int                 height_;

--- a/src/libs/netcomm/dns-sd/avahi_thread.cpp
+++ b/src/libs/netcomm/dns-sd/avahi_thread.cpp
@@ -271,7 +271,7 @@ AvahiThread::create_service(const NetworkService &service, AvahiEntryGroup *exgr
 		}
 	}
 
-	AvahiStringList *             al = NULL;
+	AvahiStringList              *al = NULL;
 	const std::list<std::string> &l  = service.txt();
 	for (std::list<std::string>::const_iterator j = l.begin(); j != l.end(); ++j) {
 		al = avahi_string_list_add(al, j->c_str());
@@ -600,11 +600,11 @@ AvahiThread::call_handler_service_removed(const char *name, const char *type, co
  * @param flags flags
  */
 void
-AvahiThread::call_handler_service_added(const char *            name,
-                                        const char *            type,
-                                        const char *            domain,
-                                        const char *            host_name,
-                                        const AvahiAddress *    address,
+AvahiThread::call_handler_service_added(const char             *name,
+                                        const char             *type,
+                                        const char             *domain,
+                                        const char             *host_name,
+                                        const AvahiAddress     *address,
                                         uint16_t                port,
                                         std::list<std::string> &txt,
                                         AvahiLookupResultFlags  flags)
@@ -687,15 +687,15 @@ AvahiThread::call_handler_cache_exhausted(const char *type)
  * the search
  */
 void
-AvahiThread::browse_callback(AvahiServiceBrowser *  b,
+AvahiThread::browse_callback(AvahiServiceBrowser   *b,
                              AvahiIfIndex           interface,
                              AvahiProtocol          protocol,
                              AvahiBrowserEvent      event,
-                             const char *           name,
-                             const char *           type,
-                             const char *           domain,
+                             const char            *name,
+                             const char            *type,
+                             const char            *domain,
                              AvahiLookupResultFlags flags,
-                             void *                 instance)
+                             void                  *instance)
 {
 	AvahiThread *at = static_cast<AvahiThread *>(instance);
 
@@ -762,19 +762,19 @@ AvahiThread::browse_callback(AvahiServiceBrowser *  b,
  * the search
  */
 void
-AvahiThread::resolve_callback(AvahiServiceResolver *         r,
+AvahiThread::resolve_callback(AvahiServiceResolver          *r,
                               AVAHI_GCC_UNUSED AvahiIfIndex  interface,
                               AVAHI_GCC_UNUSED AvahiProtocol protocol,
                               AvahiResolverEvent             event,
-                              const char *                   name,
-                              const char *                   type,
-                              const char *                   domain,
-                              const char *                   host_name,
-                              const AvahiAddress *           address,
+                              const char                    *name,
+                              const char                    *type,
+                              const char                    *domain,
+                              const char                    *host_name,
+                              const AvahiAddress            *address,
                               uint16_t                       port,
-                              AvahiStringList *              txt,
+                              AvahiStringList               *txt,
                               AvahiLookupResultFlags         flags,
-                              void *                         instance)
+                              void                          *instance)
 {
 	AvahiThread *at = static_cast<AvahiThread *>(instance);
 
@@ -788,7 +788,7 @@ AvahiThread::resolve_callback(AvahiServiceResolver *         r,
 		// handler add
 		{
 			std::list<std::string> txts;
-			AvahiStringList *      l = txt;
+			AvahiStringList       *l = txt;
 
 			txts.clear();
 			while (l) {
@@ -873,7 +873,7 @@ AvahiThread::start_address_resolvers()
  * @param handler handler to call for the result
  */
 void
-AvahiThread::resolve_address(struct sockaddr *     addr,
+AvahiThread::resolve_address(struct sockaddr      *addr,
                              socklen_t             addrlen,
                              AvahiResolverHandler *handler)
 {
@@ -941,10 +941,10 @@ AvahiThread::host_name_resolver_callback(AvahiHostNameResolver *r,
                                          AvahiIfIndex           interface,
                                          AvahiProtocol          protocol,
                                          AvahiResolverEvent     event,
-                                         const char *           name,
-                                         const AvahiAddress *   a,
+                                         const char            *name,
+                                         const AvahiAddress    *a,
                                          AvahiLookupResultFlags flags,
-                                         void *                 userdata)
+                                         void                  *userdata)
 {
 	AvahiResolverCallbackData *cd = static_cast<AvahiResolverCallbackData *>(userdata);
 
@@ -971,14 +971,14 @@ AvahiThread::host_name_resolver_callback(AvahiHostNameResolver *r,
  * Callback for avahi.
  */
 void
-AvahiThread::address_resolver_callback(AvahiAddressResolver * r,
+AvahiThread::address_resolver_callback(AvahiAddressResolver  *r,
                                        AvahiIfIndex           interface,
                                        AvahiProtocol          protocol,
                                        AvahiResolverEvent     event,
-                                       const AvahiAddress *   a,
-                                       const char *           name,
+                                       const AvahiAddress    *a,
+                                       const char            *name,
                                        AvahiLookupResultFlags flags,
-                                       void *                 userdata)
+                                       void                  *userdata)
 {
 	AvahiResolverCallbackData *cd = static_cast<AvahiResolverCallbackData *>(userdata);
 

--- a/src/libs/netcomm/dns-sd/avahi_thread.h
+++ b/src/libs/netcomm/dns-sd/avahi_thread.h
@@ -88,54 +88,54 @@ private:
 
 	static void entry_group_callback(AvahiEntryGroup *g, AvahiEntryGroupState state, void *instance);
 
-	static void browse_callback(AvahiServiceBrowser *  b,
+	static void browse_callback(AvahiServiceBrowser   *b,
 	                            AvahiIfIndex           interface,
 	                            AvahiProtocol          protocol,
 	                            AvahiBrowserEvent      event,
-	                            const char *           name,
-	                            const char *           type,
-	                            const char *           domain,
+	                            const char            *name,
+	                            const char            *type,
+	                            const char            *domain,
 	                            AvahiLookupResultFlags flags,
-	                            void *                 instance);
+	                            void                  *instance);
 
-	static void resolve_callback(AvahiServiceResolver *         r,
+	static void resolve_callback(AvahiServiceResolver          *r,
 	                             AVAHI_GCC_UNUSED AvahiIfIndex  interface,
 	                             AVAHI_GCC_UNUSED AvahiProtocol protocol,
 	                             AvahiResolverEvent             event,
-	                             const char *                   name,
-	                             const char *                   type,
-	                             const char *                   domain,
-	                             const char *                   host_name,
-	                             const AvahiAddress *           address,
+	                             const char                    *name,
+	                             const char                    *type,
+	                             const char                    *domain,
+	                             const char                    *host_name,
+	                             const AvahiAddress            *address,
 	                             uint16_t                       port,
-	                             AvahiStringList *              txt,
+	                             AvahiStringList               *txt,
 	                             AvahiLookupResultFlags         flags,
-	                             void *                         instance);
+	                             void                          *instance);
 
 	static void host_name_resolver_callback(AvahiHostNameResolver *r,
 	                                        AvahiIfIndex           interface,
 	                                        AvahiProtocol          protocol,
 	                                        AvahiResolverEvent     event,
-	                                        const char *           name,
-	                                        const AvahiAddress *   a,
+	                                        const char            *name,
+	                                        const AvahiAddress    *a,
 	                                        AvahiLookupResultFlags flags,
-	                                        void *                 userdata);
+	                                        void                  *userdata);
 
-	static void address_resolver_callback(AvahiAddressResolver * r,
+	static void address_resolver_callback(AvahiAddressResolver  *r,
 	                                      AvahiIfIndex           interface,
 	                                      AvahiProtocol          protocol,
 	                                      AvahiResolverEvent     event,
-	                                      const AvahiAddress *   a,
-	                                      const char *           name,
+	                                      const AvahiAddress    *a,
+	                                      const char            *name,
 	                                      AvahiLookupResultFlags flags,
-	                                      void *                 userdata);
+	                                      void                  *userdata);
 
 	void call_handler_service_removed(const char *name, const char *type, const char *domain);
-	void call_handler_service_added(const char *            name,
-	                                const char *            type,
-	                                const char *            domain,
-	                                const char *            host_name,
-	                                const AvahiAddress *    address,
+	void call_handler_service_added(const char             *name,
+	                                const char             *type,
+	                                const char             *domain,
+	                                const char             *host_name,
+	                                const AvahiAddress     *address,
 	                                uint16_t                port,
 	                                std::list<std::string> &txt,
 	                                AvahiLookupResultFlags  flags);
@@ -182,8 +182,8 @@ private:
 	bool do_erase_browsers;
 	bool do_reset_groups;
 
-	AvahiSimplePoll *                 simple_poll;
-	AvahiClient *                     client;
+	AvahiSimplePoll	                *simple_poll;
+	AvahiClient                      *client;
 	AvahiClientState                  client_state;
 	const static std::chrono::seconds wait_on_init_failure;
 

--- a/src/libs/netcomm/qa/qa_avahi_browser.cpp
+++ b/src/libs/netcomm/qa/qa_avahi_browser.cpp
@@ -79,11 +79,11 @@ public:
 	}
 
 	virtual void
-	service_added(const char *            name,
-	              const char *            type,
-	              const char *            domain,
-	              const char *            host_name,
-	              const struct sockaddr * addr,
+	service_added(const char             *name,
+	              const char             *type,
+	              const char             *domain,
+	              const char             *host_name,
+	              const struct sockaddr  *addr,
 	              const socklen_t         addr_size,
 	              uint16_t                port,
 	              std::list<std::string> &txt,

--- a/src/libs/netcomm/qa/qa_avahi_resolver.cpp
+++ b/src/libs/netcomm/qa/qa_avahi_resolver.cpp
@@ -148,7 +148,7 @@ public:
 	}
 
 private:
-	AvahiThread *   at;
+	AvahiThread    *at;
 	ArgumentParser *argp;
 
 	bool wait_for_name;

--- a/src/libs/netcomm/qa/qa_dynamic_buffer.cpp
+++ b/src/libs/netcomm/qa/qa_dynamic_buffer.cpp
@@ -56,7 +56,7 @@ main(int argc, char **argv)
 		char tmp[1024];
 		memset(tmp, 0, sizeof(tmp));
 		size_t size;
-		void * buf = dr->next(&size);
+		void  *buf = dr->next(&size);
 		strncpy(tmp, (const char *)buf, size);
 		printf("Read string (%lu bytes): '%s'\n", (unsigned long int)size, tmp);
 	}

--- a/src/libs/netcomm/qa/qa_resolver.cpp
+++ b/src/libs/netcomm/qa/qa_resolver.cpp
@@ -166,7 +166,7 @@ public:
 	}
 
 private:
-	ArgumentParser *     argp;
+	ArgumentParser      *argp;
 	NetworkNameResolver *r;
 	bool                 quit;
 #ifdef HAVE_AVAHI

--- a/src/libs/netcomm/qa/qa_socket_datagram.cpp
+++ b/src/libs/netcomm/qa/qa_socket_datagram.cpp
@@ -79,7 +79,7 @@ public:
 
 private:
 	unsigned int       i;
-	DatagramSocket *   s;
+	DatagramSocket    *s;
 	struct sockaddr_in to;
 	struct sockaddr_in from;
 	unsigned int       from_len;
@@ -122,7 +122,7 @@ public:
 	}
 
 private:
-	DatagramSocket *   s;
+	DatagramSocket    *s;
 	struct sockaddr_in to;
 	struct sockaddr_in from;
 	unsigned int       from_len;

--- a/src/libs/netcomm/qa/qa_socket_datagram_broadcast.cpp
+++ b/src/libs/netcomm/qa/qa_socket_datagram_broadcast.cpp
@@ -190,7 +190,7 @@ public:
 	}
 
 private:
-	BroadcastDatagramServerThread *   s;
+	BroadcastDatagramServerThread    *s;
 	BroadcastDatagramReflectorThread *r;
 };
 

--- a/src/libs/netcomm/qa/qa_socket_datagram_multicast.cpp
+++ b/src/libs/netcomm/qa/qa_socket_datagram_multicast.cpp
@@ -192,8 +192,8 @@ public:
 	}
 
 private:
-	ArgumentParser *                  argp;
-	MulticastDatagramServerThread *   s;
+	ArgumentParser                   *argp;
+	MulticastDatagramServerThread    *s;
 	MulticastDatagramReflectorThread *r;
 };
 

--- a/src/libs/netcomm/qa/qa_socket_stream.cpp
+++ b/src/libs/netcomm/qa/qa_socket_stream.cpp
@@ -92,7 +92,7 @@ public:
 private:
 	unsigned int  i;
 	StreamSocket *s;
-	Socket *      cs;
+	Socket       *cs;
 	bool          accepted;
 };
 
@@ -139,7 +139,7 @@ public:
 	}
 
 private:
-	const char *  host;
+	const char   *host;
 	StreamSocket *s;
 	bool          connected;
 };

--- a/src/libs/netcomm/qa/qa_worldinfo.cpp
+++ b/src/libs/netcomm/qa/qa_worldinfo.cpp
@@ -90,7 +90,7 @@ public:
 private:
 	WorldInfoTransceiver *t;
 	unsigned int          i;
-	float *               covariance;
+	float                *covariance;
 };
 
 class WorldInfoReceiverThread : public Thread, public WorldInfoHandler
@@ -153,7 +153,7 @@ public:
 	              float       dist,
 	              float       bearing,
 	              float       slope,
-	              float *     covariance)
+	              float      *covariance)
 	{
 		printf("Ball[%s]: vis: %i  vishis: %i   (d,b,s)=(%f,%f,%f)  cov=(%f,%f,%f,%f,%f,%f,%f,%f,%f)\n",
 		       from_host,
@@ -178,18 +178,18 @@ public:
 	                   float       vel_x,
 	                   float       vel_y,
 	                   float       vel_z,
-	                   float *     covariance)
+	                   float      *covariance)
 	{
 		cout << "BVel[" << from_host << "]: (vx,vy,vz)=(" << vel_x << "," << vel_y << "," << vel_z
 		     << ")" << endl;
 	}
 
 	virtual void
-	opponent_pose_rcvd(const char * from_host,
+	opponent_pose_rcvd(const char  *from_host,
 	                   unsigned int uid,
 	                   float        distance,
 	                   float        bearing,
-	                   float *      covariance)
+	                   float       *covariance)
 	{
 		printf("Oppt[%s]: (uid,d,b)=(%u,%f,%f)  cov=(%f,%f,%f,%f)\n",
 		       from_host,
@@ -209,7 +209,7 @@ public:
 	}
 
 	virtual void
-	gamestate_rcvd(const char *                    from_host,
+	gamestate_rcvd(const char                     *from_host,
 	               worldinfo_gamestate_t           game_state,
 	               worldinfo_gamestate_team_t      state_team,
 	               unsigned int                    score_cyan,
@@ -302,10 +302,10 @@ public:
 	}
 
 private:
-	ArgumentParser *         argp;
-	WorldInfoSenderThread *  s;
+	ArgumentParser          *argp;
+	WorldInfoSenderThread   *s;
 	WorldInfoReceiverThread *r;
-	NetworkNameResolver *    rs;
+	NetworkNameResolver     *rs;
 #ifdef HAVE_AVAHI
 	AvahiThread *at;
 #endif

--- a/src/libs/netcomm/service_discovery/browse_handler.h
+++ b/src/libs/netcomm/service_discovery/browse_handler.h
@@ -78,11 +78,11 @@ public:
    * @param txt list of txt records.
    * @param flags extra flags, see Avahi documentation
    */
-	virtual void service_added(const char *            name,
-	                           const char *            type,
-	                           const char *            domain,
-	                           const char *            host_name,
-	                           const struct sockaddr * addr,
+	virtual void service_added(const char             *name,
+	                           const char             *type,
+	                           const char             *domain,
+	                           const char             *host_name,
+	                           const struct sockaddr  *addr,
 	                           const socklen_t         addr_size,
 	                           uint16_t                port,
 	                           std::list<std::string> &txt,

--- a/src/libs/netcomm/service_discovery/service.cpp
+++ b/src/libs/netcomm/service_discovery/service.cpp
@@ -57,10 +57,10 @@ namespace fawkes {
  * @param host host of service
  * @param port port of service
  */
-NetworkService::NetworkService(const char *       name,
-                               const char *       type,
-                               const char *       domain,
-                               const char *       host,
+NetworkService::NetworkService(const char        *name,
+                               const char        *type,
+                               const char        *domain,
+                               const char        *host,
                                unsigned short int port)
 {
 	_name   = strdup(name);
@@ -86,12 +86,12 @@ NetworkService::NetworkService(const char *       name,
  * @param addr_size size in bytes of addr parameter
  * @param txt list of TXT records
  */
-NetworkService::NetworkService(const char *            name,
-                               const char *            type,
-                               const char *            domain,
-                               const char *            host,
+NetworkService::NetworkService(const char             *name,
+                               const char             *type,
+                               const char             *domain,
+                               const char             *host,
                                unsigned short int      port,
-                               const struct sockaddr * addr,
+                               const struct sockaddr  *addr,
                                const socklen_t         addr_size,
                                std::list<std::string> &txt)
 
@@ -145,8 +145,8 @@ NetworkService::NetworkService(const char *name, const char *type, unsigned shor
  * @param port port of service
  */
 NetworkService::NetworkService(NetworkNameResolver *nnresolver,
-                               const char *         name,
-                               const char *         type,
+                               const char          *name,
+                               const char          *type,
                                unsigned short int   port)
 {
 	std::string            s    = name;

--- a/src/libs/netcomm/service_discovery/service.h
+++ b/src/libs/netcomm/service_discovery/service.h
@@ -37,18 +37,18 @@ class NetworkNameResolver;
 class NetworkService
 {
 public:
-	NetworkService(const char *       name,
-	               const char *       type,
-	               const char *       domain,
-	               const char *       host,
+	NetworkService(const char        *name,
+	               const char        *type,
+	               const char        *domain,
+	               const char        *host,
 	               unsigned short int port);
 
-	NetworkService(const char *            name,
-	               const char *            type,
-	               const char *            domain,
-	               const char *            host,
+	NetworkService(const char             *name,
+	               const char             *type,
+	               const char             *domain,
+	               const char             *host,
 	               unsigned short int      port,
-	               const struct sockaddr * addr,
+	               const struct sockaddr  *addr,
 	               const socklen_t         addr_size,
 	               std::list<std::string> &txt);
 
@@ -57,8 +57,8 @@ public:
 	NetworkService(const char *name, const char *type, const char *domain);
 
 	NetworkService(NetworkNameResolver *nnresolver,
-	               const char *         name,
-	               const char *         type,
+	               const char          *name,
+	               const char          *type,
 	               unsigned short int   port);
 
 	NetworkService(const NetworkService *s);
@@ -71,11 +71,11 @@ public:
 	void set_name(const char *new_name);
 	void set_modified_name(const char *new_name) const;
 
-	const char *                  name() const;
-	const char *                  modified_name() const;
-	const char *                  type() const;
-	const char *                  domain() const;
-	const char *                  host() const;
+	const char                   *name() const;
+	const char                   *modified_name() const;
+	const char                   *type() const;
+	const char                   *domain() const;
+	const char                   *host() const;
 	std::string                   addr_string() const;
 	unsigned short int            port() const;
 	const std::list<std::string> &txt() const;
@@ -86,12 +86,12 @@ public:
 
 private:
 	std::list<std::string> list;
-	char *                 _name;
-	char *                 _type;
-	char *                 _domain;
-	char *                 _host;
+	char                  *_name;
+	char                  *_type;
+	char                  *_domain;
+	char                  *_host;
 	unsigned short int     _port;
-	struct sockaddr *      _addr;
+	struct sockaddr       *_addr;
 	socklen_t              _addr_size;
 
 	mutable char *_modified_name;

--- a/src/libs/netcomm/socket/datagram_broadcast.cpp
+++ b/src/libs/netcomm/socket/datagram_broadcast.cpp
@@ -48,7 +48,7 @@ namespace fawkes {
  * @param timeout timeout, if 0 all operationsare blocking, otherwise it
  * is tried for timeout seconds.
  */
-BroadcastDatagramSocket::BroadcastDatagramSocket(const char *   broadcast_addr_s,
+BroadcastDatagramSocket::BroadcastDatagramSocket(const char    *broadcast_addr_s,
                                                  unsigned short port,
                                                  float          timeout)
 : Socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP, timeout)

--- a/src/libs/netcomm/socket/datagram_multicast.cpp
+++ b/src/libs/netcomm/socket/datagram_multicast.cpp
@@ -47,7 +47,7 @@ namespace fawkes {
  * @param timeout timeout, if 0 all operationsare blocking, otherwise it
  * is tried for timeout seconds.
  */
-MulticastDatagramSocket::MulticastDatagramSocket(const char *   multicast_addr_s,
+MulticastDatagramSocket::MulticastDatagramSocket(const char    *multicast_addr_s,
                                                  unsigned short port,
                                                  float          timeout)
 : Socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP, timeout)

--- a/src/libs/netcomm/socket/socket.cpp
+++ b/src/libs/netcomm/socket/socket.cpp
@@ -275,7 +275,7 @@ Socket::connect(const char *hostname, unsigned short int port)
 	if (sock_fd == -1)
 		throw SocketException("Trying to connect invalid socket");
 
-	struct hostent *     h;
+	struct hostent      *h;
 	struct ::sockaddr_in host;
 
 	h = gethostbyname(hostname);
@@ -323,7 +323,7 @@ Socket::bind(const unsigned short int port)
 void
 Socket::bind(const unsigned short int port, const char *hostname)
 {
-	struct hostent *     h;
+	struct hostent      *h;
 	struct ::sockaddr_in host;
 
 	h = gethostbyname(hostname);

--- a/src/libs/netcomm/utils/acceptor_thread.cpp
+++ b/src/libs/netcomm/utils/acceptor_thread.cpp
@@ -44,7 +44,7 @@ namespace fawkes {
  */
 NetworkAcceptorThread::NetworkAcceptorThread(NetworkIncomingConnectionHandler *handler,
                                              unsigned short int                port,
-                                             const char *                      thread_name)
+                                             const char                       *thread_name)
 : Thread(thread_name)
 {
 	__handler = handler;
@@ -69,8 +69,8 @@ NetworkAcceptorThread::NetworkAcceptorThread(NetworkIncomingConnectionHandler *h
  * @exception SocketException as thrown by StreamSocket connstructor, bind and listen.
  */
 NetworkAcceptorThread::NetworkAcceptorThread(NetworkIncomingConnectionHandler *handler,
-                                             StreamSocket *                    socket,
-                                             const char *                      thread_name)
+                                             StreamSocket                     *socket,
+                                             const char                       *thread_name)
 : Thread(thread_name)
 {
 	__handler = handler;

--- a/src/libs/netcomm/utils/acceptor_thread.h
+++ b/src/libs/netcomm/utils/acceptor_thread.h
@@ -36,10 +36,10 @@ class NetworkAcceptorThread : public Thread
 public:
 	NetworkAcceptorThread(NetworkIncomingConnectionHandler *handler,
 	                      unsigned short int                port,
-	                      const char *                      thread_name = "NetworkAcceptorThread");
+	                      const char                       *thread_name = "NetworkAcceptorThread");
 	NetworkAcceptorThread(NetworkIncomingConnectionHandler *handler,
-	                      StreamSocket *                    socket,
-	                      const char *                      thread_name = "NetworkAcceptorThread");
+	                      StreamSocket                     *socket,
+	                      const char                       *thread_name = "NetworkAcceptorThread");
 	~NetworkAcceptorThread();
 
 	virtual void loop();
@@ -54,7 +54,7 @@ protected:
 
 private:
 	unsigned short int __port;
-	StreamSocket *     __socket;
+	StreamSocket      *__socket;
 
 	NetworkIncomingConnectionHandler *__handler;
 };

--- a/src/libs/netcomm/utils/resolver.cpp
+++ b/src/libs/netcomm/utils/resolver.cpp
@@ -209,9 +209,9 @@ NetworkNameResolver::resolve_name(const char *name, struct sockaddr **addr, sock
  * @return true if resolution was successful, false otherwise
  */
 bool
-NetworkNameResolver::resolve_name_blocking(const char *      name,
+NetworkNameResolver::resolve_name_blocking(const char       *name,
                                            struct sockaddr **addr,
-                                           socklen_t *       addrlen)
+                                           socklen_t        *addrlen)
 {
 	if (resolve_name(name, addr, addrlen)) {
 		return true;
@@ -318,7 +318,7 @@ NetworkNameResolver::name_resolved(char *name, struct sockaddr *addr, socklen_t 
 void
 NetworkNameResolver::addr_resolved(struct sockaddr *addr,
                                    socklen_t        addrlen,
-                                   char *           name,
+                                   char            *name,
                                    bool             namefound)
 {
 	addr2name_cache.lock();

--- a/src/libs/netcomm/utils/resolver.h
+++ b/src/libs/netcomm/utils/resolver.h
@@ -71,7 +71,7 @@ private:
 
 private:
 	NetworkNameResolverThread *resolver_thread;
-	HostInfo *                 __host_info;
+	HostInfo                  *__host_info;
 	unsigned int               __cache_timeout;
 
 	LockHashMap<uint32_t, std::pair<char *, time_t>> addr2name_cache;

--- a/src/libs/netcomm/utils/resolver_thread.cpp
+++ b/src/libs/netcomm/utils/resolver_thread.cpp
@@ -57,7 +57,7 @@ namespace fawkes {
  * Avahi is not used.
  */
 NetworkNameResolverThread::NetworkNameResolverThread(NetworkNameResolver *resolver,
-                                                     AvahiThread *        avahi_thread)
+                                                     AvahiThread         *avahi_thread)
 : Thread("NetworkNameResolverThread", Thread::OPMODE_WAITFORWAKEUP)
 {
 	__resolver     = resolver;
@@ -83,13 +83,13 @@ NetworkNameResolverThread::~NetworkNameResolverThread()
 	__namesq_mutex->lock();
 	while (!__namesq->empty()) {
 		NamesQMap::iterator nqit = __namesq->begin();
-		char *              nqn  = (*nqit);
+		char               *nqn  = (*nqit);
 		__namesq->erase(nqit);
 		free(nqn);
 	}
 	while (!__namesq_proc->empty()) {
 		NamesQMap::iterator nqit = __namesq_proc->begin();
-		char *              nqn  = (*nqit);
+		char               *nqn  = (*nqit);
 		__namesq->erase(nqit);
 		free(nqn);
 	}
@@ -126,9 +126,9 @@ NetworkNameResolverThread::~NetworkNameResolverThread()
  * addr_len carry the result, false otherwise
  */
 bool
-NetworkNameResolverThread::resolve_name_immediately(const char *      name,
+NetworkNameResolverThread::resolve_name_immediately(const char       *name,
                                                     struct sockaddr **addr,
-                                                    socklen_t *       addr_len)
+                                                    socklen_t        *addr_len)
 {
 	bool found = false;
 
@@ -146,7 +146,7 @@ NetworkNameResolverThread::resolve_name_immediately(const char *      name,
 
 #ifdef HAVE_AVAHI
 	// resolve names in .local domain with Avahi if available
-	char *      n = (char *)name + strlen(name) - 6; // 6 == strlen(".local")
+	char	     *n = (char *)name + strlen(name) - 6; // 6 == strlen(".local")
 	const char *f = strstr(name, ".local");
 	if (__avahi_thread && f && (f == n)) {
 		__avahi_thread->resolve_name(name, this);
@@ -184,8 +184,8 @@ NetworkNameResolverThread::resolve_name_immediately(const char *      name,
 bool
 NetworkNameResolverThread::resolve_address_immediately(struct sockaddr *addr,
                                                        socklen_t        addr_len,
-                                                       char **          name,
-                                                       bool *           namefound)
+                                                       char           **name,
+                                                       bool            *namefound)
 {
 	bool found = false;
 	char hbuf[NI_MAXHOST];

--- a/src/libs/netcomm/utils/resolver_thread.h
+++ b/src/libs/netcomm/utils/resolver_thread.h
@@ -61,8 +61,8 @@ public:
 	bool resolve_name_immediately(const char *name, struct sockaddr **addr, socklen_t *addr_len);
 	bool resolve_address_immediately(struct sockaddr *addr,
 	                                 socklen_t        addr_len,
-	                                 char **          name,
-	                                 bool *           namefound);
+	                                 char           **name,
+	                                 bool            *namefound);
 
 	virtual void resolved_name(char *name, struct sockaddr *addr, socklen_t addrlen);
 	virtual void resolved_address(struct sockaddr_in *addr, socklen_t addrlen, char *name);
@@ -85,7 +85,7 @@ private:
 	AvahiThread *__avahi_thread;
 #endif
 
-	Mutex *      __namesq_mutex;
+	Mutex       *__namesq_mutex;
 	unsigned int __namesq_active;
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 2)
 	typedef LockHashSet<char *, std::tr1::hash<char *>, StringEquality> NamesQMap;
@@ -96,12 +96,12 @@ private:
 	NamesQMap *__namesq;
 	NamesQMap *__namesq_proc;
 
-	Mutex *                                                             __addrq_mutex;
+	Mutex                                                              *__addrq_mutex;
 	unsigned int                                                        __addrq_active;
 	typedef std::map<uint32_t, std::pair<struct sockaddr *, socklen_t>> AddrQMap;
 	AddrQMap                                                            __addrqs[2];
-	AddrQMap *                                                          __addrq;
-	AddrQMap *                                                          __addrq_proc;
+	AddrQMap                                                           *__addrq;
+	AddrQMap                                                           *__addrq_proc;
 };
 
 } // end namespace fawkes

--- a/src/libs/protobuf_clips/communicator.cpp
+++ b/src/libs/protobuf_clips/communicator.cpp
@@ -66,7 +66,7 @@ namespace protobuf_clips {
  * @param env_mutex mutex to lock when operating on the CLIPS environment.
  */
 ClipsProtobufCommunicator::ClipsProtobufCommunicator(CLIPS::Environment *env,
-                                                     fawkes::Mutex &     env_mutex)
+                                                     fawkes::Mutex      &env_mutex)
 : clips_(env), clips_mutex_(env_mutex), server_(NULL), next_client_id_(0)
 {
 	message_register_ = new MessageRegister();
@@ -78,8 +78,8 @@ ClipsProtobufCommunicator::ClipsProtobufCommunicator(CLIPS::Environment *env,
  * @param env_mutex mutex to lock when operating on the CLIPS environment.
  * @param proto_path proto path passed to a newly instantiated message register
  */
-ClipsProtobufCommunicator::ClipsProtobufCommunicator(CLIPS::Environment *      env,
-                                                     fawkes::Mutex &           env_mutex,
+ClipsProtobufCommunicator::ClipsProtobufCommunicator(CLIPS::Environment       *env,
+                                                     fawkes::Mutex            &env_mutex,
                                                      std::vector<std::string> &proto_path)
 : clips_(env), clips_mutex_(env_mutex), server_(NULL), next_client_id_(0)
 {
@@ -409,7 +409,7 @@ ClipsProtobufCommunicator::clips_pb_field_type(void *msgptr, std::string field_n
 	if (!*m)
 		return CLIPS::Value("INVALID-MESSAGE", CLIPS::TYPE_SYMBOL);
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field) {
 		return CLIPS::Value("DOES-NOT-EXIST", CLIPS::TYPE_SYMBOL);
@@ -444,7 +444,7 @@ ClipsProtobufCommunicator::clips_pb_has_field(void *msgptr, std::string field_na
 	if (!*m)
 		return false;
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field)
 		return false;
@@ -466,7 +466,7 @@ ClipsProtobufCommunicator::clips_pb_field_label(void *msgptr, std::string field_
 	if (!*m)
 		return CLIPS::Value("INVALID-MESSAGE", CLIPS::TYPE_SYMBOL);
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field) {
 		return CLIPS::Value("DOES-NOT-EXIST", CLIPS::TYPE_SYMBOL);
@@ -487,7 +487,7 @@ ClipsProtobufCommunicator::clips_pb_field_value(void *msgptr, std::string field_
 	if (!*m)
 		return CLIPS::Value("INVALID-MESSAGE", CLIPS::TYPE_SYMBOL);
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field) {
 		//logger_->log_warn("RefBox", "Field %s of %s does not exist",
@@ -517,7 +517,7 @@ ClipsProtobufCommunicator::clips_pb_field_value(void *msgptr, std::string field_
 	case FieldDescriptor::TYPE_STRING: return CLIPS::Value(refl->GetString(**m, field));
 	case FieldDescriptor::TYPE_MESSAGE: {
 		const google::protobuf::Message &mfield = refl->GetMessage(**m, field);
-		google::protobuf::Message *      mcopy  = mfield.New();
+		google::protobuf::Message       *mcopy  = mfield.New();
 		mcopy->CopyFrom(mfield);
 		void *ptr = new std::shared_ptr<google::protobuf::Message>(mcopy);
 		return CLIPS::Value(ptr);
@@ -535,7 +535,7 @@ ClipsProtobufCommunicator::clips_pb_field_value(void *msgptr, std::string field_
 }
 
 void
-ClipsProtobufCommunicator::clips_pb_set_field(void *       msgptr,
+ClipsProtobufCommunicator::clips_pb_set_field(void        *msgptr,
                                               std::string  field_name,
                                               CLIPS::Value value)
 {
@@ -544,7 +544,7 @@ ClipsProtobufCommunicator::clips_pb_set_field(void *       msgptr,
 	if (!*m)
 		return;
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field) {
 		//logger_->log_warn("RefBox", "Could not find field %s", field_name.c_str());
@@ -577,7 +577,7 @@ ClipsProtobufCommunicator::clips_pb_set_field(void *       msgptr,
 		case FieldDescriptor::TYPE_FIXED32:
 		case FieldDescriptor::TYPE_UINT32: refl->SetUInt32(m->get(), field, value); break;
 		case FieldDescriptor::TYPE_ENUM: {
-			const EnumDescriptor *     enumdesc = field->enum_type();
+			const EnumDescriptor      *enumdesc = field->enum_type();
 			const EnumValueDescriptor *enumval  = enumdesc->FindValueByName(value);
 			if (enumval) {
 				refl->SetEnum(m->get(), field, enumval);
@@ -595,7 +595,7 @@ ClipsProtobufCommunicator::clips_pb_set_field(void *       msgptr,
 }
 
 void
-ClipsProtobufCommunicator::clips_pb_add_list(void *       msgptr,
+ClipsProtobufCommunicator::clips_pb_add_list(void        *msgptr,
                                              std::string  field_name,
                                              CLIPS::Value value)
 {
@@ -604,7 +604,7 @@ ClipsProtobufCommunicator::clips_pb_add_list(void *       msgptr,
 	if (!(m || *m))
 		return;
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field) {
 		//logger_->log_warn("RefBox", "Could not find field %s", field_name.c_str());
@@ -637,7 +637,7 @@ ClipsProtobufCommunicator::clips_pb_add_list(void *       msgptr,
 		case FieldDescriptor::TYPE_FIXED32:
 		case FieldDescriptor::TYPE_UINT32: refl->AddUInt32(m->get(), field, value); break;
 		case FieldDescriptor::TYPE_ENUM: {
-			const EnumDescriptor *     enumdesc = field->enum_type();
+			const EnumDescriptor      *enumdesc = field->enum_type();
 			const EnumValueDescriptor *enumval  = enumdesc->FindValueByName(value);
 			if (enumval)
 				refl->AddEnum(m->get(), field, enumval);
@@ -775,7 +775,7 @@ ClipsProtobufCommunicator::clips_pb_field_list(void *msgptr, std::string field_n
 	if (!(m || *m))
 		return CLIPS::Values(1, CLIPS::Value("INVALID-MESSAGE", CLIPS::TYPE_SYMBOL));
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field) {
 		return CLIPS::Values(1, CLIPS::Value("DOES-NOT-EXIST", CLIPS::TYPE_SYMBOL));
@@ -818,7 +818,7 @@ ClipsProtobufCommunicator::clips_pb_field_list(void *msgptr, std::string field_n
 			break;
 		case FieldDescriptor::TYPE_MESSAGE: {
 			const google::protobuf::Message &msg   = refl->GetRepeatedMessage(**m, field, i);
-			google::protobuf::Message *      mcopy = msg.New();
+			google::protobuf::Message       *mcopy = msg.New();
 			mcopy->CopyFrom(msg);
 			void *ptr = new std::shared_ptr<google::protobuf::Message>(mcopy);
 			rv[i]     = CLIPS::Value(ptr);
@@ -854,7 +854,7 @@ ClipsProtobufCommunicator::clips_pb_field_is_list(void *msgptr, std::string fiel
 	if (!(m || *m))
 		return false;
 
-	const Descriptor *     desc  = (*m)->GetDescriptor();
+	const Descriptor      *desc  = (*m)->GetDescriptor();
 	const FieldDescriptor *field = desc->FindFieldByName(field_name);
 	if (!field) {
 		return false;
@@ -874,7 +874,7 @@ ClipsProtobufCommunicator::clips_assert_message(std::pair<std::string, unsigned 
 	if (temp) {
 		struct timeval tv;
 		gettimeofday(&tv, 0);
-		void *               ptr  = new std::shared_ptr<google::protobuf::Message>(msg);
+		void                *ptr  = new std::shared_ptr<google::protobuf::Message>(msg);
 		CLIPS::Fact::pointer fact = CLIPS::Fact::create(*clips_, temp);
 		fact->set_slot("type", msg->GetTypeName());
 		fact->set_slot("comp-id", comp_id);
@@ -1009,7 +1009,7 @@ ClipsProtobufCommunicator::handle_server_client_fail(ProtobufStreamServer::Clien
  */
 void
 ClipsProtobufCommunicator::handle_peer_msg(long int                                   peer_id,
-                                           boost::asio::ip::udp::endpoint &           endpoint,
+                                           boost::asio::ip::udp::endpoint            &endpoint,
                                            uint16_t                                   component_id,
                                            uint16_t                                   msg_type,
                                            std::shared_ptr<google::protobuf::Message> msg)

--- a/src/libs/protobuf_clips/communicator.h
+++ b/src/libs/protobuf_clips/communicator.h
@@ -58,8 +58,8 @@ class ClipsProtobufCommunicator
 {
 public:
 	ClipsProtobufCommunicator(CLIPS::Environment *env, fawkes::Mutex &env_mutex);
-	ClipsProtobufCommunicator(CLIPS::Environment *      env,
-	                          fawkes::Mutex &           env_mutex,
+	ClipsProtobufCommunicator(CLIPS::Environment       *env,
+	                          fawkes::Mutex            &env_mutex,
 	                          std::vector<std::string> &proto_path);
 	~ClipsProtobufCommunicator();
 
@@ -158,16 +158,16 @@ private:
 	CLIPS::Value clips_pb_connect(std::string host, int port);
 
 	typedef enum { CT_SERVER, CT_CLIENT, CT_PEER } ClientType;
-	void clips_assert_message(std::pair<std::string, unsigned short> &    endpoint,
+	void clips_assert_message(std::pair<std::string, unsigned short>     &endpoint,
 	                          uint16_t                                    comp_id,
 	                          uint16_t                                    msg_type,
 	                          std::shared_ptr<google::protobuf::Message> &msg,
 	                          ClientType                                  ct,
 	                          long int                                    client_id = 0);
 	void handle_server_client_connected(protobuf_comm::ProtobufStreamServer::ClientID client,
-	                                    boost::asio::ip::tcp::endpoint &              endpoint);
+	                                    boost::asio::ip::tcp::endpoint               &endpoint);
 	void handle_server_client_disconnected(protobuf_comm::ProtobufStreamServer::ClientID client,
-	                                       const boost::system::error_code &             error);
+	                                       const boost::system::error_code              &error);
 
 	void handle_server_client_msg(protobuf_comm::ProtobufStreamServer::ClientID client,
 	                              uint16_t                                      component_id,
@@ -180,7 +180,7 @@ private:
 	                               std::string                                   msg);
 
 	void handle_peer_msg(long int                                   peer_id,
-	                     boost::asio::ip::udp::endpoint &           endpoint,
+	                     boost::asio::ip::udp::endpoint            &endpoint,
 	                     uint16_t                                   component_id,
 	                     uint16_t                                   msg_type,
 	                     std::shared_ptr<google::protobuf::Message> msg);
@@ -202,9 +202,9 @@ private:
 
 private:
 	CLIPS::Environment *clips_;
-	fawkes::Mutex &     clips_mutex_;
+	fawkes::Mutex      &clips_mutex_;
 
-	protobuf_comm::MessageRegister *     message_register_;
+	protobuf_comm::MessageRegister      *message_register_;
 	protobuf_comm::ProtobufStreamServer *server_;
 
 	boost::signals2::signal<void(protobuf_comm::ProtobufStreamServer::ClientID,

--- a/src/libs/protobuf_comm/client.cpp
+++ b/src/libs/protobuf_comm/client.cpp
@@ -93,7 +93,7 @@ ProtobufStreamClient::ProtobufStreamClient(std::vector<std::string> &proto_path)
  * @param mr message register to use to (de)serialize messages
  * @param header_version protobuf protocol frame header version to use,
  */
-ProtobufStreamClient::ProtobufStreamClient(MessageRegister *      mr,
+ProtobufStreamClient::ProtobufStreamClient(MessageRegister       *mr,
                                            frame_header_version_t header_version)
 : resolver_(io_service_),
   socket_(io_service_),
@@ -259,7 +259,7 @@ ProtobufStreamClient::handle_read_message(const boost::system::error_code &error
 	if (!error) {
 		frame_header_t   frame_header;
 		message_header_t message_header;
-		void *           data;
+		void            *data;
 
 		if (frame_header_version_ == PB_FRAME_V1) {
 			frame_header_v1_t *frame_header_v1 = (frame_header_v1_t *)in_frame_header_;
@@ -391,7 +391,7 @@ ProtobufStreamClient::send(uint16_t component_id, uint16_t msg_type, google::pro
 void
 ProtobufStreamClient::send(google::protobuf::Message &m)
 {
-	const google::protobuf::Descriptor *    desc     = m.GetDescriptor();
+	const google::protobuf::Descriptor     *desc     = m.GetDescriptor();
 	const google::protobuf::EnumDescriptor *enumdesc = desc->FindEnumTypeByName("CompType");
 	if (!enumdesc) {
 		throw std::logic_error("Message does not have CompType enum");

--- a/src/libs/protobuf_comm/client.h
+++ b/src/libs/protobuf_comm/client.h
@@ -131,7 +131,7 @@ private: // types
 private: // methods
 	void disconnect_nosig();
 	void run_asio();
-	void handle_resolve(const boost::system::error_code &        err,
+	void handle_resolve(const boost::system::error_code         &err,
 	                    boost::asio::ip::tcp::resolver::iterator endpoint_iterator);
 	void handle_connect(const boost::system::error_code &err);
 	void handle_write(const boost::system::error_code &error,
@@ -161,10 +161,10 @@ private: // members
 	std::mutex               outbound_mutex_;
 	bool                     outbound_active_;
 
-	void * in_frame_header_;
+	void  *in_frame_header_;
 	size_t in_frame_header_size_;
 	size_t in_data_size_;
-	void * in_data_;
+	void  *in_data_;
 
 	MessageRegister *message_register_;
 	bool             own_message_register_;

--- a/src/libs/protobuf_comm/crypto.cpp
+++ b/src/libs/protobuf_comm/crypto.cpp
@@ -216,7 +216,7 @@ size_t
 BufferDecryptor::decrypt(int         cipher,
                          const void *enc,
                          size_t      enc_size,
-                         void *      plain,
+                         void       *plain,
                          size_t      plain_size)
 {
 #ifdef HAVE_LIBCRYPTO
@@ -228,7 +228,7 @@ BufferDecryptor::decrypt(int         cipher,
 
 	const size_t         iv_size = EVP_CIPHER_iv_length(evp_cipher);
 	const unsigned char *iv      = (const unsigned char *)enc;
-	unsigned char *      enc_m   = (unsigned char *)enc + iv_size;
+	unsigned char       *enc_m   = (unsigned char *)enc + iv_size;
 	enc_size -= iv_size;
 
 	EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();

--- a/src/libs/protobuf_comm/crypto.h
+++ b/src/libs/protobuf_comm/crypto.h
@@ -68,7 +68,7 @@ public:
 	size_t encrypted_buffer_size(size_t plain_length);
 
 private:
-	unsigned char *        key_;
+	unsigned char         *key_;
 	long long unsigned int iv_;
 
 	const EVP_CIPHER *cipher_;

--- a/src/libs/protobuf_comm/message_register.cpp
+++ b/src/libs/protobuf_comm/message_register.cpp
@@ -79,7 +79,7 @@ MessageRegister::MessageRegister(std::vector<std::string> &proto_path)
 	pb_factory_  = new google::protobuf::DynamicMessageFactory(pb_importer_->pool());
 
 	for (size_t i = 0; i < proto_path.size(); ++i) {
-		DIR *          dir;
+		DIR           *dir;
 		struct dirent *ent;
 		if ((dir = opendir(proto_path[i].c_str())) != NULL) {
 			while ((ent = readdir(dir)) != NULL) {
@@ -264,9 +264,9 @@ void
 MessageRegister::serialize(uint16_t                   component_id,
                            uint16_t                   msg_type,
                            google::protobuf::Message &msg,
-                           frame_header_t &           frame_header,
-                           message_header_t &         message_header,
-                           std::string &              data)
+                           frame_header_t            &frame_header,
+                           message_header_t          &message_header,
+                           std::string               &data)
 {
 	if (msg.SerializeToString(&data)) {
 		message_header.component_id = htons(component_id);
@@ -288,9 +288,9 @@ MessageRegister::serialize(uint16_t                   component_id,
  * for the given component ID and message type.
  */
 std::shared_ptr<google::protobuf::Message>
-MessageRegister::deserialize(frame_header_t &  frame_header,
+MessageRegister::deserialize(frame_header_t   &frame_header,
                              message_header_t &message_header,
-                             void *            data)
+                             void             *data)
 {
 	uint16_t comp_id   = ntohs(message_header.component_id);
 	uint16_t msg_type  = ntohs(message_header.msg_type);

--- a/src/libs/protobuf_comm/message_register.h
+++ b/src/libs/protobuf_comm/message_register.h
@@ -126,9 +126,9 @@ public:
 	void serialize(uint16_t                   component_id,
 	               uint16_t                   msg_type,
 	               google::protobuf::Message &msg,
-	               frame_header_t &           frame_header,
-	               message_header_t &         message_header,
-	               std::string &              data);
+	               frame_header_t            &frame_header,
+	               message_header_t          &message_header,
+	               std::string               &data);
 	std::shared_ptr<google::protobuf::Message>
 	deserialize(frame_header_t &frame_header, message_header_t &message_header, void *data);
 
@@ -159,8 +159,8 @@ private: // members
 	TypeNameMap message_by_typename_;
 
 	google::protobuf::compiler::DiskSourceTree *pb_srctree_;
-	google::protobuf::compiler::Importer *      pb_importer_;
-	google::protobuf::MessageFactory *          pb_factory_;
+	google::protobuf::compiler::Importer       *pb_importer_;
+	google::protobuf::MessageFactory           *pb_factory_;
 	std::multimap<std::string, std::string>     failed_to_load_types_;
 };
 

--- a/src/libs/protobuf_comm/peer.cpp
+++ b/src/libs/protobuf_comm/peer.cpp
@@ -134,7 +134,7 @@ ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string         address,
  */
 ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string address,
                                              unsigned short    port,
-                                             MessageRegister * mr)
+                                             MessageRegister  *mr)
 : io_service_(),
   resolver_(io_service_),
   socket_(io_service_, ip::udp::endpoint(ip::udp::v4(), port)),
@@ -176,7 +176,7 @@ ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string address,
 ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string address,
                                              unsigned short    send_to_port,
                                              unsigned short    recv_on_port,
-                                             MessageRegister * mr,
+                                             MessageRegister  *mr,
                                              const std::string crypto_key,
                                              const std::string cipher)
 : io_service_(),
@@ -216,7 +216,7 @@ ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string address,
  */
 ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string address,
                                              unsigned short    port,
-                                             MessageRegister * mr,
+                                             MessageRegister  *mr,
                                              const std::string crypto_key,
                                              const std::string cipher)
 : io_service_(),
@@ -241,7 +241,7 @@ ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string address,
 ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string      address,
                                              unsigned short         send_to_port,
                                              unsigned short         recv_on_port,
-                                             MessageRegister *      mr,
+                                             MessageRegister       *mr,
                                              frame_header_version_t header_version)
 : io_service_(),
   resolver_(io_service_),
@@ -260,7 +260,7 @@ ProtobufBroadcastPeer::ProtobufBroadcastPeer(const std::string      address,
  * @þaram header_version which frame header version to send, use with caution
  */
 void
-ProtobufBroadcastPeer::ctor(const std::string &    address,
+ProtobufBroadcastPeer::ctor(const std::string     &address,
                             unsigned int           send_to_port,
                             const std::string      crypto_key,
                             const std::string      cipher,
@@ -478,7 +478,7 @@ ProtobufBroadcastPeer::handle_recv(const boost::system::error_code &error, size_
 				    || !std::binary_search(local_endpoints_.begin(),
 				                           local_endpoints_.end(),
 				                           in_endpoint_)) {
-					void *           data;
+					void            *data;
 					message_header_t message_header;
 
 					if (frame_header_version_ == PB_FRAME_V1) {
@@ -524,7 +524,7 @@ ProtobufBroadcastPeer::handle_recv(const boost::system::error_code &error, size_
 void
 ProtobufBroadcastPeer::handle_sent(const boost::system::error_code &error,
                                    size_t                           bytes_transferred,
-                                   QueueEntry *                     entry)
+                                   QueueEntry                      *entry)
 {
 	delete entry;
 
@@ -589,7 +589,7 @@ ProtobufBroadcastPeer::send(uint16_t component_id, uint16_t msg_type, google::pr
  */
 void
 ProtobufBroadcastPeer::send_raw(const frame_header_t &frame_header,
-                                const void *          data,
+                                const void           *data,
                                 size_t                data_size)
 {
 	QueueEntry *entry         = new QueueEntry();
@@ -637,7 +637,7 @@ ProtobufBroadcastPeer::send(std::shared_ptr<google::protobuf::Message> m)
 void
 ProtobufBroadcastPeer::send(google::protobuf::Message &m)
 {
-	const google::protobuf::Descriptor *    desc     = m.GetDescriptor();
+	const google::protobuf::Descriptor     *desc     = m.GetDescriptor();
 	const google::protobuf::EnumDescriptor *enumdesc = desc->FindEnumTypeByName("CompType");
 	if (!enumdesc) {
 		throw std::logic_error("Message does not have CompType enum");

--- a/src/libs/protobuf_comm/peer.h
+++ b/src/libs/protobuf_comm/peer.h
@@ -76,7 +76,7 @@ public:
 	ProtobufBroadcastPeer(const std::string      address,
 	                      unsigned short         send_to_port,
 	                      unsigned short         recv_on_port,
-	                      MessageRegister *      mr,
+	                      MessageRegister       *mr,
 	                      frame_header_version_t header_version = PB_FRAME_V2);
 	ProtobufBroadcastPeer(const std::string address,
 	                      unsigned short    port,
@@ -84,7 +84,7 @@ public:
 	                      const std::string cipher = "aes-128-ecb");
 	ProtobufBroadcastPeer(const std::string address,
 	                      unsigned short    port,
-	                      MessageRegister * mr,
+	                      MessageRegister  *mr,
 	                      const std::string crypto_key,
 	                      const std::string cipher = "aes-128-ecb");
 	ProtobufBroadcastPeer(const std::string address,
@@ -95,7 +95,7 @@ public:
 	ProtobufBroadcastPeer(const std::string address,
 	                      unsigned short    send_to_port,
 	                      unsigned short    recv_on_port,
-	                      MessageRegister * mr,
+	                      MessageRegister  *mr,
 	                      const std::string crypto_key,
 	                      const std::string cipher = "aes-128-ecb");
 	~ProtobufBroadcastPeer();
@@ -187,7 +187,7 @@ private: // methods
 	void run_asio();
 	void start_send();
 	void start_recv();
-	void handle_resolve(const boost::system::error_code &        err,
+	void handle_resolve(const boost::system::error_code         &err,
 	                    boost::asio::ip::udp::resolver::iterator endpoint_iterator);
 	void handle_sent(const boost::system::error_code &error,
 	                 size_t /*bytes_transferred*/,
@@ -215,8 +215,8 @@ private: // members
 	boost::asio::ip::udp::endpoint outbound_endpoint_;
 	boost::asio::ip::udp::endpoint in_endpoint_;
 
-	void * in_data_;
-	void * enc_in_data_;
+	void  *in_data_;
+	void  *enc_in_data_;
 	size_t in_data_size_;
 	size_t enc_in_data_size_;
 

--- a/src/libs/protobuf_comm/qa/qa_peer.cpp
+++ b/src/libs/protobuf_comm/qa/qa_peer.cpp
@@ -64,7 +64,7 @@ handle_error(const boost::system::error_code &error)
 }
 
 void
-handle_message(boost::asio::ip::udp::endpoint &           sender,
+handle_message(boost::asio::ip::udp::endpoint            &sender,
                uint16_t                                   component_id,
                uint16_t                                   msg_type,
                std::shared_ptr<google::protobuf::Message> msg)

--- a/src/libs/protobuf_comm/server.cpp
+++ b/src/libs/protobuf_comm/server.cpp
@@ -60,7 +60,7 @@ namespace protobuf_comm {
  * @param io_service ASIO I/O service to use for communication
  */
 ProtobufStreamServer::Session::Session(ClientID                 id,
-                                       ProtobufStreamServer *   parent,
+                                       ProtobufStreamServer    *parent,
                                        boost::asio::io_service &io_service)
 : id_(id), parent_(parent), socket_(io_service)
 {
@@ -354,7 +354,7 @@ ProtobufStreamServer::send(ClientID                                   client,
 void
 ProtobufStreamServer::send(ClientID client, google::protobuf::Message &m)
 {
-	const google::protobuf::Descriptor *    desc     = m.GetDescriptor();
+	const google::protobuf::Descriptor     *desc     = m.GetDescriptor();
 	const google::protobuf::EnumDescriptor *enumdesc = desc->FindEnumTypeByName("CompType");
 	if (!enumdesc) {
 		throw std::logic_error("Message does not have CompType enum");

--- a/src/libs/protobuf_comm/server.h
+++ b/src/libs/protobuf_comm/server.h
@@ -71,7 +71,7 @@ public:
 	~ProtobufStreamServer();
 
 	void
-	     send(ClientID client, uint16_t component_id, uint16_t msg_type, google::protobuf::Message &m);
+	send(ClientID client, uint16_t component_id, uint16_t msg_type, google::protobuf::Message &m);
 	void send(ClientID                                   client,
 	          uint16_t                                   component_id,
 	          uint16_t                                   msg_type,
@@ -181,13 +181,13 @@ private:
 
 	private:
 		ClientID                       id_;
-		ProtobufStreamServer *         parent_;
+		ProtobufStreamServer          *parent_;
 		boost::asio::ip::tcp::socket   socket_;
 		boost::asio::ip::tcp::endpoint remote_endpoint_;
 
 		frame_header_t in_frame_header_;
 		size_t         in_data_size_;
-		void *         in_data_;
+		void          *in_data_;
 
 		std::queue<QueueEntry *> outbound_queue_;
 		std::mutex               outbound_mutex_;

--- a/src/libs/rest-api/clips-rest-api/clips-rest-api.h
+++ b/src/libs/rest-api/clips-rest-api/clips-rest-api.h
@@ -83,6 +83,6 @@ private:
 	CLIPS::Environment *env_;
 
 	fawkes::Mutex &env_mutex_;
-	Logger *       logger_;
+	Logger        *logger_;
 };
 } //end namespace llsfrb

--- a/src/libs/rest-api/rest_processor.cpp
+++ b/src/libs/rest-api/rest_processor.cpp
@@ -51,9 +51,9 @@ using namespace fawkes;
 
 namespace llsfrb {
 
-WebviewRESTRequestProcessor::WebviewRESTRequestProcessor(fawkes::WebUrlManager *        url_manager,
+WebviewRESTRequestProcessor::WebviewRESTRequestProcessor(fawkes::WebUrlManager         *url_manager,
                                                          fawkes::WebviewRestApiManager *api_mgr,
-                                                         Logger *                       logger)
+                                                         Logger                        *logger)
 : url_mgr_(url_manager),
   api_mgr_(api_mgr),
   logger_(logger),

--- a/src/libs/rest-api/rest_processor.h
+++ b/src/libs/rest-api/rest_processor.h
@@ -43,18 +43,18 @@ class Logger;
 class WebviewRESTRequestProcessor
 {
 public:
-	WebviewRESTRequestProcessor(fawkes::WebUrlManager *        url_manager,
+	WebviewRESTRequestProcessor(fawkes::WebUrlManager         *url_manager,
 	                            fawkes::WebviewRestApiManager *api_mgr,
-	                            llsfrb::Logger *               logger);
+	                            llsfrb::Logger                *logger);
 	~WebviewRESTRequestProcessor();
 
 private:
 	fawkes::WebReply *process_request(const fawkes::WebRequest *request);
 
 private:
-	fawkes::WebUrlManager *        url_mgr_;
+	fawkes::WebUrlManager         *url_mgr_;
 	fawkes::WebviewRestApiManager *api_mgr_;
-	llsfrb::Logger *               logger_;
+	llsfrb::Logger                *logger_;
 
 	std::vector<fawkes::WebRequest::Method> methods_;
 };

--- a/src/libs/rest-api/service_browse_handler.cpp
+++ b/src/libs/rest-api/service_browse_handler.cpp
@@ -42,7 +42,7 @@ using namespace fawkes;
 namespace llsfrb {
 
 WebviewServiceBrowseHandler::WebviewServiceBrowseHandler(
-  Logger *                                logger,
+  Logger                                 *logger,
   std::shared_ptr<fawkes::NetworkService> webview_service)
 
 {
@@ -75,11 +75,11 @@ WebviewServiceBrowseHandler::browse_failed(const char *name, const char *type, c
 }
 
 void
-WebviewServiceBrowseHandler::service_added(const char *            name,
-                                           const char *            type,
-                                           const char *            domain,
-                                           const char *            host_name,
-                                           const struct sockaddr * addr,
+WebviewServiceBrowseHandler::service_added(const char             *name,
+                                           const char             *type,
+                                           const char             *domain,
+                                           const char             *host_name,
+                                           const struct sockaddr  *addr,
                                            const socklen_t         addr_size,
                                            uint16_t                port,
                                            std::list<std::string> &txt,

--- a/src/libs/rest-api/service_browse_handler.h
+++ b/src/libs/rest-api/service_browse_handler.h
@@ -37,18 +37,18 @@ class Logger;
 class WebviewServiceBrowseHandler : public fawkes::ServiceBrowseHandler
 {
 public:
-	WebviewServiceBrowseHandler(Logger *                                logger,
+	WebviewServiceBrowseHandler(Logger                                 *logger,
 	                            std::shared_ptr<fawkes::NetworkService> webview_service);
 	~WebviewServiceBrowseHandler();
 
 	virtual void all_for_now();
 	virtual void cache_exhausted();
 	virtual void browse_failed(const char *name, const char *type, const char *domain);
-	virtual void service_added(const char *            name,
-	                           const char *            type,
-	                           const char *            domain,
-	                           const char *            host_name,
-	                           const struct sockaddr * addr,
+	virtual void service_added(const char             *name,
+	                           const char             *type,
+	                           const char             *domain,
+	                           const char             *host_name,
+	                           const struct sockaddr  *addr,
 	                           const socklen_t         addr_size,
 	                           uint16_t                port,
 	                           std::list<std::string> &txt,
@@ -63,7 +63,7 @@ public:
 	ServiceList &service_list();
 
 private:
-	Logger *                                logger_;
+	Logger                                 *logger_;
 	std::shared_ptr<fawkes::NetworkService> webview_service_;
 	ServiceList                             service_list_;
 };

--- a/src/libs/rest-api/webview_server.cpp
+++ b/src/libs/rest-api/webview_server.cpp
@@ -67,8 +67,8 @@ WebviewServer::WebviewServer(bool                                           enab
                              std::unique_ptr<fawkes::NetworkNameResolver>   nnresolver,
                              std::shared_ptr<fawkes::ServicePublisher>      service_publisher,
                              std::shared_ptr<fawkes::ServiceBrowser>        service_browser,
-                             Configuration *                                config,
-                             Logger *                                       logger)
+                             Configuration                                 *config,
+                             Logger                                        *logger)
 : fawkes::Thread("WebviewServer", Thread::OPMODE_CONTINUOUS),
   rest_api_manager_(rest_api_manager),
   nnresolver_(std::move(nnresolver)),

--- a/src/libs/rest-api/webview_server.h
+++ b/src/libs/rest-api/webview_server.h
@@ -65,8 +65,8 @@ public:
 	              std::unique_ptr<fawkes::NetworkNameResolver>   nnresolver,
 	              std::shared_ptr<fawkes::ServicePublisher>      service_publisher,
 	              std::shared_ptr<fawkes::ServiceBrowser>        service_browser,
-	              Configuration *                                config,
-	              Logger *                                       logger);
+	              Configuration                                 *config,
+	              Logger                                        *logger);
 	~WebviewServer();
 
 	virtual void loop();
@@ -107,7 +107,7 @@ private:
 	std::shared_ptr<fawkes::ServiceBrowser>      service_browser_;
 
 	Configuration *config_;
-	Logger *       logger_;
+	Logger        *logger_;
 };
 } // namespace llsfrb
 

--- a/src/libs/utils/misc/string_conversions.cpp
+++ b/src/libs/utils/misc/string_conversions.cpp
@@ -72,7 +72,7 @@ StringConversions::to_lower(std::string str)
 std::string
 StringConversions::to_string(const unsigned int i)
 {
-	char *      tmp;
+	char	     *tmp;
 	std::string rv;
 	if (asprintf(&tmp, "%u", i) == -1) {
 		throw OutOfMemoryException(
@@ -90,7 +90,7 @@ StringConversions::to_string(const unsigned int i)
 std::string
 StringConversions::to_string(const int i)
 {
-	char *      tmp;
+	char	     *tmp;
 	std::string rv;
 	if (asprintf(&tmp, "%i", i) == -1) {
 		throw OutOfMemoryException("StringConversions::tostring(const int): asprintf() failed");
@@ -107,7 +107,7 @@ StringConversions::to_string(const int i)
 std::string
 StringConversions::to_string(const long int i)
 {
-	char *      tmp;
+	char	     *tmp;
 	std::string rv;
 	if (asprintf(&tmp, "%li", i) == -1) {
 		throw OutOfMemoryException("StringConversions::tostring(const long int): asprintf() failed");
@@ -124,7 +124,7 @@ StringConversions::to_string(const long int i)
 std::string
 StringConversions::to_string(const float f)
 {
-	char *      tmp;
+	char	     *tmp;
 	std::string rv;
 	if (asprintf(&tmp, "%f", f) == -1) {
 		throw OutOfMemoryException("StringConversions::tostring(const float): asprintf() failed");
@@ -141,7 +141,7 @@ StringConversions::to_string(const float f)
 std::string
 StringConversions::to_string(const double d)
 {
-	char *      tmp;
+	char	     *tmp;
 	std::string rv;
 	if (asprintf(&tmp, "%f", d) == -1) {
 		throw OutOfMemoryException("StringConversions::tostring(const double d): asprintf() failed");

--- a/src/libs/utils/system/argparser.cpp
+++ b/src/libs/utils/system/argparser.cpp
@@ -295,7 +295,7 @@ long int
 ArgumentParser::parse_int(const char *argn)
 {
 	if ((__opts.count(argn) > 0) && (__opts[argn] != NULL)) {
-		char *   endptr;
+		char    *endptr;
 		long int rv = strtol(__opts[argn], &endptr, 10);
 		if (endptr[0] != 0) {
 			throw IllegalArgumentException("Supplied argument is not of type int");
@@ -318,7 +318,7 @@ double
 ArgumentParser::parse_float(const char *argn)
 {
 	if ((__opts.count(argn) > 0) && (__opts[argn] != NULL)) {
-		char * endptr;
+		char  *endptr;
 		double rv = strtod(__opts[argn], &endptr);
 		if (endptr[0] != 0) {
 			throw IllegalArgumentException("Supplied argument is not of type double");
@@ -341,7 +341,7 @@ long int
 ArgumentParser::parse_item_int(unsigned int index)
 {
 	if (index < __items.size()) {
-		char *   endptr;
+		char    *endptr;
 		long int rv = strtol(__items[index], &endptr, 10);
 		if (endptr[0] != 0) {
 			throw IllegalArgumentException("Supplied argument is not of type int");
@@ -364,7 +364,7 @@ double
 ArgumentParser::parse_item_float(unsigned int index)
 {
 	if (index < __items.size()) {
-		char * endptr;
+		char  *endptr;
 		double rv = strtod(__items[index], &endptr);
 		if (endptr[0] != 0) {
 			throw IllegalArgumentException("Supplied argument is not of type double");

--- a/src/libs/utils/system/argparser.h
+++ b/src/libs/utils/system/argparser.h
@@ -79,7 +79,7 @@ public:
 	long int parse_item_int(unsigned int index);
 	double   parse_item_float(unsigned int index);
 
-	const std::vector<const char *> &    items() const;
+	const std::vector<const char *>     &items() const;
 	std::vector<const char *>::size_type num_items() const;
 
 	int          argc() const;
@@ -106,7 +106,7 @@ private:
 	std::map<std::string, const char *> __opts_cit;
 	std::vector<const char *>           __items;
 
-	char * __program_name;
+	char  *__program_name;
 	char **__argv;
 	int    __argc;
 

--- a/src/libs/utils/system/file.h
+++ b/src/libs/utils/system/file.h
@@ -52,7 +52,7 @@ public:
 	File(const char *filename, FileOpenMethod method = APPEND);
 	~File();
 
-	FILE *      stream() const;
+	FILE	     *stream() const;
 	const char *filename() const;
 
 	static bool exists(const char *filename);

--- a/src/libs/utils/system/hostinfo.h
+++ b/src/libs/utils/system/hostinfo.h
@@ -48,8 +48,8 @@ public:
 
 private:
 	struct ::utsname *utsname;
-	char *            short__name;
-	char *            domain_name;
+	char             *short__name;
+	char             *domain_name;
 };
 
 } // end namespace fawkes

--- a/src/libs/utils/time/time.h
+++ b/src/libs/utils/time/time.h
@@ -167,13 +167,13 @@ public:
 	double operator-(const Time *t) const;
 	Time   operator-(const long int usec) const;
 	Time   operator-(const double sec) const;
-	Time & operator+=(const long int usec);
-	Time & operator+=(const Time &t);
-	Time & operator+=(const double sec);
-	Time & operator-=(const Time &t);
-	Time & operator-=(const double sec);
-	Time & operator-=(const long int usec);
-	Time & operator=(const Time &t);
+	Time  &operator+=(const long int usec);
+	Time  &operator+=(const Time &t);
+	Time  &operator+=(const double sec);
+	Time  &operator-=(const Time &t);
+	Time  &operator-=(const double sec);
+	Time  &operator-=(const long int usec);
+	Time  &operator=(const Time &t);
 	bool   operator==(const Time &t) const;
 	bool   operator==(const Time *t) const;
 	bool   operator!=(const Time &t) const;
@@ -196,7 +196,7 @@ public:
 	static const unsigned int TIMESTR_SIZE;
 
 private:
-	Clock *       clock_;
+	Clock	      *clock_;
 	timeval       time_;
 	mutable char *timestr_;
 };

--- a/src/libs/utils/time/tracker.cpp
+++ b/src/libs/utils/time/tracker.cpp
@@ -278,10 +278,10 @@ TimeTracker::ping_abort(unsigned int cls)
 
 void
 TimeTracker::average_and_deviation(vector<struct timeval *> &values,
-                                   double &                  average_sec,
-                                   double &                  average_ms,
-                                   double &                  deviation_sec,
-                                   double &                  deviation_ms)
+                                   double                   &average_sec,
+                                   double                   &average_ms,
+                                   double                   &deviation_sec,
+                                   double                   &deviation_ms)
 {
 	vector<struct timeval *>::iterator tit;
 

--- a/src/libs/utils/time/tracker.h
+++ b/src/libs/utils/time/tracker.h
@@ -58,10 +58,10 @@ public:
 
 private:
 	void average_and_deviation(std::vector<struct timeval *> &values,
-	                           double &                       average_sec,
-	                           double &                       average_ms,
-	                           double &                       deviation_sec,
-	                           double &                       deviation_ms);
+	                           double                        &average_sec,
+	                           double                        &average_ms,
+	                           double                        &deviation_sec,
+	                           double                        &deviation_ms);
 
 private:
 	timeval                                       start_time;
@@ -75,7 +75,7 @@ private:
 	std::string                                   tracker_comment_;
 
 	unsigned int write_cycle_;
-	FILE *       timelog_;
+	FILE        *timelog_;
 };
 
 class ScopedClassItemTracker

--- a/src/libs/utils/time/wait.cpp
+++ b/src/libs/utils/time/wait.cpp
@@ -140,7 +140,7 @@ TimeWait::wait(long int usec)
 {
 	if (usec < 0)
 		return;
-	Clock *        clock = Clock::instance();
+	Clock         *clock = Clock::instance();
 	struct timeval start, now;
 	long int       remaining_usec = usec;
 	clock->get_time(&start);

--- a/src/libs/utils/time/wait.h
+++ b/src/libs/utils/time/wait.h
@@ -43,10 +43,10 @@ public:
 	static void wait_systime(long int usec);
 
 private:
-	Clock *  clock_;
-	Time *   until_;
-	Time *   until_systime_;
-	Time *   now_;
+	Clock   *clock_;
+	Time    *until_;
+	Time    *until_systime_;
+	Time    *now_;
 	long int desired_loop_time_;
 };
 

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -725,7 +725,7 @@ Data::on_connect_info(std::string tmpl_name,
  */
 template <class T>
 void
-Data::get_known_teams_fact(T *                                 o,
+Data::get_known_teams_fact(T                                  *o,
                            rapidjson::Document::AllocatorType &alloc,
                            CLIPS::Fact::pointer                fact)
 {
@@ -757,7 +757,7 @@ Data::get_known_teams_fact(T *                                 o,
  */
 template <class T>
 void
-Data::get_machine_info_fact(T *                                 o,
+Data::get_machine_info_fact(T                                  *o,
                             rapidjson::Document::AllocatorType &alloc,
                             CLIPS::Fact::pointer                fact)
 {
@@ -826,7 +826,7 @@ Data::get_machine_info_fact(T *                                 o,
  */
 template <class T>
 void
-Data::get_order_info_fact(T *                                 o,
+Data::get_order_info_fact(T                                  *o,
                           rapidjson::Document::AllocatorType &alloc,
                           CLIPS::Fact::pointer                fact)
 {
@@ -939,7 +939,7 @@ Data::get_unconfirmed_delivery_fact(rapidjson::Document::AllocatorType &alloc, i
  */
 template <class T>
 void
-Data::get_robot_info_fact(T *                                 o,
+Data::get_robot_info_fact(T                                  *o,
                           rapidjson::Document::AllocatorType &alloc,
                           CLIPS::Fact::pointer                fact)
 {
@@ -1002,7 +1002,7 @@ Data::get_robot_info_fact(T *                                 o,
  */
 template <class T>
 void
-Data::get_game_state_fact(T *                                 o,
+Data::get_game_state_fact(T                                  *o,
                           rapidjson::Document::AllocatorType &alloc,
                           CLIPS::Fact::pointer                fact)
 {
@@ -1099,7 +1099,7 @@ Data::get_points_fact(T *o, rapidjson::Document::AllocatorType &alloc, CLIPS::Fa
  */
 template <class T>
 void
-Data::get_workpiece_info_fact(T *                                 o,
+Data::get_workpiece_info_fact(T                                  *o,
                               rapidjson::Document::AllocatorType &alloc,
                               CLIPS::Fact::pointer                fact)
 {

--- a/src/libs/websocket/data.h
+++ b/src/libs/websocket/data.h
@@ -106,7 +106,7 @@ public:
 	template <class T>
 	void get_points_fact(T *o, rapidjson::Document::AllocatorType &alloc, CLIPS::Fact::pointer fact);
 	template <class T>
-	void get_workpiece_info_fact(T *                                 o,
+	void get_workpiece_info_fact(T                                  *o,
 	                             rapidjson::Document::AllocatorType &alloc,
 	                             CLIPS::Fact::pointer                fact);
 
@@ -125,7 +125,7 @@ private:
 	std::queue<std::string>                    logs;
 	std::vector<std::shared_ptr<Client>>       clients;
 	std::shared_ptr<CLIPS::Environment>        env_;
-	fawkes::Mutex &                            env_mutex_;
+	fawkes::Mutex                             &env_mutex_;
 	std::shared_ptr<rapidjson::SchemaDocument> load_schema(std::string path);
 };
 

--- a/src/libs/webview/access_log.h
+++ b/src/libs/webview/access_log.h
@@ -39,7 +39,7 @@ public:
 
 private:
 	Mutex *mutex_;
-	FILE * logfile_;
+	FILE  *logfile_;
 };
 
 } // namespace fawkes

--- a/src/libs/webview/file_reply.h
+++ b/src/libs/webview/file_reply.h
@@ -44,7 +44,7 @@ private:
 	void determine_file_size();
 
 private:
-	FILE * file_;
+	FILE  *file_;
 	size_t size_;
 	bool   close_when_done_;
 };

--- a/src/libs/webview/page_reply.cpp
+++ b/src/libs/webview/page_reply.cpp
@@ -106,7 +106,7 @@ WebPageReply::pack(std::string             active_baseurl,
 		merged_body_ += headergen->html_header(_title, active_baseurl, html_header_);
 	else {
 		fawkes::HostInfo hi;
-		char *           s;
+		char            *s;
 		if (asprintf(&s, PAGE_HEADER, _title.c_str(), html_header_.c_str(), hi.short_name()) != -1) {
 			merged_body_ += s;
 			free(s);

--- a/src/libs/webview/page_reply.h
+++ b/src/libs/webview/page_reply.h
@@ -35,7 +35,7 @@ class WebPageReply : public StaticWebReply
 public:
 	WebPageReply(std::string title, std::string page = "");
 
-	virtual const std::string &    body();
+	virtual const std::string     &body();
 	virtual std::string::size_type body_length();
 	virtual void
 	pack()

--- a/src/libs/webview/reply.h
+++ b/src/libs/webview/reply.h
@@ -141,7 +141,7 @@ public:
 	void            append_body(const std::string &s);
 	StaticWebReply &operator+=(std::string text);
 
-	virtual const std::string &    body();
+	virtual const std::string     &body();
 	virtual std::string::size_type body_length();
 
 	virtual void pack();

--- a/src/libs/webview/request.cpp
+++ b/src/libs/webview/request.cpp
@@ -93,9 +93,9 @@ WebRequest::WebRequest(const char *uri) : pp_(NULL), is_setup_(false), uri_(uri)
  * @param connection MicroHTTPd connection
  */
 void
-WebRequest::setup(const char *    url,
-                  const char *    method,
-                  const char *    version,
+WebRequest::setup(const char     *url,
+                  const char     *method,
+                  const char     *version,
                   MHD_Connection *connection)
 {
 	url_ = url;

--- a/src/libs/webview/request_dispatcher.cpp
+++ b/src/libs/webview/request_dispatcher.cpp
@@ -62,7 +62,7 @@ namespace fawkes {
  * @param headergen page header generator
  * @param footergen page footer generator
  */
-WebRequestDispatcher::WebRequestDispatcher(WebUrlManager *         url_manager,
+WebRequestDispatcher::WebRequestDispatcher(WebUrlManager          *url_manager,
                                            WebPageHeaderGenerator *headergen,
                                            WebPageFooterGenerator *footergen)
 {
@@ -163,14 +163,14 @@ WebRequestDispatcher::uri_log_cb(void *cls, const char *uri)
  * @return appropriate return code for libmicrohttpd
  */
 MHD_RESULT
-WebRequestDispatcher::process_request_cb(void *                 callback_data,
+WebRequestDispatcher::process_request_cb(void                  *callback_data,
                                          struct MHD_Connection *connection,
-                                         const char *           url,
-                                         const char *           method,
-                                         const char *           version,
-                                         const char *           upload_data,
-                                         size_t *               upload_data_size,
-                                         void **                session_data)
+                                         const char            *url,
+                                         const char            *method,
+                                         const char            *version,
+                                         const char            *upload_data,
+                                         size_t                *upload_data_size,
+                                         void                 **session_data)
 {
 	WebRequestDispatcher *rd = static_cast<WebRequestDispatcher *>(callback_data);
 	return rd->process_request(
@@ -184,13 +184,13 @@ WebRequestDispatcher::process_request_cb(void *                 callback_data,
  * @param toe termination code
  */
 void
-WebRequestDispatcher::request_completed_cb(void *                          cls,
-                                           struct MHD_Connection *         connection,
-                                           void **                         con_cls,
+WebRequestDispatcher::request_completed_cb(void                           *cls,
+                                           struct MHD_Connection          *connection,
+                                           void                          **con_cls,
                                            enum MHD_RequestTerminationCode toe)
 {
 	WebRequestDispatcher *rd      = static_cast<WebRequestDispatcher *>(cls);
-	WebRequest *          request = static_cast<WebRequest *>(*con_cls);
+	WebRequest           *request = static_cast<WebRequest *>(*con_cls);
 	rd->request_completed(request, toe);
 	delete request;
 }
@@ -208,7 +208,7 @@ dynamic_reply_data_cb(void *reply, uint64_t pos, char *buf, size_t max)
 {
 	DynamicWebReply *dreply  = static_cast<DynamicWebReply *>(reply);
 	ssize_t          bytes   = dreply->next_chunk(pos, buf, max);
-	WebRequest *     request = dreply->get_request();
+	WebRequest      *request = dreply->get_request();
 	if (bytes > 0 && request)
 		request->increment_reply_size(bytes);
 	return bytes;
@@ -232,7 +232,7 @@ struct MHD_Response *
 WebRequestDispatcher::prepare_static_response(StaticWebReply *sreply)
 {
 	struct MHD_Response *response;
-	WebPageReply *       wpreply = dynamic_cast<WebPageReply *>(sreply);
+	WebPageReply        *wpreply = dynamic_cast<WebPageReply *>(sreply);
 	if (wpreply) {
 		wpreply->pack(active_baseurl_, page_header_generator_, page_footer_generator_);
 	} else {
@@ -253,7 +253,7 @@ WebRequestDispatcher::prepare_static_response(StaticWebReply *sreply)
 		request->increment_reply_size(sreply->body_length());
 	}
 
-	const WebReply::HeaderMap &         headers = sreply->headers();
+	const WebReply::HeaderMap          &headers = sreply->headers();
 	WebReply::HeaderMap::const_iterator i;
 	for (i = headers.begin(); i != headers.end(); ++i) {
 		MHD_add_response_header(response, i->first.c_str(), i->second.c_str());
@@ -269,8 +269,8 @@ WebRequestDispatcher::prepare_static_response(StaticWebReply *sreply)
  */
 MHD_RESULT
 WebRequestDispatcher::queue_dynamic_reply(struct MHD_Connection *connection,
-                                          WebRequest *           request,
-                                          DynamicWebReply *      dreply)
+                                          WebRequest            *request,
+                                          DynamicWebReply       *dreply)
 {
 	dreply->set_request(request);
 	dreply->pack_caching();
@@ -280,7 +280,7 @@ WebRequestDispatcher::queue_dynamic_reply(struct MHD_Connection *connection,
 	response = MHD_create_response_from_callback(
 	  dreply->size(), dreply->chunk_size(), dynamic_reply_data_cb, dreply, dynamic_reply_free_cb);
 
-	const WebReply::HeaderMap &         headers = dreply->headers();
+	const WebReply::HeaderMap          &headers = dreply->headers();
 	WebReply::HeaderMap::const_iterator i;
 	for (i = headers.begin(); i != headers.end(); ++i) {
 		MHD_add_response_header(response, i->first.c_str(), i->second.c_str());
@@ -300,8 +300,8 @@ WebRequestDispatcher::queue_dynamic_reply(struct MHD_Connection *connection,
  */
 MHD_RESULT
 WebRequestDispatcher::queue_static_reply(struct MHD_Connection *connection,
-                                         WebRequest *           request,
-                                         StaticWebReply *       sreply)
+                                         WebRequest            *request,
+                                         StaticWebReply        *sreply)
 {
 	sreply->set_request(request);
 
@@ -358,13 +358,13 @@ WebRequestDispatcher::queue_basic_auth_fail(struct MHD_Connection *connection, W
  *         MHD_NO to abort the iteration
  */
 static MHD_RESULT
-post_iterator(void *             cls,
+post_iterator(void              *cls,
               enum MHD_ValueKind kind,
-              const char *       key,
-              const char *       filename,
-              const char *       content_type,
-              const char *       transfer_encoding,
-              const char *       data,
+              const char        *key,
+              const char        *filename,
+              const char        *content_type,
+              const char        *transfer_encoding,
+              const char        *data,
               uint64_t           off,
               size_t             size)
 {
@@ -401,12 +401,12 @@ WebRequestDispatcher::log_uri(const char *uri)
  */
 MHD_RESULT
 WebRequestDispatcher::process_request(struct MHD_Connection *connection,
-                                      const char *           url,
-                                      const char *           method,
-                                      const char *           version,
-                                      const char *           upload_data,
-                                      size_t *               upload_data_size,
-                                      void **                session_data)
+                                      const char            *url,
+                                      const char            *method,
+                                      const char            *version,
+                                      const char            *upload_data,
+                                      size_t                *upload_data_size,
+                                      void                 **session_data)
 {
 	WebRequest *request = static_cast<WebRequest *>(*session_data);
 
@@ -499,7 +499,7 @@ WebRequestDispatcher::process_request(struct MHD_Connection *connection,
 	}
 
 	try {
-		WebReply * reply = url_manager_->process_request(request);
+		WebReply  *reply = url_manager_->process_request(request);
 		MHD_RESULT ret;
 
 		if (reply) {
@@ -507,7 +507,7 @@ WebRequestDispatcher::process_request(struct MHD_Connection *connection,
 				reply->add_header("Access-Control-Allow-Origin", "*");
 			}
 
-			StaticWebReply * sreply = dynamic_cast<StaticWebReply *>(reply);
+			StaticWebReply  *sreply = dynamic_cast<StaticWebReply *>(reply);
 			DynamicWebReply *dreply = dynamic_cast<DynamicWebReply *>(reply);
 			if (sreply) {
 				ret = queue_static_reply(connection, request, sreply);

--- a/src/libs/webview/request_dispatcher.h
+++ b/src/libs/webview/request_dispatcher.h
@@ -51,23 +51,23 @@ class Mutex;
 class WebRequestDispatcher
 {
 public:
-	WebRequestDispatcher(WebUrlManager *         url_manager,
+	WebRequestDispatcher(WebUrlManager          *url_manager,
 	                     WebPageHeaderGenerator *headergen = 0,
 	                     WebPageFooterGenerator *footergen = 0);
 	~WebRequestDispatcher();
 
-	static MHD_RESULT process_request_cb(void *                 callback_data,
+	static MHD_RESULT process_request_cb(void                  *callback_data,
 	                                     struct MHD_Connection *connection,
-	                                     const char *           url,
-	                                     const char *           method,
-	                                     const char *           version,
-	                                     const char *           upload_data,
-	                                     size_t *               upload_data_size,
-	                                     void **                session_data);
+	                                     const char            *url,
+	                                     const char            *method,
+	                                     const char            *version,
+	                                     const char            *upload_data,
+	                                     size_t                *upload_data_size,
+	                                     void                 **session_data);
 
-	static void request_completed_cb(void *                          cls,
-	                                 struct MHD_Connection *         connection,
-	                                 void **                         con_cls,
+	static void request_completed_cb(void                           *cls,
+	                                 struct MHD_Connection          *connection,
+	                                 void                          **con_cls,
 	                                 enum MHD_RequestTerminationCode toe);
 
 	static void *uri_log_cb(void *cls, const char *uri);
@@ -82,36 +82,36 @@ public:
 private:
 	struct MHD_Response *prepare_static_response(StaticWebReply *sreply);
 	MHD_RESULT           queue_static_reply(struct MHD_Connection *connection,
-	                                        WebRequest *           request,
-	                                        StaticWebReply *       sreply);
+	                                        WebRequest            *request,
+	                                        StaticWebReply        *sreply);
 	MHD_RESULT           queue_dynamic_reply(struct MHD_Connection *connection,
-	                                         WebRequest *           request,
-	                                         DynamicWebReply *      sreply);
+	                                         WebRequest            *request,
+	                                         DynamicWebReply       *sreply);
 	MHD_RESULT queue_basic_auth_fail(struct MHD_Connection *connection, WebRequest *request);
 	MHD_RESULT process_request(struct MHD_Connection *connection,
-	                           const char *           url,
-	                           const char *           method,
-	                           const char *           version,
-	                           const char *           upload_data,
-	                           size_t *               upload_data_size,
-	                           void **                session_data);
-	void *     log_uri(const char *uri);
+	                           const char            *url,
+	                           const char            *method,
+	                           const char            *version,
+	                           const char            *upload_data,
+	                           size_t                *upload_data_size,
+	                           void                 **session_data);
+	void      *log_uri(const char *uri);
 
 	void request_completed(WebRequest *request, MHD_RequestTerminationCode term_code);
 
 private:
-	WebUrlManager *   url_manager_;
+	WebUrlManager    *url_manager_;
 	WebviewAccessLog *access_log_;
 
 	std::string             active_baseurl_;
 	WebPageHeaderGenerator *page_header_generator_;
 	WebPageFooterGenerator *page_footer_generator_;
 
-	char *           realm_;
+	char            *realm_;
 	WebUserVerifier *user_verifier_;
 
 	unsigned int   active_requests_;
-	fawkes::Time * last_request_completion_time_;
+	fawkes::Time  *last_request_completion_time_;
 	fawkes::Mutex *active_requests_mutex_;
 
 	bool                     cors_allow_all_;

--- a/src/libs/webview/request_manager.h
+++ b/src/libs/webview/request_manager.h
@@ -46,7 +46,7 @@ private:
 	void set_server(WebServer *server);
 
 private:
-	Mutex *    mutex_;
+	Mutex     *mutex_;
 	WebServer *server_;
 };
 

--- a/src/libs/webview/rest_api.h
+++ b/src/libs/webview/rest_api.h
@@ -406,7 +406,7 @@ public:
 
 private:
 	std::string                             name_;
-	llsfrb::Logger *                        logger_;
+	llsfrb::Logger                         *logger_;
 	bool                                    pretty_json_;
 	std::shared_ptr<WebviewRouter<Handler>> router_;
 };

--- a/src/libs/webview/rest_api_manager.h
+++ b/src/libs/webview/rest_api_manager.h
@@ -43,7 +43,7 @@ public:
 	void unregister_api(WebviewRestApi *api);
 
 	WebviewRestApi *get_api(std::string &name);
-	Mutex &         mutex();
+	Mutex          &mutex();
 
 private:
 	Mutex                                   mutex_;

--- a/src/libs/webview/router.h
+++ b/src/libs/webview/router.h
@@ -75,7 +75,7 @@ public:
 	 */
 	T &
 	find_handler(WebRequest::Method                  method,
-	             const std::string &                 path,
+	             const std::string                  &path,
 	             std::map<std::string, std::string> &path_args)
 	{
 		auto ri = std::find_if(
@@ -208,8 +208,8 @@ private:
 	 * @return true if the path cold be matched, false otherwise.
 	 */
 	bool
-	path_match(const std::string &                 url,
-	           const path_regex &                  path_re,
+	path_match(const std::string                  &url,
+	           const path_regex                   &path_re,
 	           std::map<std::string, std::string> &path_args)
 	{
 		std::smatch matches;

--- a/src/libs/webview/server.cpp
+++ b/src/libs/webview/server.cpp
@@ -51,7 +51,7 @@ namespace fawkes {
  */
 WebServer::WebServer(unsigned short int    port,
                      WebRequestDispatcher *dispatcher,
-                     llsfrb::Logger *      logger)
+                     llsfrb::Logger       *logger)
 {
 	port_            = port;
 	dispatcher_      = dispatcher;

--- a/src/libs/webview/server.h
+++ b/src/libs/webview/server.h
@@ -70,10 +70,10 @@ private:
 	std::string read_file(const char *filename);
 
 private:
-	struct MHD_Daemon *   daemon_;
+	struct MHD_Daemon    *daemon_;
 	WebRequestDispatcher *dispatcher_;
-	WebRequestManager *   request_manager_;
-	llsfrb::Logger *      logger_;
+	WebRequestManager    *request_manager_;
+	llsfrb::Logger       *logger_;
 
 	unsigned short int port_;
 

--- a/src/refbox/clips_logger.cpp
+++ b/src/refbox/clips_logger.cpp
@@ -137,7 +137,7 @@ log_router_query(void *env, char *logical_name)
 static int
 log_router_print(void *env, char *logical_name, char *str)
 {
-	void *       rc     = GetEnvironmentRouterContext(env);
+	void        *rc     = GetEnvironmentRouterContext(env);
 	CLIPSLogger *logger = static_cast<CLIPSLogger *>(rc);
 	logger->log(logical_name, str);
 	return TRUE;

--- a/src/refbox/clips_logger.h
+++ b/src/refbox/clips_logger.h
@@ -57,9 +57,9 @@ public:
 	void log(const char *logical_name, const char *str);
 
 private:
-	Logger *    logger_;
-	Logger *    trace_logger_;
-	char *      component_;
+	Logger     *logger_;
+	Logger     *trace_logger_;
+	char	     *component_;
 	std::string buffer_;
 };
 

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -62,7 +62,7 @@ static_assert(false, "__has_include not supported");
 #else
 #	if __cplusplus >= 201703L && __has_include(<filesystem>)
 #		include <filesystem>
-namespace fs = std::filesystem;
+namespace fs    = std::filesystem;
 #	elif __has_include(<experimental/filesystem>)
 #		include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
@@ -761,7 +761,7 @@ LLSFRefBox::handle_clips_periodic()
 		long int              index = to_erase.front();
 		CLIPS::Fact::pointer &f     = clips_msg_facts_[index];
 		CLIPS::Value          v     = f->slot_value("ptr")[0];
-		void *                ptr   = v.as_address();
+		void                 *ptr   = v.as_address();
 		delete static_cast<std::shared_ptr<google::protobuf::Message> *>(ptr);
 		clips_msg_facts_.erase(index);
 		to_erase.pop();
@@ -1319,7 +1319,7 @@ LLSFRefBox::handle_server_client_msg(ProtobufStreamServer::ClientID             
  * @param msg the message
  */
 void
-LLSFRefBox::handle_peer_msg(boost::asio::ip::udp::endpoint &           endpoint,
+LLSFRefBox::handle_peer_msg(boost::asio::ip::udp::endpoint            &endpoint,
                             uint16_t                                   component_id,
                             uint16_t                                   msg_type,
                             std::shared_ptr<google::protobuf::Message> msg)
@@ -1351,7 +1351,7 @@ LLSFRefBox::handle_server_client_fail(ProtobufStreamServer::ClientID client,
 void
 LLSFRefBox::add_comp_type(google::protobuf::Message &m, document *doc)
 {
-	const google::protobuf::Descriptor *    desc     = m.GetDescriptor();
+	const google::protobuf::Descriptor     *desc     = m.GetDescriptor();
 	const google::protobuf::EnumDescriptor *enumdesc = desc->FindEnumTypeByName("CompType");
 	if (!enumdesc)
 		return;
@@ -1692,9 +1692,9 @@ LLSFRefBox::clips_mongodb_insert(std::string collection, void *bson)
 }
 
 void
-LLSFRefBox::mongodb_update(std::string &                  collection,
+LLSFRefBox::mongodb_update(std::string                   &collection,
                            const bsoncxx::document::view &doc,
-                           CLIPS::Value &                 query,
+                           CLIPS::Value                  &query,
                            bool                           upsert)
 {
 	if (!cfg_mongodb_enabled_) {
@@ -2058,7 +2058,7 @@ LLSFRefBox::run()
 	                               boost::asio::placeholders::error,
 	                               boost::asio::placeholders::signal_number));
 #else
-	g_refbox = this;
+	g_refbox          = this;
 	signal(SIGINT, llsfrb::handle_signal);
 #endif
 

--- a/src/refbox/refbox.h
+++ b/src/refbox/refbox.h
@@ -136,9 +136,9 @@ private: // methods
 	void         clips_mongodb_update(std::string collection, void *bson, CLIPS::Value query);
 	void         clips_mongodb_replace(std::string collection, void *bson, CLIPS::Value query);
 	void         clips_mongodb_insert(std::string collection, void *bson);
-	void         mongodb_update(std::string &                  collection,
+	void         mongodb_update(std::string                   &collection,
 	                            const bsoncxx::document::view &doc,
-	                            CLIPS::Value &                 query,
+	                            CLIPS::Value                  &query,
 	                            bool                           upsert);
 	CLIPS::Value clips_mongodb_query_sort(std::string collection, void *bson, void *bson_sort);
 	CLIPS::Value clips_mongodb_query(std::string collection, void *bson);
@@ -189,7 +189,7 @@ private: // methods
 	                               uint16_t                                      component_id,
 	                               uint16_t                                      msg_type,
 	                               std::string                                   msg);
-	void handle_peer_msg(boost::asio::ip::udp::endpoint &           endpoint,
+	void handle_peer_msg(boost::asio::ip::udp::endpoint            &endpoint,
 	                     uint16_t                                   component_id,
 	                     uint16_t                                   msg_type,
 	                     std::shared_ptr<google::protobuf::Message> msg);

--- a/src/shell/menus.cpp
+++ b/src/shell/menus.cpp
@@ -165,7 +165,7 @@ GenericItemsMenu::max_cols(int n_items, NCursesMenuItem **items)
 	return rv;
 }
 
-TeamSelectMenu::TeamSelectMenu(NCursesWindow *                       parent,
+TeamSelectMenu::TeamSelectMenu(NCursesWindow                        *parent,
                                llsf_msgs::Team                       team,
                                std::shared_ptr<llsf_msgs::GameInfo>  gameinfo,
                                std::shared_ptr<llsf_msgs::GameState> gstate)
@@ -237,7 +237,7 @@ TeamSelectMenu::On_Menu_Init()
 }
 
 int
-TeamSelectMenu::det_lines(std::shared_ptr<llsf_msgs::GameInfo> & gameinfo,
+TeamSelectMenu::det_lines(std::shared_ptr<llsf_msgs::GameInfo>  &gameinfo,
                           std::shared_ptr<llsf_msgs::GameState> &gstate)
 {
 	int rv = 0;
@@ -321,8 +321,8 @@ GameMenu::GameMenu(NCursesWindow *parent)
   menu_selected_(false)
 {
 	NCursesMenuItem **mitems         = new NCursesMenuItem *[3];
-	SignalItem *      randomize_item = new SignalItem(s_randomize_);
-	SignalItem *      cancel_item    = new SignalItem(s_cancel_);
+	SignalItem       *randomize_item = new SignalItem(s_randomize_);
+	SignalItem       *cancel_item    = new SignalItem(s_cancel_);
 	randomize_item->signal().connect([this]() {
 		next_menu_     = randomize;
 		menu_selected_ = true;
@@ -366,7 +366,7 @@ RandomizeFieldMenu::RandomizeFieldMenu(NCursesWindow *parent)
   confirmed_(false)
 {
 	NCursesMenuItem **mitems   = new NCursesMenuItem *[3];
-	SignalItem *      yes_item = new SignalItem(s_yes_);
+	SignalItem       *yes_item = new SignalItem(s_yes_);
 	yes_item->signal().connect([this]() { confirmed_ = true; });
 	SignalItem *no_item = new SignalItem(s_no_);
 	no_item->signal().connect([this]() { confirmed_ = false; });
@@ -390,7 +390,7 @@ RandomizeFieldMenu::On_Menu_Init()
 	refresh();
 }
 
-RobotMaintenanceMenu::RobotMaintenanceMenu(NCursesWindow *                       parent,
+RobotMaintenanceMenu::RobotMaintenanceMenu(NCursesWindow                        *parent,
                                            llsf_msgs::Team                       team,
                                            std::shared_ptr<llsf_msgs::RobotInfo> rinfo)
 : Menu(det_lines(team, rinfo) + 1 + 2,
@@ -529,7 +529,7 @@ RobotMaintenanceMenu::det_cols(std::shared_ptr<llsf_msgs::RobotInfo> &rinfo)
 	return cols;
 }
 
-OrderDeliverMenu::OrderDeliverMenu(NCursesWindow *                       parent,
+OrderDeliverMenu::OrderDeliverMenu(NCursesWindow                        *parent,
                                    llsf_msgs::Team                       team,
                                    std::shared_ptr<llsf_msgs::OrderInfo> oinfo,
                                    std::shared_ptr<llsf_msgs::GameState> gstate)
@@ -697,7 +697,7 @@ OrderDeliverMenu::operator bool() const
 	return show_all_selected_ || delivery_selected_;
 }
 
-SelectOrderByIDMenu::SelectOrderByIDMenu(NCursesWindow *                       parent,
+SelectOrderByIDMenu::SelectOrderByIDMenu(NCursesWindow                        *parent,
                                          llsf_msgs::Team                       team,
                                          std::shared_ptr<llsf_msgs::OrderInfo> oinfo,
                                          std::shared_ptr<llsf_msgs::GameState> gstate)
@@ -840,7 +840,7 @@ SelectOrderByIDMenu::operator bool() const
 	return order_selected_;
 }
 
-DeliveryCorrectMenu::DeliveryCorrectMenu(NCursesWindow *                       parent,
+DeliveryCorrectMenu::DeliveryCorrectMenu(NCursesWindow                        *parent,
                                          llsf_msgs::Team                       team,
                                          unsigned int                          delivery,
                                          std::shared_ptr<llsf_msgs::OrderInfo> oinfo)
@@ -855,7 +855,7 @@ DeliveryCorrectMenu::DeliveryCorrectMenu(NCursesWindow *                       p
   s_cancel_("CANCEL")
 {
 	NCursesMenuItem **mitems   = new NCursesMenuItem *[4];
-	SignalItem *      yes_item = new SignalItem(s_yes_);
+	SignalItem       *yes_item = new SignalItem(s_yes_);
 	yes_item->signal().connect(boost::bind(&DeliveryCorrectMenu::correct_selected, this, true));
 	int idx             = 0;
 	mitems[idx++]       = yes_item;

--- a/src/shell/menus.h
+++ b/src/shell/menus.h
@@ -122,7 +122,7 @@ private:
 class RobotMaintenanceMenu : public Menu
 {
 public:
-	RobotMaintenanceMenu(NCursesWindow *                       parent,
+	RobotMaintenanceMenu(NCursesWindow                        *parent,
 	                     llsf_msgs::Team                       team,
 	                     std::shared_ptr<llsf_msgs::RobotInfo> minfo);
 
@@ -151,7 +151,7 @@ private:
 class TeamSelectMenu : public Menu
 {
 public:
-	TeamSelectMenu(NCursesWindow *                       parent,
+	TeamSelectMenu(NCursesWindow                        *parent,
 	               llsf_msgs::Team                       team,
 	               std::shared_ptr<llsf_msgs::GameInfo>  gameinfo,
 	               std::shared_ptr<llsf_msgs::GameState> gstate);
@@ -164,7 +164,7 @@ public:
 
 private:
 	virtual void On_Menu_Init();
-	int          det_lines(std::shared_ptr<llsf_msgs::GameInfo> & gameinfo,
+	int          det_lines(std::shared_ptr<llsf_msgs::GameInfo>  &gameinfo,
 	                       std::shared_ptr<llsf_msgs::GameState> &gstate);
 	void         team_selected(std::string team_name);
 
@@ -260,7 +260,7 @@ private:
 class OrderDeliverMenu : public Menu
 {
 public:
-	OrderDeliverMenu(NCursesWindow *                       parent,
+	OrderDeliverMenu(NCursesWindow                        *parent,
 	                 llsf_msgs::Team                       team,
 	                 std::shared_ptr<llsf_msgs::OrderInfo> oinfo,
 	                 std::shared_ptr<llsf_msgs::GameState> gstate);
@@ -291,7 +291,7 @@ private:
 class SelectOrderByIDMenu : public Menu
 {
 public:
-	SelectOrderByIDMenu(NCursesWindow *                       parent,
+	SelectOrderByIDMenu(NCursesWindow                        *parent,
 	                    llsf_msgs::Team                       team,
 	                    std::shared_ptr<llsf_msgs::OrderInfo> oinfo,
 	                    std::shared_ptr<llsf_msgs::GameState> gstate);
@@ -316,7 +316,7 @@ private:
 class DeliveryCorrectMenu : public Menu
 {
 public:
-	DeliveryCorrectMenu(NCursesWindow *                       parent,
+	DeliveryCorrectMenu(NCursesWindow                        *parent,
 	                    llsf_msgs::Team                       team,
 	                    unsigned int                          delivery,
 	                    std::shared_ptr<llsf_msgs::OrderInfo> oinfo);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -801,7 +801,7 @@ LLSFRefBoxShell::client_msg(uint16_t                                   comp_id,
 		last_minfo_ = minfo;
 		for (int i = 0; i < minfo->machines_size(); ++i) {
 			std::map<std::string, LLSFRefBoxShellMachine *>::iterator mpanel;
-			const llsf_msgs::Machine &                                mspec = minfo->machines(i);
+			const llsf_msgs::Machine                                 &mspec = minfo->machines(i);
 			//logf("Adding %s @ (%f, %f, %f)\n", mspec.name().c_str(),
 			//     mspec.pose().x(), mspec.pose().y(), mspec.pose().ori());
 			if ((mpanel = machines_.find(mspec.name())) != machines_.end()) {
@@ -845,7 +845,7 @@ LLSFRefBoxShell::client_msg(uint16_t                                   comp_id,
 		const size_t size = std::min((size_t)ordins->orders_size(), (size_t)orders_.size());
 		size_t       oidx = 0;
 		for (size_t i = 0; i < size; ++i) {
-			const llsf_msgs::Order &          ospec = ordins->orders(i);
+			const llsf_msgs::Order           &ospec = ordins->orders(i);
 			std::vector<llsf_msgs::RingColor> ring_colors(ospec.ring_colors_size());
 			for (int j = 0; j < ospec.ring_colors_size(); ++j) {
 				ring_colors[j] = ospec.ring_colors(j);
@@ -892,8 +892,8 @@ void
 LLSFRefBoxShell::log(llsf_log_msgs::LogMessage::LogLevel log_level,
                      long int                            ts_sec,
                      long int                            ts_nsec,
-                     const std::string &                 component,
-                     const std::string &                 message)
+                     const std::string                  &component,
+                     const std::string                  &message)
 {
 	rb_log_->standend();
 	rb_log_->attron(' ' | COLOR_PAIR(COLOR_DEFAULT));
@@ -927,8 +927,8 @@ LLSFRefBoxShell::log(llsf_log_msgs::LogMessage::LogLevel log_level,
 
 void
 LLSFRefBoxShell::log(llsf_log_msgs::LogMessage::LogLevel log_level,
-                     const std::string &                 component,
-                     const char *                        format,
+                     const std::string                  &component,
+                     const char                         *format,
                      ...)
 {
 	va_list arg;
@@ -1154,7 +1154,7 @@ LLSFRefBoxShell::run()
 	// State menu
 	const google::protobuf::EnumDescriptor *state_enum_desc = llsf_msgs::GameState_State_descriptor();
 	const int                               num_state_values = state_enum_desc->value_count() - 1;
-	NCursesMenuItem **                      state_items = new NCursesMenuItem *[2 + num_state_values];
+	NCursesMenuItem                       **state_items = new NCursesMenuItem *[2 + num_state_values];
 	int                                     item_i      = 0;
 	for (int i = 0; i < state_enum_desc->value_count(); ++i) {
 		if (state_enum_desc->value(i)->name() == "INIT")
@@ -1180,7 +1180,7 @@ LLSFRefBoxShell::run()
 	// Phase menu
 	const google::protobuf::EnumDescriptor *phase_enum_desc = llsf_msgs::GameState_Phase_descriptor();
 	const int                               num_phase_values = phase_enum_desc->value_count();
-	NCursesMenuItem **                      phase_items = new NCursesMenuItem *[2 + num_phase_values];
+	NCursesMenuItem                       **phase_items = new NCursesMenuItem *[2 + num_phase_values];
 	size_t                                  max_length  = 0;
 	for (int i = 0; i < phase_enum_desc->value_count(); ++i) {
 		SignalItem *item = new SignalItem(phase_enum_desc->value(i)->name());

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -120,12 +120,12 @@ private: // methods
 	void log(llsf_log_msgs::LogMessage::LogLevel log_level,
 	         long int                            ts_sec,
 	         long int                            ts_nsec,
-	         const std::string &                 component,
-	         const std::string &                 message);
+	         const std::string                  &component,
+	         const std::string                  &message);
 
 	void log(llsf_log_msgs::LogMessage::LogLevel log_level,
-	         const std::string &                 component,
-	         const char *                        format,
+	         const std::string                  &component,
+	         const char                         *format,
 	         ...);
 
 	void logf(const char *format, ...);

--- a/src/tools/llsf-fake-robot.cpp
+++ b/src/tools/llsf-fake-robot.cpp
@@ -64,8 +64,8 @@ std::string                         name_;
 Team                                team_color_;
 std::string                         team_name_;
 unsigned long                       seq_          = 0;
-ProtobufBroadcastPeer *             peer_public_  = NULL;
-ProtobufBroadcastPeer *             peer_team_    = NULL;
+ProtobufBroadcastPeer              *peer_public_  = NULL;
+ProtobufBroadcastPeer              *peer_team_    = NULL;
 bool                                crypto_setup_ = false;
 
 llsfrb::Configuration *config_;
@@ -98,7 +98,7 @@ handle_send_error(std::string msg)
 }
 
 void
-handle_message(boost::asio::ip::udp::endpoint &           sender,
+handle_message(boost::asio::ip::udp::endpoint            &sender,
                uint16_t                                   component_id,
                uint16_t                                   msg_type,
                std::shared_ptr<google::protobuf::Message> msg)
@@ -233,7 +233,7 @@ handle_message(boost::asio::ip::udp::endpoint &           sender,
 		printf("MachineInfo received:\n");
 		for (int i = 0; i < mi->machines_size(); ++i) {
 			const Machine &m = mi->machines(i);
-			const Pose2D & p = m.pose();
+			const Pose2D  &p = m.pose();
 			printf("  %-3s|%2s|%s (%s) @ (%f, %f, %f)\n",
 			       m.name().c_str(),
 			       m.type().substr(0, 2).c_str(),
@@ -302,7 +302,7 @@ handle_timer(const boost::system::error_code &error)
 	if (!error) {
 		boost::posix_time::ptime               now(boost::posix_time::microsec_clock::universal_time());
 		std::shared_ptr<BeaconSignal>          signal(new BeaconSignal());
-		Time *                                 time        = signal->mutable_time();
+		Time                                  *time        = signal->mutable_time();
 		boost::posix_time::time_duration const since_epoch = now - boost::posix_time::from_time_t(0);
 
 		time->set_sec(static_cast<google::protobuf::int64>(since_epoch.total_seconds()));

--- a/src/tools/llsf-report-machine.cpp
+++ b/src/tools/llsf-report-machine.cpp
@@ -89,7 +89,7 @@ handle_send_error(std::string msg)
 }
 
 void
-handle_message(boost::asio::ip::udp::endpoint &           sender,
+handle_message(boost::asio::ip::udp::endpoint            &sender,
                uint16_t                                   component_id,
                uint16_t                                   msg_type,
                std::shared_ptr<google::protobuf::Message> msg)

--- a/src/tools/llsf-show-peers.cpp
+++ b/src/tools/llsf-show-peers.cpp
@@ -71,7 +71,7 @@ handle_send_error(std::string msg)
 }
 
 void
-handle_message(boost::asio::ip::udp::endpoint &           sender,
+handle_message(boost::asio::ip::udp::endpoint            &sender,
                uint16_t                                   component_id,
                uint16_t                                   msg_type,
                std::shared_ptr<google::protobuf::Message> msg)

--- a/src/tools/rcll-prepare-machine.cpp
+++ b/src/tools/rcll-prepare-machine.cpp
@@ -91,7 +91,7 @@ handle_send_error(std::string msg)
 }
 
 void
-handle_message(boost::asio::ip::udp::endpoint &           sender,
+handle_message(boost::asio::ip::udp::endpoint            &sender,
                uint16_t                                   component_id,
                uint16_t                                   msg_type,
                std::shared_ptr<google::protobuf::Message> msg)

--- a/src/tools/rcll-refbox-instruct.cpp
+++ b/src/tools/rcll-refbox-instruct.cpp
@@ -57,11 +57,11 @@ boost::asio::deadline_timer wait_refbox_timer_(io_service_);
 static bool                 wait_state_      = false;
 static unsigned int         wait_state_time_ = 0;
 boost::asio::deadline_timer wait_state_timer_(io_service_);
-ProtobufStreamClient *      client_ = NULL;
+ProtobufStreamClient       *client_ = NULL;
 static std::string          host_   = "localhost";
 static unsigned short int   port_   = 4444;
 
-llsf_msgs::SetTeamName * msg_team_cyan_ = NULL, *msg_team_magenta_ = NULL;
+llsf_msgs::SetTeamName  *msg_team_cyan_ = NULL, *msg_team_magenta_ = NULL;
 llsf_msgs::SetGamePhase *msg_phase_ = NULL;
 llsf_msgs::SetGameState *msg_state_ = NULL;
 

--- a/src/tools/rcll-reset-machine.cpp
+++ b/src/tools/rcll-reset-machine.cpp
@@ -88,7 +88,7 @@ handle_send_error(std::string msg)
 }
 
 void
-handle_message(boost::asio::ip::udp::endpoint &           sender,
+handle_message(boost::asio::ip::udp::endpoint            &sender,
                uint16_t                                   component_id,
                uint16_t                                   msg_type,
                std::shared_ptr<google::protobuf::Message> msg)

--- a/src/tools/rcll-set-machine-lights.cpp
+++ b/src/tools/rcll-set-machine-lights.cpp
@@ -162,7 +162,7 @@ main(int argc, char **argv)
 
 	//MessageRegister & message_register = client_->message_register();
 
-	char *             host      = (char *)"localhost";
+	char              *host      = (char *)"localhost";
 	unsigned short int port      = 4444;
 	bool               free_host = argp.parse_hostport("R", &host, &port);
 


### PR DESCRIPTION
The switch to f35 requires a full source tree reformat due to a bugfix in clang-format v13 (https://github.com/llvm/llvm-project/issues/27727).