### PR TITLE
clips-logger: also print buffer if line ends with .

### DIFF
--- a/src/refbox/clips_logger.cpp
+++ b/src/refbox/clips_logger.cpp
@@ -89,7 +89,7 @@ CLIPSLogger::~CLIPSLogger()
 void
 CLIPSLogger::log(const char *logical_name, const char *str)
 {
-	if (strcmp(str, "\n") == 0) {
+	if (strcmp(str, "\n") == 0 || strcmp(str, ".\n") == 0) {
 		if (strcmp(logical_name, "debug") == 0) {
 			logger_->log_debug(component_ ? component_ : "CLIPS", "%s", buffer_.c_str());
 		} else if (strcmp(logical_name, WTRACE) == 0) {


### PR DESCRIPTION
Error messages when the execution is halted do not end with \n but with .\n for some reason...
With this fix, the refbox will properly print error such as:

```
09:56:46.641570 C: [TMPLTDEF1] Invalid slot complexity not defined in corresponding deftemplate order
09:56:46.641764 C: [PRCCODE4] Execution halted during the actions of deffunction net-create-Order
09:56:46.641983 C: [PRCCODE4] Execution halted during the actions of deffunction net-create-OrderInfo
09:56:46.642147 C: [PRCCODE4] Execution halted during the actions of defrule net-send-OrderInfo
```