### PR TITLE
WS: Multiple additions to WS data

### DIFF
--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -383,6 +383,10 @@
   (multislot teams (type STRING) (cardinality 2 2) (default "" ""))
 
   (slot over-time (type SYMBOL) (allowed-values FALSE TRUE) (default FALSE))
+
+  (slot field-height (type INTEGER) (default 8))
+  (slot field-width (type INTEGER) (default 7))
+  (slot field-mirrored (type SYMBOL) (allowed-values FALSE TRUE) (default TRUE))
 )
 
 (deftemplate exploration-report

--- a/src/games/rcll/facts.clp
+++ b/src/games/rcll/facts.clp
@@ -424,6 +424,7 @@
 (deftemplate points
   (slot points (type INTEGER))
   (slot team (type SYMBOL) (allowed-values CYAN MAGENTA))
+  (slot order (type INTEGER) (default 0))
   (slot game-time (type FLOAT))
   (slot phase (type SYMBOL) (allowed-values EXPLORATION PRODUCTION))
   (slot reason (type STRING))

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -443,14 +443,16 @@
 (defrule game-start-training
   ?gs <- (gamestate (teams "" "") (phase PRE_GAME) (state RUNNING))
   =>
-  (modify ?gs (phase SETUP) (prev-phase PRE_GAME) (game-time 0.0) (start-time (now)))
+  (modify ?gs (phase SETUP) (prev-phase PRE_GAME) (game-time 0.0) (start-time (now))
+    (field-height ?*FIELD-HEIGHT*) (field-width ?*FIELD-WIDTH*) (field-mirrored ?*FIELD-MIRRORED*))
   (assert (attention-message (text "Starting  *** TRAINING ***  game")))
 )
 
 (defrule game-start
   ?gs <- (gamestate (teams ?team_cyan ?team_magenta) (phase PRE_GAME) (state RUNNING))
   =>
-  (modify ?gs (phase SETUP) (prev-phase PRE_GAME) (start-time (now)))
+  (modify ?gs (phase SETUP) (prev-phase PRE_GAME) (start-time (now))
+    (field-height ?*FIELD-HEIGHT*) (field-width ?*FIELD-WIDTH*) (field-mirrored ?*FIELD-MIRRORED*))
   (assert (attention-message (text "Starting setup phase") (time 15)))
 )
 

--- a/src/games/rcll/orders.clp
+++ b/src/games/rcll/orders.clp
@@ -498,7 +498,7 @@
 		  (case C3 then (bind ?points ?*PRODUCTION-POINTS-DELIVER-C3*))
 		)
 		(assert (points (game-time ?delivery-time) (team ?team) (phase PRODUCTION)
-			                (points ?points) (product-step ?p-id) (reason "Delivered item for order")))
+			                (points ?points) (order ?id) (product-step ?p-id) (reason "Delivered item for order")))
 		(bind ?delivery-overtime (- ?delivery-time (nth$ 2 ?dp)))
 		(bind ?overtime-percentile 0.0)
 		(bind ?delivery-length (- (nth$ 2 ?dp) (nth$ 1 ?dp)))
