### PR TITLE
rcll: fix occupied zones being in wrong format

### DIFF
--- a/src/games/rcll/challenges.clp
+++ b/src/games/rcll/challenges.clp
@@ -83,7 +83,7 @@
 	)
 	(do-for-all-facts ((?m machine)) TRUE
 		(if (neq ?m:zone TBD) then
-			(bind ?occupied (append$ ?occupied ?m:zone))
+			(bind ?occupied (append$ ?occupied (sym-cat (sub-string 3 5 ?m:zone))))
 		)
 	)
 	; remove occupied zones


### PR DESCRIPTION
the free zones are just ZXY, why the machine zones are M_ZXY