### PR TITLE
cleanly start, terminate, reset and restart the refbox

### DIFF
--- a/cfg/comm/default_comm.yaml
+++ b/cfg/comm/default_comm.yaml
@@ -38,3 +38,8 @@ llsfrb:
       # port: !udp-port 4442
       send-port: !udp-port 4442
       recv-port: !udp-port 4447
+
+    # Turn this on if messages to instruct the refbox
+    # (SetTeamName, SetGameState, SetGamePhase)
+    # are also accepted from broadcast clients (e.g., the robots)
+    control-via-broadcast: false

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -433,6 +433,7 @@
   ?gf <- (gamestate (last-time $?last-time&:(neq ?last-time ?now)))
   (or (sim-time (enabled false))
       (gamestate (last-time $?last-time&:(neq ?last-time ?sim-time))))
+  (not (finalize))
   =>
   (bind ?now (get-time ?sts ?ste ?now ?sim-time ?lrt ?rtf))
   (modify ?gf (last-time ?now))
@@ -603,6 +604,14 @@
   else
     (game-summary)
   )
+)
+
+(defrule game-quit-after-finalize
+  (declare (salience ?*PRIORITY_LAST*))
+  (gamestate (phase POST_GAME))
+	(finalize)
+  =>
+  (exit)
 )
 
 (defrule game-over-on-finalize

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -586,6 +586,7 @@
 )
 
 (defrule game-goto-post-game
+  (declare (salience ?*PRIORITY_FIRST*))
   ?gs <- (gamestate (phase POST_GAME) (prev-phase ~POST_GAME))
   =>
   (modify ?gs (prev-phase POST_GAME) (end-time (now)))
@@ -607,15 +608,16 @@
 )
 
 (defrule game-quit-after-finalize
-  (declare (salience ?*PRIORITY_LAST*))
-  (gamestate (phase POST_GAME))
-	(finalize)
+  (declare (salience ?*PRIORITY_HIGH*))
+  (gamestate (phase POST_GAME) (end-time $?end-time))
+  (finalize)
   =>
   (exit)
 )
 
 (defrule game-over-on-finalize
 	"Switch to post-game if the refbox is stopped"
+	(declare (salience ?*PRIORITY_HIGH*))
 	(finalize)
 	?gs <- (gamestate (phase ~POST_GAME))
 	=>

--- a/src/games/rcll/init.clp
+++ b/src/games/rcll/init.clp
@@ -60,18 +60,6 @@
   (batch* (resolve-file (str-cat ?v ".clp")))
 )
 
-(defrule enable-debug
-  (init)
-  (confval (path "/llsfrb/clips/debug") (type BOOL) (value ?v))
-  =>
-  (if (eq ?v true) then
-    (printout t "CLIPS debugging enabled, watching facts and rules" crlf)
-    (watch facts)
-    (watch rules)
-    ;(dribble-on "trace.txt")
-  )
-)
-
 (defrule debug-level
   (init)
   (confval (path "/llsfrb/clips/debug-level") (type UINT) (value ?v))

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -514,7 +514,7 @@
 	(foreach ?m-type (deftemplate-slot-allowed-values machine mtype)
 		; for some reason clips crashes, if the meta-fact-name is passed
 		; on-the-fly. Therefore, store it via bind first.
-		(bind ?meta-fact-name (sym-cat (lowcase ?m-type -meta)))
+		(bind ?meta-fact-name (sym-cat (lowcase ?m-type) -meta))
 		(do-for-all-facts ((?meta-f ?meta-fact-name)) TRUE
 			(bind ?meta-doc (mongodb-fact-to-bson ?meta-f))
 			(bson-array-append ?m-arr ?meta-doc)
@@ -822,7 +822,7 @@
 	         (mongodb-load-facts-from-game-report ?report-name
 	                                              "ring-specs"
 	                                              ring-spec
-	                                              color))
+	                                              color)
 	         (mongodb-load-facts-from-game-report ?report-name
 	                                              "machine-meta"
 	                                              rs-meta

--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -92,3 +92,24 @@
   =>
   (ws-create-RingInfo)
 )
+
+(defrule ws-unwatch-all
+  (init)
+  =>
+  (bind ?ws-rules (create$
+    ws-send-attention-message
+    ws-reset-machine-by-team
+    ws-update-gamestate
+    ws-update-order
+    ws-update-unconfirmed-delivery
+    ws-update-order-external
+    ws-update-robot
+    ws-update-workpiece
+    ws-update-machine
+    ws-update-points
+    ws-update-ringspec
+  ))
+  (foreach ?r ?ws-rules
+    (unwatch rules ?r)
+  )
+)

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -190,6 +190,8 @@ LLSFRefBox::LLSFRefBox(int argc, char **argv)
 		logger_->add_logger(new FileLogger(logfile.c_str(), log_level_));
 	} catch (fawkes::Exception &e) {
 	} // ignored, use default
