### PR TITLE
rcll: handle special order id 0 to consume products

### DIFF
--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -262,7 +262,7 @@
 )
 
 (deftemplate order
-  (slot id (type INTEGER))
+  (slot id (type INTEGER) (range 1 ?VARIABLE))
 
   ; Product specification
   (slot complexity (type SYMBOL) (allowed-values C0 C1 C2 C3))


### PR DESCRIPTION
Instead of dropping products to the floor, one can instruct the DS to consume the product. Instead of relying on existing order ids, a better way is to simply send id 0, which is treated differently.