### PR TITLE
improve dynamic field loading

### DIFF
--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -252,6 +252,7 @@
 )
 
 (defrule game-init-parameterization-from-config
+	(gamestate (phase ~PRE_GAME))
 	?gt <- (game-parameters (is-initialized FALSE))
 	(confval (path "/llsfrb/game/random-field") (type BOOL) (value ?random-field))
 	(confval (path "/llsfrb/game/random-machine-setup") (type BOOL) (value ?random-machine-setup))

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -746,6 +746,7 @@
 	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
 	(confval (path "/llsfrb/game/restore-gamestate/enable") (type BOOL) (value TRUE))
 	(confval (path "/llsfrb/game/restore-gamestate/phase") (type STRING) (value ?p))
+	(game-parameters (is-initialized TRUE))
 	=>
 	(bind ?success FALSE)
 	(bind ?t-doc (mongodb-retrieve-report ?report-name))
@@ -771,7 +772,7 @@
 	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
 	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
 	(confval (path "/llsfrb/game/default-storage") (type BOOL) (value FALSE))
-	?gp <- (game-parameters (storage-status PENDING))
+	?gp <- (game-parameters (storage-status PENDING) (is-initialized TRUE))
 	=>
 	(printout t "Loading storage from database" crlf)
 	(if (mongodb-load-all-facts-from-game-report ?report-name
@@ -792,7 +793,7 @@
 	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
 	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
 	(confval (path "/llsfrb/game/random-orders") (type BOOL) (value FALSE))
-	?gp <- (game-parameters (orders PENDING))
+	?gp <- (game-parameters (orders PENDING) (is-initialized TRUE))
 	=>
 	(printout t "Loading orders from database" crlf)
 	(if (mongodb-load-all-facts-from-game-report ?report-name
@@ -819,7 +820,7 @@
 	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
 	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
 	(confval (path "/llsfrb/game/random-machine-setup") (type BOOL) (value FALSE))
-	?gp <- (game-parameters (machine-setup PENDING))
+	?gp <- (game-parameters (machine-setup PENDING) (is-initialized TRUE))
 	=>
 	(printout t "Loading machine setup from database" crlf)
 	(if (and (mongodb-load-all-facts-from-game-report ?report-name
@@ -852,7 +853,7 @@
 	(gamestate (phase SETUP|EXPLORATION|PRODUCTION) (prev-phase PRE_GAME))
 	(not (confval (path "/llsfrb/game/random-field") (type BOOL) (value TRUE)))
 	(confval (path "/llsfrb/game/load-from-report") (type STRING) (value ?report-name))
-	?gp <- (game-parameters (machine-positions PENDING))
+	?gp <- (game-parameters (machine-positions PENDING) (is-initialized TRUE))
 	?mg <- (machine-generation (state NOT-STARTED))
 	=>
 	(modify ?mg (state FINISHED))


### PR DESCRIPTION
The idea of this PR is to easily allow teams to build their own field setups, save them and load them again with improved frontend-sided reconfiguration.

The workflow to modify and save a field is as follows:
1) start a game regularly, including the setting of at least one team.
2) go to field view (pressing "watch" in the frontend) and move the field around to your liking per drag and drop
3) go to referee view again (pressing "referee" in the frontend)
4) change the config value "store-to-report" to a name of your choice in the "config" tab
 
The workflow to load the modified field is as follows:
1) start the refbox, but leave it in PRE-GAME (by not pressing "start-game")
2) change the config value "load-from-report" to the chosen name in the "config" tab
3) change the config value "random-field" to "true" in the config tab.
4) press "start-game" and proceed as usual.
Note: experienced users can of course pre-configure the yaml files of the refbox directly to always load the saved field.