### PR TITLE
Improve sending of VersionInfo and migrate to mongodb 7 scripts

### DIFF
--- a/etc/scripts/drop_reports.bash
+++ b/etc/scripts/drop_reports.bash
@@ -25,7 +25,7 @@ read -p "Are you sure? [Yy]" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-	mongo rcll --eval 'db.game_report.drop()'
+	mongosh rcll --eval 'db.game_report.drop()'
 else
 	echo "abort"
 fi

--- a/etc/scripts/generate_benchmarks.bash
+++ b/etc/scripts/generate_benchmarks.bash
@@ -28,7 +28,7 @@ if [ -z "$1" ] || [ -z "$2" ]
 		exit
 fi
 
-mongo --eval "print(\"Test for connection\")" &>/dev/null
+mongosh --eval "print(\"Test for connection\")" &>/dev/null
 if [ $? -ne 0 ]
 	then
 		echo "Mongo instance not running, abort."
@@ -50,8 +50,7 @@ trap cleanup $TRAP_SIGNALS
 
 for i in  $(seq 1 $NUM_BENCHMARKS)
 do
-	DOC_COUNT=$(mongo rcll --eval "db.game_report.count({\"report_name\": \"${NAME_PREFIX}_${i}\"})" --quiet)
-
+	DOC_COUNT=$(mongosh rcll --eval "db.game_report.countDocuments({\"report_name\": \"${NAME_PREFIX}_${i}\"})" --quiet)
 	# make sure that the report name is fresh
 	if [ ${DOC_COUNT} -ne 0 ]; then
 		echo "Skipping ${NAME_PREFIX}_${i} as a report already exists"
@@ -75,7 +74,7 @@ do
 			sleep 1
 			killall -15 llsf-refbox  &>/dev/null &
 			sleep 1
-			DOC_COUNT=$(mongo rcll --eval "db.game_report.count({\"report_name\": \"${NAME_PREFIX}_${i}\"})" --quiet)
+			DOC_COUNT=$(mongosh rcll --eval "db.game_report.countDocuments({\"report_name\": \"${NAME_PREFIX}_${i}\"})" --quiet)
 		done
 		echo "Created report for ${NAME_PREFIX}_${i}"
 	fi

--- a/src/games/rcll/globals.clp
+++ b/src/games/rcll/globals.clp
@@ -35,7 +35,7 @@
   ?*BC-ORDERINFO-BURST-COUNT* = 10
   ; How often and in what period should the version information
   ; be send over the network when a new peer is detected?
-  ?*BC-VERSIONINFO-PERIOD* = 0.5
+  ?*BC-VERSIONINFO-PERIOD* = 5.0
   ?*BC-VERSIONINFO-COUNT* = 10
   ; Minimum and maximum machine down times, actual value will be
   ; chosen randomly from this range

--- a/src/games/rcll/net.clp
+++ b/src/games/rcll/net.clp
@@ -979,7 +979,7 @@
 (defrule net-send-VersionInfo
   (time $?now)
   ?sf <- (signal (type version-info) (seq ?seq)
-		 (count ?count&:(< ?count ?*BC-VERSIONINFO-COUNT*))
+		 (count ?count)
 		 (time $?t&:(timeout ?now ?t ?*BC-VERSIONINFO-PERIOD*)))
   (network-peer (group PUBLIC) (id ?peer-id-public))
   =>


### PR DESCRIPTION
Its quite annoying that VersionInfo can be missed, hence send it continuously, albeit with a low frequency.