+	clips_ = std::make_unique<CLIPS::Environment>();
+	setup_clips();
 
 	cfg_machine_assignment_ = ASSIGNMENT_2014;
 	try {
@@ -212,9 +214,7 @@ LLSFRefBox::LLSFRefBox(int argc, char **argv)
 	                  "Using %s machine assignment",
 	                  (cfg_machine_assignment_ == ASSIGNMENT_2013) ? "2013" : "2014");
 
-	clips_ = std::make_unique<CLIPS::Environment>();
 	setup_protobuf_comm();
-	setup_clips();
 
 #ifdef HAVE_WEBSOCKETS
 	//launch websocket backend and add websocket logger
@@ -638,6 +638,10 @@ LLSFRefBox::setup_clips()
 		clips_logger_->add_logger(new FileLogger(logfile.c_str(), Logger::LL_DEBUG));
 	} catch (fawkes::Exception &e) {
 	} // ignored, use default
+	if (config_->get_bool_or_default("/llsfrb/clips/debug", false)) {
+		clips_->evaluate("(watch rules)");
+		clips_->evaluate("(watch facts)");
+	}
 
 	bool simulation = false;
 	try {

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -893,8 +893,8 @@ LLSFRefBox::clips_print_fact_list(CLIPS::Values facts, CLIPS::Values fields)
 		table_sep << std::left << std::setw(slot_value_length[slot_name]) << std::setfill('-') << "-"
 		          << "---";
 	}
-	logger_->log_info("C", table_header.str().c_str());
-	logger_->log_info("C", table_sep.str().c_str());
+	clips_logger_->log_info("C", table_header.str().c_str());
+	clips_logger_->log_info("C", table_sep.str().c_str());
 	for (auto &fact_id : fact_indices) {
 		std::stringstream row;
 		row << " | ";
@@ -906,7 +906,7 @@ LLSFRefBox::clips_print_fact_list(CLIPS::Values facts, CLIPS::Values fields)
 			row << std::left << std::setw(slot_value_length[slot_name]) << std::setfill(' ') << slot_str
 			    << " | ";
 		}
-		logger_->log_info("C", row.str().c_str());
+		clips_logger_->log_info("C", row.str().c_str());
 	}
 }
 


### PR DESCRIPTION
This PR addresses a few issues that were bugging me in the past:
 - Start the clips log as early as possible to not miss important logging steps
 - Exit the clips environment after finalize so that a single sigint signal actually can shut down the refbox
 - Shift logging of final stat tables to debug log to avoid malformed tables in frontend
 - Properly reset the refbox by also resetting machine meta information and order related stuff
 - Create new game reports if the refbox is reset
 - When the refbox is put to PRE_GAME, it is a full reset (e.g., new field gets generated, orders get randomized etc), if it is put back to SETUP instead, then machine positions and order setup remains stable, so it is merely restarted.

This PR depends on https://github.com/robocup-logistics/rcll-refbox/pull/135, hence it remains a draft for now and its base needs to be switched to the master, before opening it for review.