### PR TITLE
websocket: distinguish robots by team

### DIFF
--- a/src/games/rcll/websocket.clp
+++ b/src/games/rcll/websocket.clp
@@ -88,9 +88,9 @@
 
 (defrule ws-update-robot
   "send update of a robot, whenever the robot fact changes"
-  ?sf <- (robot (number ?number) (name ?name))
+  ?sf <- (robot (number ?number) (name ?name) (team ?team))
   =>
-  (ws-create-RobotInfo ?number ?name)
+  (ws-create-RobotInfo ?number ?name ?team)
 )
 
 (defrule ws-update-agent-task

--- a/src/libs/websocket/data.cpp
+++ b/src/libs/websocket/data.cpp
@@ -555,7 +555,7 @@ Data::log_push_order_info_via_delivery(int delivery_id)
  *
  */
 void
-Data::log_push_robot_info(int number, std::string name)
+Data::log_push_robot_info(int number, std::string name, std::string team)
 {
 	MutexLocker lock(&env_mutex_);
 
@@ -565,6 +565,7 @@ Data::log_push_robot_info(int number, std::string name)
 		if (match(fact, "robot")) {
 			try {
 				if (get_value<int64_t>(fact, "number") == number
+				    && get_value<std::string>(fact, "team") == team
 				    && get_value<std::string>(fact, "name") == name) {
 					facts.push_back(fact);
 				}

--- a/src/libs/websocket/data.h
+++ b/src/libs/websocket/data.h
@@ -81,7 +81,7 @@ public:
 	void        log_push_cfg_preset(const std::string &category, const std::string &preset);
 	void        log_push_game_state();
 	void        log_push_time_info();
-	void        log_push_robot_info(int number, std::string name);
+	void        log_push_robot_info(int number, std::string name, std::string team);
 	void        log_push_agent_task_info(int tid, int rid);
 	void        log_push_order_info(int id);
 	void        log_push_machine_info(std::string name);

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -2156,7 +2156,7 @@ LLSFRefBox::setup_clips_websocket()
 	                                                    &websocket::Data::log_push_time_info)));
 
 	clips_->add_function("ws-create-RobotInfo",
-	                     sigc::slot<void, int, std::string>(
+	                     sigc::slot<void, int, std::string, std::string>(
 	                       sigc::mem_fun(*(backend_->get_data()),
 	                                     &websocket::Data::log_push_robot_info)));
 	clips_->add_function("ws-create-AgentTaskInfo",


### PR DESCRIPTION
This PR attempts to fix issues when robots of different teams share the same name.

At the moment the robot info does not sufficiently check uniqueness of robots as it only uses the name not the team.
There might be other places where the same error occurs, hence this is a draft PR for now until it is investigated further.