### PR TITLE
ws: send numerical values as numericals via WS

### DIFF
--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -69,6 +69,13 @@
   (ws-create-RobotInfo ?number ?name)
 )
 
+(defrule ws-update-agent-task
+  "send update of an agent task, whenever the agent task fact changes"
+  ?sf <- (agent-task (task-id ?tid) (robot-id ?rid))
+  =>
+  (ws-create-AgentTaskInfo ?tid ?rid)
+)
+
 (defrule ws-update-workpiece
   "send update of a workpiece, whenever the workpiece fact changes"
   ?sf <- (workpiece (id ?id) (latest-data TRUE))

--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -13,7 +13,7 @@
   (gamestate (game-time ?gt))
   =>
   (retract ?msg)
-  (ws-send-attention-message (str-cat ?text) (str-cat ?team) (str-cat ?time-to-show) ?gt)
+  (ws-send-attention-message (str-cat ?text) (str-cat ?team) ?time-to-show ?gt)
 )
 
 (defrule ws-reset-machine-by-team

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -249,7 +249,7 @@ Data::clients_send_all(rapidjson::Document &d)
 void
 Data::log_push_attention_message(std::string text,
                                  std::string team,
-                                 std::string time_to_display,
+                                 int         time_to_display,
                                  float       game_time)
 {
 	rapidjson::Document d;
@@ -263,7 +263,7 @@ Data::log_push_attention_message(std::string text,
 	d.AddMember("text", json_string, alloc);
 	json_string.SetString((team).c_str(), alloc);
 	d.AddMember("team", json_string, alloc);
-	json_string.SetString((time_to_display).c_str(), alloc);
+	json_string.SetInt(time_to_display);
 	d.AddMember("time_to_display", json_string, alloc);
 	json_string.SetFloat(game_time);
 	d.AddMember("game_time", json_string, alloc);
@@ -732,11 +732,11 @@ Data::on_connect_info(std::string tmpl_name,
 
 /**
  * @brief Gets data of the saved known-teams on the refbox side to support user input
- * 
- * @tparam T 
- * @param o 
- * @param alloc 
- * @param fact 
+ *
+ * @tparam T
+ * @param o
+ * @param alloc
+ * @param fact
  */
 template <class T>
 void
@@ -895,19 +895,19 @@ Data::get_order_info_fact(T                                  *o,
 	json_string.SetInt((get_value<int64_t>(fact, "activate-at")));
 	(*o).AddMember("activate_at", json_string, alloc);
 	rapidjson::Value delivery_array(rapidjson::kArrayType);
-	delivery_array.Reserve(get_values(fact, "delivery-period").size(), alloc);
-	for (const auto &e : get_values(fact, "delivery-period")) {
+	delivery_array.Reserve(fact->slot_value("delivery-period").size(), alloc);
+	for (auto value : fact->slot_value("delivery-period")) {
 		rapidjson::Value v;
-		v.SetString(e, alloc);
+		v.SetInt(value.as_integer());
 		delivery_array.PushBack(v, alloc);
 	}
 	(*o).AddMember("delivery_period", delivery_array, alloc);
 
 	rapidjson::Value quantity_array(rapidjson::kArrayType);
-	quantity_array.Reserve(get_values(fact, "quantity-delivered").size(), alloc);
-	for (const auto &e : get_values(fact, "quantity-delivered")) {
+	quantity_array.Reserve(fact->slot_value("quantity-delivered").size(), alloc);
+	for (auto value : fact->slot_value("quantity-delivered")) {
 		rapidjson::Value v;
-		v.SetString(e, alloc);
+		v.SetInt(value.as_integer());
 		quantity_array.PushBack(v, alloc);
 	}
 	(*o).AddMember("quantity_delivered", quantity_array, alloc);
@@ -1019,19 +1019,19 @@ Data::get_robot_info_fact(T                                  *o,
 	(*o).AddMember("maintenance_warning_sent", json_string, alloc);
 
 	rapidjson::Value last_seen_array(rapidjson::kArrayType);
-	last_seen_array.Reserve(get_values(fact, "last-seen").size(), alloc);
-	for (const auto &e : get_values(fact, "last-seen")) {
+	last_seen_array.Reserve(fact->slot_value("last-seen").size(), alloc);
+	for (auto value : fact->slot_value("last-seen")) {
 		rapidjson::Value v;
-		v.SetString(e, alloc);
+		v.SetFloat(value.as_float());
 		last_seen_array.PushBack(v, alloc);
 	}
 	(*o).AddMember("last_seen", last_seen_array, alloc);
 
 	rapidjson::Value pose_array(rapidjson::kArrayType);
-	pose_array.Reserve(get_values(fact, "pose").size(), alloc);
-	for (const auto &e : get_values(fact, "pose")) {
+	pose_array.Reserve(fact->slot_value("pose").size(), alloc);
+	for (auto value : fact->slot_value("pose")) {
 		rapidjson::Value v;
-		v.SetString(e, alloc);
+		v.SetFloat(value.as_float());
 		pose_array.PushBack(v, alloc);
 	}
 	(*o).AddMember("pose", pose_array, alloc);
@@ -1072,9 +1072,9 @@ Data::get_game_state_fact(T                                  *o,
 	(*o).AddMember("cyan", json_string, alloc);
 	json_string.SetString((get_values(fact, "teams")[1]).c_str(), alloc);
 	(*o).AddMember("magenta", json_string, alloc);
-	json_string.SetString((get_values(fact, "points")[0]).c_str(), alloc);
+	json_string.SetInt(fact->slot_value("points")[0].as_integer());
 	(*o).AddMember("points_cyan", json_string, alloc);
-	json_string.SetString((get_values(fact, "points")[1]).c_str(), alloc);
+	json_string.SetInt(fact->slot_value("points")[1].as_integer());
 	(*o).AddMember("points_magenta", json_string, alloc);
 	json_string.SetInt((get_value<int64_t>(fact, "field-height")));
 	(*o).AddMember("field_height", json_string, alloc);

--- a/src/libs/websocket/data.h
+++ b/src/libs/websocket/data.h
@@ -55,7 +55,7 @@ public:
 	void                                             clients_send_all(rapidjson::Document &d);
 	void                                             log_push_attention_message(std::string text,
 	                                                                            std::string team,
-	                                                                            std::string time_to_display,
+	                                                                            int         time_to_display,
 	                                                                            float       game_time);
 	std::function<void(std::string)>                 clips_set_gamestate;
 	std::function<void(std::string)>                 clips_set_gamephase;

--- a/src/libs/websocket/data.h
+++ b/src/libs/websocket/data.h
@@ -73,6 +73,7 @@ public:
 	void        log_push_ring_spec();
 	void        log_push_game_state();
 	void        log_push_robot_info(int number, std::string name);
+	void        log_push_agent_task_info(int tid, int rid);
 	void        log_push_order_info(int id);
 	void        log_push_machine_info(std::string name);
 	void        log_push_workpiece_info(int id);
@@ -101,6 +102,10 @@ public:
 	template <class T>
 	void
 	get_robot_info_fact(T *o, rapidjson::Document::AllocatorType &alloc, CLIPS::Fact::pointer fact);
+	template <class T>
+	void get_agent_task_info_fact(T                                  *o,
+	                              rapidjson::Document::AllocatorType &alloc,
+	                              CLIPS::Fact::pointer                fact);
 	template <class T>
 	void
 	get_game_state_fact(T *o, rapidjson::Document::AllocatorType &alloc, CLIPS::Fact::pointer fact);

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -2084,7 +2084,7 @@ LLSFRefBox::setup_clips_websocket()
 	//define the functions called by CLIPS
 
 	clips_->add_function("ws-send-attention-message",
-	                     sigc::slot<void, std::string, std::string, std::string, float>(
+	                     sigc::slot<void, std::string, std::string, int, float>(
 	                       sigc::mem_fun(*(backend_->get_data()),
 	                                     &websocket::Data::log_push_attention_message)));
 

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -2096,6 +2096,10 @@ LLSFRefBox::setup_clips_websocket()
 	                     sigc::slot<void, int, std::string>(
 	                       sigc::mem_fun(*(backend_->get_data()),
 	                                     &websocket::Data::log_push_robot_info)));
+	clips_->add_function("ws-create-AgentTaskInfo",
+	                     sigc::slot<void, int, int>(
+	                       sigc::mem_fun(*(backend_->get_data()),
+	                                     &websocket::Data::log_push_agent_task_info)));
 
 	clips_->add_function("ws-create-MachineInfo",
 	                     sigc::slot<void, std::string>(


### PR DESCRIPTION
This PR addresses #186 and #187.

Websocket communication improvements:
- numerical values that used to be sent as string are now serialised as numericals in the json messages
- agent tasks are now communicated via websockets