### PR TITLE
Add game time to attention message, use phase time for maintenance

### DIFF
--- a/src/games/rcll/robots.clp
+++ b/src/games/rcll/robots.clp
@@ -44,10 +44,10 @@
 )
 
 (defrule robot-maintenance-warning
-  (gamestate (cont-time ?ctime))
+  (gamestate (cont-time ?ctime) (game-time ?game-time))
   ?rf <- (robot (state MAINTENANCE) (number ?number) (name ?name) (team ?team)
 		(maintenance-warning-sent FALSE)
-		(maintenance-start-time ?st&:(timeout-sec ?ctime ?st ?*MAINTENANCE-WARN-TIME*)))
+		(maintenance-start-time ?st&:(timeout-sec ?game-time ?st ?*MAINTENANCE-WARN-TIME*)))
 
   =>
   (modify ?rf (maintenance-warning-sent TRUE))
@@ -57,9 +57,9 @@
 )
 
 (defrule robot-disqualify-maintenance-timeout
-  (gamestate (cont-time ?ctime))
+  (gamestate (cont-time ?ctime) (game-time ?game-time))
   ?rf <- (robot (state MAINTENANCE) (number ?number) (name ?name) (team ?team)
-		(maintenance-start-time ?st&:(timeout-sec ?ctime ?st (+ ?*MAINTENANCE-ALLOWED-TIME* ?*MAINTENANCE-GRACE-TIME*))))
+		(maintenance-start-time ?st&:(timeout-sec ?game-time ?st (+ ?*MAINTENANCE-ALLOWED-TIME* ?*MAINTENANCE-GRACE-TIME*))))
 
   =>
   (modify ?rf (state DISQUALIFIED))
@@ -111,7 +111,7 @@
         (printout t "Robot " ?robot:number " scheduled for maintenance cycle " ?cycle crlf)
         ; update the maintenance state
         (bind ?state MAINTENANCE)
-        (bind ?maintenance-start-time ?ctime)
+        (bind ?maintenance-start-time ?game-time)
         (bind ?maintenance-cycles ?cycle)
         (bind ?maintenance-warning-sent FALSE)
         (bind ?cycle-cost (nth$ ?cycle ?*MAINTENANCE-COST*))

--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -10,9 +10,10 @@
 (defrule ws-send-attention-message
   "forward attention messages to the websocket backend"
   ?msg <- (ws-attention-message ?text ?team ?time-to-show)
+  (gamestate (game-time ?gt))
   =>
   (retract ?msg)
-  (ws-send-attention-message (str-cat ?text) (str-cat ?team) (str-cat ?time-to-show))
+  (ws-send-attention-message (str-cat ?text) (str-cat ?team) (str-cat ?time-to-show) ?gt)
 )
 
 (defrule ws-reset-machine-by-team

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -247,7 +247,10 @@ Data::clients_send_all(rapidjson::Document &d)
  * @param time
  */
 void
-Data::log_push_attention_message(std::string text, std::string team, std::string time)
+Data::log_push_attention_message(std::string text,
+                                 std::string team,
+                                 std::string time_to_display,
+                                 float       game_time)
 {
 	rapidjson::Document d;
 	d.SetObject();
@@ -260,8 +263,10 @@ Data::log_push_attention_message(std::string text, std::string team, std::string
 	d.AddMember("text", json_string, alloc);
 	json_string.SetString((team).c_str(), alloc);
 	d.AddMember("team", json_string, alloc);
-	json_string.SetString((time).c_str(), alloc);
-	d.AddMember("time", json_string, alloc);
+	json_string.SetString((time_to_display).c_str(), alloc);
+	d.AddMember("time_to_display", json_string, alloc);
+	json_string.SetFloat(game_time);
+	d.AddMember("game_time", json_string, alloc);
 
 	log_push(d);
 }

--- a/src/libs/websocket/data.h
+++ b/src/libs/websocket/data.h
@@ -45,15 +45,18 @@ class Data
 {
 public:
 	Data(std::shared_ptr<Logger> logger, CLIPS::Environment *env, fawkes::Mutex &env_mutex);
-	std::string log_pop();
-	void        log_push(std::string log);
-	void        log_push(rapidjson::Document &d);
-	bool        log_empty();
-	void        log_wait();
-	void        clients_add(std::shared_ptr<Client> client);
-	void        clients_send_all(std::string msg);
-	void        clients_send_all(rapidjson::Document &d);
-	void        log_push_attention_message(std::string text, std::string team, std::string time);
+	std::string                                      log_pop();
+	void                                             log_push(std::string log);
+	void                                             log_push(rapidjson::Document &d);
+	bool                                             log_empty();
+	void                                             log_wait();
+	void                                             clients_add(std::shared_ptr<Client> client);
+	void                                             clients_send_all(std::string msg);
+	void                                             clients_send_all(rapidjson::Document &d);
+	void                                             log_push_attention_message(std::string text,
+	                                                                            std::string team,
+	                                                                            std::string time_to_display,
+	                                                                            float       game_time);
 	std::function<void(std::string)>                 clips_set_gamestate;
 	std::function<void(std::string)>                 clips_set_gamephase;
 	std::function<void()>                            clips_randomize_field;

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -2084,7 +2084,7 @@ LLSFRefBox::setup_clips_websocket()
 	//define the functions called by CLIPS
 
 	clips_->add_function("ws-send-attention-message",
-	                     sigc::slot<void, std::string, std::string, std::string>(
+	                     sigc::slot<void, std::string, std::string, std::string, float>(
 	                       sigc::mem_fun(*(backend_->get_data()),
 	                                     &websocket::Data::log_push_attention_message)));
 


### PR DESCRIPTION
This PR addresses #171 and #172

Requires a fix in the refbox frontend for attention messages to be compatible due to a renamed field (see comment on #171 )