### PR TITLE
fix images not building on quay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ RUN shopt -s globstar; \
     /usr/lib/rpm/rpmdeps -R lib/** bin/** | grep -v -f provides.txt > requires.txt
 
 FROM fedora:38 as refbox
+RUN   dnf update -y --refresh && dnf install -y --nodocs 'dnf-command(copr)' && \
+      dnf -y copr enable thofmann/clips-6.31 && \
+      dnf -y copr enable tavie/clips_protobuf
 COPY --from=buildenv /buildenv/bin/* /usr/local/bin/
 COPY --from=buildenv /buildenv/lib/* /usr/local/lib64/
 COPY --from=buildenv /buildenv/src/games /usr/local/share/rcll-refbox/games

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,3 @@ COPY --from=buildenv /buildenv/requires.txt /
 RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && /sbin/ldconfig
 RUN dnf install -y --nodocs $(cat /requires.txt) && dnf clean all && rm /requires.txt
 CMD ["llsf-refbox"]
-
-FROM builder as devcontainer
-ARG USER_NAME
-ENV USER_NAME=$USER_NAME
-RUN useradd -u 1000 $USER_NAME

--- a/devcontainer.Dockerfile
+++ b/devcontainer.Dockerfile
@@ -1,0 +1,4 @@
+FROM builder as devcontainer
+ARG USER_NAME
+ENV USER_NAME=$USER_NAME
+RUN useradd -u 1000 $USER_NAME


### PR DESCRIPTION
There were 2 problems with the Dockerfile.
1. thrid-party repos were not enabled at final image, which caused the installation to fail.
2. the devcontainer only works with an arg, hence the build on quay failed due to no provided arg.

With the fixes to the above problem the containers build normally again:
https://quay.io/repository/robocup-logistics/rcll-refbox/build/2f575a61-122c-4568-a80d-6c595bf18cc0
