### PR TITLE
fix bugs in data pipeline

### DIFF
--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -435,7 +435,7 @@
 			; for some reason clips crashes, if the meta-fact-name is passed
 			; on-the-fly. Therefore, store it via bind first.
 			(bind ?meta-fact-name (sym-cat (lowcase ?m-type) -meta))
-			(bind ?machine-meta-facts (find-fact ((?m ?meta-fact-name)) (eq ?m-name ?m-name)))
+			(bind ?machine-meta-facts (find-fact ((?m ?meta-fact-name)) (eq ?m-name ?m:name)))
 			(if ?machine-meta-facts then
 			  (bind ?meta-fact (nth$ 1 ?machine-meta-facts))
 			)

--- a/src/games/rcll/net.clp
+++ b/src/games/rcll/net.clp
@@ -213,12 +213,14 @@
     (bind ?team-color (pb-field-value ?at "team_color"))
     (bind ?task-id (pb-field-value ?at "task_id"))
     (bind ?robot-id (pb-field-value ?at "robot_id"))
+    (bind ?start-time ?gt)
 
     ; if agent task does not exist, create one
     (do-for-fact ((?agent-task agent-task)) (and (eq ?agent-task:team-color ?team-color)
                                                         (eq ?agent-task:task-id ?task-id)
                                                         (eq ?agent-task:robot-id ?robot-id))
       (if (eq ?agent-task:processed FALSE) then
+        (bind ?start-time ?agent-task:start-time)
         (printout ?*AGENT-TASK-ROUTER* "delete old agent-task" crlf)
         (retract ?agent-task)
        else
@@ -304,7 +306,7 @@
                         (task-id ?task-id)
                         (robot-id ?robot-id)
                         (team-color ?team-color)
-                        (start-time ?gt)
+                        (start-time ?start-time)
                         (end-time 0.0)
                         (order-id ?order-id)
                         (successful ?successful)


### PR DESCRIPTION
Due to recent debugging sessions, we detected some bugs in the data pipeline.
One regards broken timestamps in agent task messages, the other is about wrongly assigned meta facts for machine histories.