@@ -511,7 +511,7 @@
 		)
 		(if (> ?overtime-percentile 0.0)
 		 then
-			(assert (points (game-time ?delivery-time) (team ?team) (phase PRODUCTION)
+			(assert (points (game-time ?delivery-time) (order ?id) (team ?team) (phase PRODUCTION)
 			  (points (- 0 (integer (* ?overtime-percentile
 			                  (* ?*PRODUCTION-POINTS-DELIVER-LATE-POINTS-DEDUCTION-REL* ?points)))))
 			  (product-step ?p-id) (reason (str-cat "Late delivery of order (>" ?overtime-percentile "% )"))))
@@ -522,12 +522,12 @@
 			 then
 				; the other team delivered first
 				(bind ?deduction (min ?points ?*PRODUCTION-POINTS-COMPETITIVE-SECOND-DEDUCTION*))
-				(assert (points (game-time ?delivery-time) (team ?team) (phase PRODUCTION)
+				(assert (points (game-time ?delivery-time) (order ?id) (team ?team) (phase PRODUCTION)
 				                (points (* -1 ?deduction)) (product-step ?p-id)
 				                (reason (str-cat "Second delivery for competitive order " ?id))))
 			 else
 				; this team delivered first
-				(assert (points (game-time ?delivery-time) (team ?team) (phase PRODUCTION)
+				(assert (points (game-time ?delivery-time) (order ?id) (team ?team) (phase PRODUCTION)
 				                (points ?*PRODUCTION-POINTS-COMPETITIVE-FIRST-BONUS*)
 				                (product-step ?p-id)
 				                (reason (str-cat "First delivery for competitive order " ?id))))
@@ -562,7 +562,7 @@
 	(modify ?pf (scored TRUE))
 	(printout warn "Delivered item for order " ?o-id " (too soon, before time window)" crlf)
 
-	(assert (points (game-time ?game-time) (points 0)
+	(assert (points (game-time ?game-time) (order ?o-id) (points 0)
 									(team ?team) (phase PRODUCTION) (product-step ?p-id)
 									(reason (str-cat "Delivered item for order " ?o-id
 																	 " (too soon, before time window)"))))
@@ -585,7 +585,7 @@
   (bind ?q-del-new (replace$ ?q-del ?q-del-idx ?q-del-idx (+ (nth$ ?q-del-idx ?q-del) 1)))
   (modify ?of (quantity-delivered ?q-del-new))
 
-	(assert (points (game-time ?game-time) (points ?*PRODUCTION-POINTS-DELIVERY-WRONG*)
+	(assert (points (game-time ?game-time) (order ?o-id) (points ?*PRODUCTION-POINTS-DELIVERY-WRONG*)
 									(team ?team) (phase PRODUCTION) (product-step ?p-id)
 									(reason (str-cat "Delivered item for order " ?o-id
 																	 " (too many)"))))
@@ -655,7 +655,7 @@
     (if (config-get-bool "/llsfrb/workpiece-tracking/enable") then (bind ?points 0))
     (bind ?reason (str-cat ?reason " Late (deadline: " (nth$ 2 ?dp) ")"))
   )
-  (assert (points (phase PRODUCTION) (game-time ?g-time) (team ?team)
+  (assert (points (phase PRODUCTION) (order ?o-id) (game-time ?g-time) (team ?team)
                   (points ?points) (product-step ?p-id)
                   (reason ?reason)))
   (modify ?pf (scored TRUE) (order ?o-id))
@@ -699,7 +699,7 @@
     (bind ?reason (str-cat ?reason " Late (deadline: " (nth$ 2 ?dp) ")"))
     (if (config-get-bool "/llsfrb/workpiece-tracking/enable") then (bind ?points 0))
   )
-  (assert (points (game-time ?g-time) (team ?team)
+  (assert (points (game-time ?g-time) (order ?o-id) (team ?team)
                   (points ?points)
                   (phase PRODUCTION) (product-step ?p-id)
                   (reason ?reason)))

--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -39,6 +39,7 @@
 (defrule ws-update-order
   "send update of an order, whenever the order fact changes"
   ?sf <- (order (id ?id))
+  (gamestate (phase PRODUCTION))
   =>
   (ws-create-OrderInfo ?id)
 )
@@ -46,6 +47,7 @@
 (defrule ws-update-unconfirmed-delivery
   "send update of an order, whenever the unconfirmed delivery information changes"
   ?sf <- (product-processed (order ?id))
+  (gamestate (phase PRODUCTION))
   =>
   (ws-create-OrderInfo ?id)
 )
@@ -53,6 +55,7 @@
 (defrule ws-update-order-external
   "send an update when the fact ws-update-order-cmd is asserted by an external rule or function"
   ?cmd <- (ws-update-order-cmd ?id)
+  (gamestate (phase PRODUCTION))
   =>
   (retract ?cmd)
   (ws-create-OrderInfo-via-delivery ?id)

--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -96,6 +96,13 @@
   (ws-create-RingInfo)
 )
 
+(defrule ws-update-known-teams
+  "send udpate of known teams whenever the known teams fact changes"
+  ?sf <- (known-teams $?)
+  =>
+  (ws-create-KnownTeams)
+)
+
 (defrule ws-unwatch-all
   (init)
   =>
@@ -111,6 +118,7 @@
     ws-update-machine
     ws-update-points
     ws-update-ringspec
+    ws-udpate-known-teams
   ))
   (foreach ?r ?ws-rules
     (unwatch rules ?r)

--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -118,7 +118,7 @@
     ws-update-machine
     ws-update-points
     ws-update-ringspec
-    ws-udpate-known-teams
+    ws-update-known-teams
   ))
   (foreach ?r ?ws-rules
     (unwatch rules ?r)

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -550,6 +550,16 @@ Data::log_push_workpiece_info(int id)
 }
 
 /**
+ * @brief Gets all known teams facts from CLIPS and pushes them to the send queue as an array
+ *
+ */
+void
+Data::log_push_known_teams()
+{
+	log_push(on_connect_known_teams());
+}
+
+/**
  * @brief Create a string of a JSON array containing the data of all current known teams facts
  *
  * @return std::string
@@ -1111,7 +1121,7 @@ Data::get_points_fact(T *o, rapidjson::Document::AllocatorType &alloc, CLIPS::Fa
 	(*o).AddMember("reason", json_string, alloc);
 	json_string.SetString((get_value<std::string>(fact, "team")).c_str(), alloc);
 	(*o).AddMember("team", json_string, alloc);
-	json_string.SetInt((get_value<int64_t>(fact, "order")), alloc);
+	json_string.SetInt((get_value<int64_t>(fact, "order")));
 	(*o).AddMember("order", json_string, alloc);
 	json_string.SetInt((get_value<int64_t>(fact, "points")));
 	(*o).AddMember("points", json_string, alloc);

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -1111,6 +1111,8 @@ Data::get_points_fact(T *o, rapidjson::Document::AllocatorType &alloc, CLIPS::Fa
 	(*o).AddMember("reason", json_string, alloc);
 	json_string.SetString((get_value<std::string>(fact, "team")).c_str(), alloc);
 	(*o).AddMember("team", json_string, alloc);
+	json_string.SetInt((get_value<int64_t>(fact, "order")), alloc);
+	(*o).AddMember("order", json_string, alloc);
 	json_string.SetInt((get_value<int64_t>(fact, "points")));
 	(*o).AddMember("points", json_string, alloc);
 	json_string.SetFloat((get_value<float>(fact, "game-time")));

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -990,6 +990,8 @@ Data::get_robot_info_fact(T                                  *o,
 	(*o).AddMember("number", json_string, alloc);
 	json_string.SetInt((get_value<int64_t>(fact, "port")));
 	(*o).AddMember("port", json_string, alloc);
+	json_string.SetBool((get_value<bool>(fact, "warning-sent")));
+	(*o).AddMember("warning_sent", json_string, alloc);
 	json_string.SetInt((get_value<int64_t>(fact, "maintenance-start-time")));
 	(*o).AddMember("maintenance_start-time", json_string, alloc);
 	json_string.SetInt((get_value<int64_t>(fact, "maintenance-cycles")));

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -1069,6 +1069,12 @@ Data::get_game_state_fact(T                                  *o,
 	(*o).AddMember("points_cyan", json_string, alloc);
 	json_string.SetString((get_values(fact, "points")[1]).c_str(), alloc);
 	(*o).AddMember("points_magenta", json_string, alloc);
+	json_string.SetInt((get_value<int64_t>(fact, "field-height")));
+	(*o).AddMember("field_height", json_string, alloc);
+	json_string.SetInt((get_value<int64_t>(fact, "field-width")));
+	(*o).AddMember("field_width", json_string, alloc);
+	json_string.SetBool((get_value<bool>(fact, "field-mirrored")));
+	(*o).AddMember("field_mirrored", json_string, alloc);
 }
 
 /**

--- a/src/libs/websocket/data.h
+++ b/src/libs/websocket/data.h
@@ -74,6 +74,7 @@ public:
 	void        log_push_machine_info(std::string name);
 	void        log_push_workpiece_info(int id);
 	void        log_push_order_info_via_delivery(int delivery_id);
+	void        log_push_known_teams();
 	std::string on_connect_known_teams();
 	std::string on_connect_machine_info();
 	std::string on_connect_order_info();

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -2124,6 +2124,10 @@ LLSFRefBox::setup_clips_websocket()
 	                       sigc::mem_fun(*(backend_->get_data()),
 	                                     &websocket::Data::log_push_order_info_via_delivery)));
 
+	clips_->add_function("ws-create-KnownTeams",
+	                     sigc::slot<void>(sigc::mem_fun(*(backend_->get_data()),
+	                                                    &websocket::Data::log_push_known_teams)));
+
 	//define functions that set facts in the CLIPS environment to control the refbox
 	backend_->get_data()->clips_set_gamestate = [this](std::string state_string) {
 		fawkes::MutexLocker clips_lock(&clips_mutex_);


### PR DESCRIPTION
This PR addresses multiple issues related to the backend for the Webfrontend. In particular it:
- closes #163 by including field information in the game state
- addresses #164 (this will not be fixed, but the data is now sent periodically, which was a limitation before)
- closes #165 by including the "warning-sent" slot
- closes #168 by adding order information to points wherever it is available