### PR TITLE
do not shift cyan field to magenta.

### DIFF
--- a/src/games/rcll/challenges.clp
+++ b/src/games/rcll/challenges.clp
@@ -395,7 +395,8 @@
 	(challenges-route (id ?r-id) (team-color ?col) (remaining $?zones&:(member$ (pose-to-zone ?x ?y) ?zones)))
 	(not (challenges-zone-visit (robot-number ?n) (team-color ?col)))
 	(not (challenges-zone-visit (team-color ?col) (route-id ?r-id)))
-	(gamestate (game-time ?gt) (phase PRODUCTION) (state RUNNING))
+	(gamestate (phase PRODUCTION) (state RUNNING))
+	(time-info (game-time ?gt))
 =>
 	(assert (challenges-zone-visit (route-id ?r-id) (team-color ?col)
 	(robot-number ?n) (visited-zone (pose-to-zone ?x ?y)) (visit-start ?gt)))
@@ -404,13 +405,15 @@
 	(robot (number ?n) (team-color ?col) (pose ?x ?y ?z) (state ACTIVE))
 	?zv <- (challenges-zone-visit (robot-number ?n) (team-color ?col)
 	         (visited-zone ?zone&:(neq ?zone (pose-to-zone ?x ?y))))
-	(gamestate (game-time ?gt) (phase PRODUCTION) (state RUNNING))
+	(gamestate (phase PRODUCTION) (state RUNNING))
+	(time-info (game-time ?gt))
 =>
 	(retract ?zv)
 )
 
 (defrule challenges-zone-visit-success
-	(gamestate (game-time ?gt) (phase PRODUCTION) (state RUNNING))
+	(gamestate (phase PRODUCTION) (state RUNNING))
+	(time-info (game-time ?gt))
 	?route <- (challenges-route (team-color ?col) (id ?r-id)
 	  (remaining $?remaining) (reached $?reached))
 	?zv <- (challenges-zone-visit (team-color ?col) (route-id ?r-id)

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -99,7 +99,7 @@
 	(return (if (eq ?prefix "C") then CYAN else MAGENTA))
 )
 
-(deffunction machine-retrieve-generated-mps (?mirror)
+(deffunction machine-retrieve-generated-mps ()
 	(bind ?machines (mps-generator-get-generated-field))
 	(delayed-do-for-all-facts ((?m machine)) (and (eq ?m:team CYAN) (eq ?m:zone TBD))
 		(if (member$ ?m:name ?machines)
@@ -116,15 +116,9 @@
 	; Mirror machines for other team
 	(delayed-do-for-all-facts ((?mm machine)) (eq ?mm:team CYAN)
 		(do-for-fact ((?mc machine)) (and (eq ?mm:name (mirror-name ?mc:name)) (eq ?mc:team MAGENTA))
-		(if ?mirror then
 			(modify ?mc
 			  (zone (mirror-zone ?mm:zone))
 			  (rotation (mirror-orientation ?mm:mtype ?mm:zone ?mm:rotation))
-			)
-		 else
-			(modify ?mc
-			  (zone ?mm:zone)
-			  (rotation ?mm:rotation))
 			)
 		)
 	)
@@ -142,27 +136,28 @@
 	)
 	; randomly assigned machines to zones using the external generator
 	(bind ?zones-magenta ?*MACHINE-ZONES-MAGENTA*)
-	(machine-retrieve-generated-mps ?*FIELD-MIRRORED*)
+	(machine-retrieve-generated-mps)
 
+	(if ?*FIELD-MIRRORED* then
+		; Swap machines
+		(bind ?machines-to-swap
+		(create$ (str-cat "RS" (random 1 2)) (str-cat "CS" (random 1 2))))
+		(foreach ?ms ?machines-to-swap
+			(do-for-fact ((?m-cyan machine) (?m-magenta machine))
+			    (and (eq ?m-cyan:team CYAN) (eq ?m-cyan:name (sym-cat C- ?ms))
+			         (eq ?m-magenta:team MAGENTA) (eq ?m-magenta:name (sym-cat M- ?ms)))
 
-  ; Swap machines
-	(bind ?machines-to-swap
-    (create$ (str-cat "RS" (random 1 2)) (str-cat "CS" (random 1 2))))
-	(foreach ?ms ?machines-to-swap
-		(do-for-fact ((?m-cyan machine) (?m-magenta machine))
-		    (and (eq ?m-cyan:team CYAN) (eq ?m-cyan:name (sym-cat C- ?ms))
-		         (eq ?m-magenta:team MAGENTA) (eq ?m-magenta:name (sym-cat M- ?ms)))
+			  (printout t "Swapping " ?m-cyan:name " with " ?m-magenta:name crlf)
 
-		  (printout t "Swapping " ?m-cyan:name " with " ?m-magenta:name crlf)
-
-		  (bind ?z-cyan ?m-cyan:zone)
-		  (bind ?r-cyan ?m-cyan:rotation)
-		  (bind ?z-magenta ?m-magenta:zone)
-		  (bind ?r-magenta ?m-magenta:rotation)
-		  (modify ?m-cyan    (zone ?z-magenta) (rotation ?r-magenta))
-		  (modify ?m-magenta (zone ?z-cyan) (rotation ?r-cyan))
+			  (bind ?z-cyan ?m-cyan:zone)
+			  (bind ?r-cyan ?m-cyan:rotation)
+			  (bind ?z-magenta ?m-magenta:zone)
+			  (bind ?r-magenta ?m-magenta:rotation)
+			  (modify ?m-cyan    (zone ?z-magenta) (rotation ?r-magenta))
+			  (modify ?m-magenta (zone ?z-cyan) (rotation ?r-cyan))
+			)
 		)
-  )
+	)
 )
 
 (deffunction machine-randomize-machine-setup ()

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -101,7 +101,7 @@
 
 (deffunction machine-retrieve-generated-mps (?mirror)
 	(bind ?machines (mps-generator-get-generated-field))
-	(delayed-do-for-all-facts ((?m machine)) (and (eq ?m:team MAGENTA) (eq ?m:zone TBD))
+	(delayed-do-for-all-facts ((?m machine)) (and (eq ?m:team CYAN) (eq ?m:zone TBD))
 		(if (member$ ?m:name ?machines)
 		 then
 			(bind ?zone (nth$ (+ (member$ ?m:name ?machines) 1) ?machines))
@@ -114,8 +114,8 @@
 		)
 	)
 	; Mirror machines for other team
-	(delayed-do-for-all-facts ((?mm machine)) (eq ?mm:team MAGENTA)                 ; for each MAGENTA
-		(do-for-fact ((?mc machine)) (and (eq ?mm:name (mirror-name ?mc:name)) (eq ?mc:team CYAN))  ; get the CYAN
+	(delayed-do-for-all-facts ((?mm machine)) (eq ?mm:team CYAN)
+		(do-for-fact ((?mc machine)) (and (eq ?mm:name (mirror-name ?mc:name)) (eq ?mc:team MAGENTA))
 		(if ?mirror then
 			(modify ?mc
 			  (zone (mirror-zone ?mm:zone))

--- a/src/libs/mps_placing_clips/mps_placing_clips.cpp
+++ b/src/libs/mps_placing_clips/mps_placing_clips.cpp
@@ -214,17 +214,17 @@ MPSPlacingGenerator::get_generated_field()
 	for (MPSPlacingPlacing pose : poses) {
 		std::string type = "";
 		switch (pose.type_) {
-		case BASE: type = "M-BS"; break;
-		case DELIVERY: type = "M-DS"; break;
-		case STORAGE: type = "M-SS"; break;
-		case CAP1: type = "M-CS1"; break;
-		case CAP2: type = "M-CS2"; break;
-		case RING1: type = "M-RS1"; break;
-		case RING2: type = "M-RS2"; break;
+		case BASE: type = "C-BS"; break;
+		case DELIVERY: type = "C-DS"; break;
+		case STORAGE: type = "C-SS"; break;
+		case CAP1: type = "C-CS1"; break;
+		case CAP2: type = "C-CS2"; break;
+		case RING1: type = "C-RS1"; break;
+		case RING2: type = "C-RS2"; break;
 		default: type = "NOT-SET";
 		}
 		machines.push_back(CLIPS::Value(type.c_str(), CLIPS::TYPE_SYMBOL));
-		std::string zone = "M_Z" + std::to_string(pose.x_) + std::to_string(pose.y_);
+		std::string zone = "C_Z" + std::to_string(pose.x_) + std::to_string(pose.y_);
 		machines.push_back(CLIPS::Value(zone.c_str(), CLIPS::TYPE_SYMBOL));
 
 		int rotation = -2;


### PR DESCRIPTION
This PR superseedes https://github.com/robocup-logistics/rcll-refbox/pull/153.
~It is currently rooted on https://github.com/robocup-logistics/rcll-refbox/pull/180, which should be merged first.~

~Once the merge is done, this branch should further update the grasping challenge field layout.~

Original PR messages below:

The constraints actually express a cyan field (positive x axis). By placing these machines into the magenta halve, we break constraints for placement of input-only mps (the delivery station). This setup on side cyan (where left is a delivery station of ratation 180 and the right is any station with input and output side and rotation 90.
```
 |`````| |    i    |
 | i   | |         |
 |_____| |    o    |
```
Adding them to the magenta sides results in the following illegal setup:
```
|    i    | |`````|
|         | | i   |
|    o    | |_____|
```
(The DS input side is blocked by the other station).

~For now we can simply add the magenta machines to the cyan side and mirror their prosition.~
~The better solution would be to simply populate  the cyan side, that would be much cleaner code. However, this would also require further action (as the current fixation to magenta is the reason why the magenta field is used in the challenge track, while changing this we should update the rulebook).~