### PR TITLE
mps_placing_clips: do not shift generated field to magenta

### DIFF
--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -107,7 +107,7 @@
 			(bind ?zone (nth$ (+ (member$ ?m:name ?machines) 1) ?machines))
 			(bind ?rot (nth$ (+ (member$ ?m:name ?machines) 2) ?machines))
 			(printout t ?m:name ": " ?zone " with " ?rot crlf)
-			(modify ?m (zone ?zone) (rotation ?rot))
+			(modify ?m (zone (mirror-zone ?zone)) (rotation ?rot))
 		 else
 			(printout t ?m:name " not found in generation, skipping" crlf)
 			(retract ?m)

--- a/src/libs/mps_placing_clips/mps_placing_clips.cpp
+++ b/src/libs/mps_placing_clips/mps_placing_clips.cpp
@@ -224,7 +224,7 @@ MPSPlacingGenerator::get_generated_field()
 		default: type = "NOT-SET";
 		}
 		machines.push_back(CLIPS::Value(type.c_str(), CLIPS::TYPE_SYMBOL));
-		std::string zone = "M_Z" + std::to_string(pose.x_) + std::to_string(pose.y_);
+		std::string zone = "C_Z" + std::to_string(pose.x_) + std::to_string(pose.y_);
 		machines.push_back(CLIPS::Value(zone.c_str(), CLIPS::TYPE_SYMBOL));
 
 		int rotation = -2;


### PR DESCRIPTION
The constraints actually express a cyan field (positive x axis). By placing these machines into the magenta halve, we break constraints for placement of input-only mps (the delivery station). This setup on side cyan (where left is a delivery station of ratation 180 and the right is any station with input and output side and rotation 90.
```
 |`````| |    i    |
 | i   | |         |
 |_____| |    o    |
```
Adding them to the magenta sides results in the following illegal setup:
```
|    i    | |`````|
|         | | i   |
|    o    | |_____|
```
(The DS input side is blocked by the other station).

For now we can simply add the magenta machines to the cyan side and mirror their prosition.
The better solution would be to simply populate  the cyan side, that would be much cleaner code. However, this would also require further action (as the current fixation to magenta is the reason why the magenta field is used in the challenge track, while changing this we should update the rulebook).