### PR TITLE
Make field size configurable and send it via GameState messages

### DIFF
--- a/cfg/game/default_game.yaml
+++ b/cfg/game/default_game.yaml
@@ -25,3 +25,9 @@ llsfrb:
     store-to-report: ""
 
     exploration-time: 180
+
+    # the size of the field (7x8 default) and whether it should be mirrored
+    field:
+      width: 7
+      height: 8
+      mirrored: true

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -284,6 +284,7 @@
   (game-parameters (is-parameterized FALSE) (machine-positions RANDOM))
   =>
   (printout t "starting the solver for the generation of the machine positions" crlf)
+  (mps-generator-set-field ?*FIELD-WIDTH* ?*FIELD-HEIGHT*)
   (mps-generator-start)
   (modify ?mg (state STARTED) (generation-state-last-checked ?gt))
 )

--- a/src/games/rcll/globals.clp
+++ b/src/games/rcll/globals.clp
@@ -145,6 +145,8 @@
 
   ?*FIELD-WIDTH*  = (config-get-int "/llsfrb/game/field/width")
   ?*FIELD-HEIGHT* = (config-get-int "/llsfrb/game/field/height")
+  ?*FIELD-MIRRORED* = (config-get-bool "/llsfrb/game/field/mirrored")
+
 
   ?*ORDER-PRODUCTION-WINDOW-START-C0*  = 60
   ?*ORDER-PRODUCTION-WINDOW-START-C1*  = 120

--- a/src/games/rcll/globals.clp
+++ b/src/games/rcll/globals.clp
@@ -143,8 +143,8 @@
     M_Z12 M_Z22 M_Z32 M_Z42 M_Z52 M_Z62 M_Z72
     M_Z11 M_Z21 M_Z31 M_Z41)
 
-  ?*FIELD-WIDTH*  = 7
-  ?*FIELD-HEIGHT* = 8
+  ?*FIELD-WIDTH*  = (config-get-int "/llsfrb/game/field/width")
+  ?*FIELD-HEIGHT* = (config-get-int "/llsfrb/game/field/height")
 
   ?*ORDER-PRODUCTION-WINDOW-START-C0*  = 60
   ?*ORDER-PRODUCTION-WINDOW-START-C1*  = 120

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -142,7 +142,7 @@
 	)
 	; randomly assigned machines to zones using the external generator
 	(bind ?zones-magenta ?*MACHINE-ZONES-MAGENTA*)
-	(machine-retrieve-generated-mps TRUE)
+	(machine-retrieve-generated-mps (config-get-bool "/llsfrb/game/field/mirror"))
 
 
   ; Swap machines

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -142,7 +142,7 @@
 	)
 	; randomly assigned machines to zones using the external generator
 	(bind ?zones-magenta ?*MACHINE-ZONES-MAGENTA*)
-	(machine-retrieve-generated-mps (config-get-bool "/llsfrb/game/field/mirror"))
+	(machine-retrieve-generated-mps ?*FIELD-MIRRORED*)
 
 
   ; Swap machines

--- a/src/games/rcll/net.clp
+++ b/src/games/rcll/net.clp
@@ -545,6 +545,9 @@
   (if (neq ?team_magenta "") then
     (pb-set-field ?gamestate "team_magenta"  ?team_magenta))
 
+  (pb-set-field ?gamestate "field_width"  ?*FIELD-WIDTH*)
+  (pb-set-field ?gamestate "field_height" ?*FIELD-HEIGHT*)
+  (pb-set-field ?gamestate "field_mirrored" ?*FIELD-MIRRORED*)
   (return ?gamestate)
 )
 

--- a/src/msgs/GameState.proto
+++ b/src/msgs/GameState.proto
@@ -80,6 +80,11 @@ message GameState {
   optional uint32 points_magenta = 8;
   // Name of the currently playing team
   optional string team_magenta = 9;
+
+  // the field height and width, and mirroring status
+  optional uint32 field_height = 10;
+  optional uint32 field_width = 11;
+  optional bool field_mirrored = 12;
 }
 
 // Request setting of a new game state


### PR DESCRIPTION
Field size is variable according to the new rules but was not easy to configure. Additionally, teams often suffered from ill configured field sizes mismatching the actual size. This PR:
- makes field size easily configurable
- sends the field size to all teams via the GameState messages