### PR TITLE
rcll: remove doubled proc-start increase on down

### DIFF
--- a/src/games/rcll/production.clp
+++ b/src/games/rcll/production.clp
@@ -225,7 +225,7 @@
 		  (down-period $?dp&:(< (nth$ 2 ?dp) ?gt)))
   =>
 	(printout t "Machine " ?name " is up again" crlf)
-	(modify ?mf (state ?prev-state) (proc-start (+ ?proc-start (- (nth$ 2 ?dp) (nth$ 1 ?dp)))))
+	(modify ?mf (state ?prev-state))
   (assert (send-machine-update))
 )
 


### PR DESCRIPTION
The proc-start is already increased by the down duratiom. when the machine goes down.
Increasing it again when it is coming up again is wrong.