### PR TITLE
opcua: probe connection and port before attempting to connect via opcua

### DIFF
--- a/src/libs/mps_comm/opcua/machine.h
+++ b/src/libs/mps_comm/opcua/machine.h
@@ -123,6 +123,7 @@ protected:
 	void cancelAllSubscriptions(bool log = false);
 	// Print the final subscription values
 	void printFinalSubscribtions();
+	bool probeIpAndPort(const std::string &ip, int port);
 
 	const Station     machine_type_;
 	const std::string ip_;


### PR DESCRIPTION
This hopefully prevents spurious crashes of the refbox if mashines are not connected.