### PR TITLE
Machine generation fixes

### DIFF
--- a/src/games/rcll/exploration.clp
+++ b/src/games/rcll/exploration.clp
@@ -266,6 +266,7 @@
 	       (time $?t&:(timeout ?now ?t ?*BC-MACHINE-REPORT-INFO-PERIOD*)) (seq ?seq))
 	(network-peer (group CYAN) (id ?peer-id-cyan))
 	(network-peer (group MAGENTA) (id ?peer-id-magenta))
+	(machine-generation (state FINISHED))
 	=>
 	(modify ?sf (time ?now) (seq (+ ?seq 1)))
 

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -298,8 +298,8 @@
     (printout t "the machine generation is finished" crlf)
     (modify ?mg (state FINISHED))
    else
-    (printout warn "waiting for the generation of the machine positions" crlf)
-    (modify ?mg (generation-state-last-checked ?gt))
+    (printout warn "time-out for the generation of the machine positions, resetting game" crlf)
+    (assert (game-reset))
   )
 )
 

--- a/src/games/rcll/globals.clp
+++ b/src/games/rcll/globals.clp
@@ -121,7 +121,7 @@
   ?*RANDOMIZE-GAME* = TRUE
 	?*RANDOMIZE-STEPS-MACHINES* = 2
 	?*RANDOMIZE-ACTIVATE-ALL-AT-START* = FALSE
-	?*MACHINE-GENERATION-TIMEOUT-CHECK-STATE* = 1
+	?*MACHINE-GENERATION-TIMEOUT-CHECK-STATE* = 2
 	; Incremental randomization probability for switching the machines across
 	; field halfs. A value from 0 to 10, 0 no change, 10, always change
 	?*RANDOMIZE-INTER-SIDE-SWAP-PROB* = 3

--- a/src/games/rcll/net.clp
+++ b/src/games/rcll/net.clp
@@ -773,6 +773,7 @@
   (gamestate (phase ?phase))
   ?sf <- (signal (type machine-info)
 		 (time $?t&:(timeout ?now ?t ?*MACHINE-INFO-PERIOD*)) (seq ?seq))
+  (machine-generation (state FINISHED))
   =>
   (modify ?sf (time ?now) (seq (+ ?seq 1)))
   (bind ?s (pb-create "llsf_msgs.MachineInfo"))
@@ -810,6 +811,7 @@
   (network-peer (group CYAN) (id ?peer-id-cyan))
   (network-peer (group MAGENTA) (id ?peer-id-magenta))
   ?smu <- (send-machine-update)
+  (machine-generation (state FINISHED))
   =>
   (modify ?sf (time ?now) (seq (+ ?seq 1)) (count (+ ?count 1)))
 
@@ -833,6 +835,7 @@
 					       else ?*BC-MACHINE-INFO-BURST-PERIOD*))))
   (network-peer (group CYAN) (id ?peer-id-cyan))
   (network-peer (group MAGENTA) (id ?peer-id-magenta))
+  (machine-generation (state FINISHED))
   =>
   (modify ?sf (time ?now) (seq (+ ?seq 1)) (count (+ ?count 1)))
 
@@ -865,6 +868,7 @@
 								 (time $?t&:(timeout ?now ?t ?*BC-MACHINE-INFO-PERIOD*)))
   (network-peer (group CYAN) (id ?peer-id-cyan))
   (network-peer (group MAGENTA) (id ?peer-id-magenta))
+  (machine-generation (state FINISHED))
   =>
   (modify ?sf (time ?now) (seq (+ ?seq 1)) (count (+ ?count 1)))
 


### PR DESCRIPTION
This PR addresses https://github.com/robocup-logistics/rcll-refbox/issues/144 by 
- re-setting the game if machine generation is not completed after 5 checks 
- sending machine related messages only after generation is completed

It is a new version of #145 which was based on a faulty branch.