### PR TITLE
Process agent tasks only once they actually ended

### DIFF
--- a/src/games/rcll/task-tracking.clp
+++ b/src/games/rcll/task-tracking.clp
@@ -16,6 +16,7 @@
                     (robot-id ?robot-id)
                     (unknown-action FALSE)
                     (processed FALSE)
+                    (end-time ~0.0)
                     (team-color ?team-color)
                     (task-parameters waypoint ?waypoint
                                      machine-point ?machine-point)
@@ -107,6 +108,7 @@
                     (robot-id ?robot-id)
                     (unknown-action FALSE)
                     (processed FALSE)
+                    (end-time ~0.0)
                     (team-color ?team-color)
                     (task-parameters machine-id ?machine-id
                                      machine-point ?machine-point)
@@ -264,6 +266,7 @@
                     (robot-id ?robot-id)
                     (unknown-action FALSE)
                     (processed FALSE)
+                    (end-time ~0.0)
                     (team-color ?team-color)
                     (task-parameters machine-id ?machine-id
                                      machine-point ?machine-point)
@@ -401,6 +404,7 @@
                     (robot-id ?robot-id)
                     (unknown-action FALSE)
                     (processed FALSE)
+                    (end-time ~0.0)
                     (team-color ?team-color)
                     (task-parameters machine-id ?machine-id
                                      shelf-number ?shelf-number)


### PR DESCRIPTION
Otherwise nasty side-effects can occur when placing workpieces down in quick succession at the same machine. As the refbox only updates the workpiece position (e.g., from input to output) once the processing step is advanced to processed.
Teams may in the meantime decide to start placing another product by aligning at the machine, hence sending a fresh agent task message before the input is actually cleared.