### PR TITLE
Tviehmann/points post game

### DIFF
--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -412,8 +412,7 @@
 (defrule game-update-gametime-points
   (declare (salience ?*PRIORITY_FIRST*))
   (time $?now)
-  ?gf <- (gamestate (phase SETUP|EXPLORATION|PRODUCTION) (points $?old-points)
-		    (state RUNNING))
+  ?gf <- (gamestate (points $?old-points))
   ?ti <- (time-info (game-time ?game-time) (cont-time ?cont-time)
 		    (last-time $?last-time&:(neq ?last-time ?now)))
   ?st <- (sim-time (enabled ?sts) (estimate ?ste) (now $?sim-time)

--- a/src/games/rcll/game.clp
+++ b/src/games/rcll/game.clp
@@ -612,12 +612,8 @@
            (eq ?cfg:value "mockup"))
     (printout warn "Please add points for remaining bases in slide of "
                    (str-cat ?m:name) " manually." crlf))
-  (if (any-factp ((?pd referee-confirmation)) TRUE) then
-    (assert (attention-message (text "Game ended, please confirm deliveries!")))
-    (assert (postgame-for-unconfirmed-deliveries))
-  else
-    (game-summary)
-  )
+  (assert (attention-message (text "Game ended, please confirm deliveries!")))
+  (assert (postgame-for-unconfirmed-deliveries))
 )
 
 (defrule game-quit-after-finalize

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -636,7 +636,7 @@
 (defrule mongodb-game-report-new-phase-update
 	(declare (salience ?*PRIORITY_HIGHER*))
 	(time $?now)
-	(gamestate (phase ?p) (state RUNNING)
+	(gamestate (phase ?p) (state PAUSED|RUNNING)
 	     (teams $?teams&:(neq ?teams (create$ "" "")))
 	     (start-time $?stime) (end-time $?etime))
 	?pc <- (mongodb-phase-change (registered-phases $?phases&:(not (member$ ?p ?phases))))

--- a/src/games/rcll/mongodb.clp
+++ b/src/games/rcll/mongodb.clp
@@ -648,7 +648,7 @@
 )
 
 
-(defrule mongodb-game-report-update
+(defrule mongodb-game-report-update-running
 	(declare (salience ?*PRIORITY_HIGHER*))
 	(time $?now)
 	(gamestate (state RUNNING)
@@ -656,9 +656,28 @@
 	     (start-time $?stime) (end-time $?etime)
 	     (points $?points))
 	?gr <- (mongodb-game-report (points $?gr-points) (name ?report-name)
-	     (last-updated $?last-updated&:(or
-	       (neq $?points $?gr-points)
-	       (timeout $?now $?last-updated ?*MONGODB-REPORT-UPDATE-FREQUENCY*))))
+	     (last-updated $?last-updated&:
+	       (timeout $?now $?last-updated ?*MONGODB-REPORT-UPDATE-FREQUENCY*)))
+	=>
+	(modify ?gr (points $?points) (last-updated $?now))
+	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime ?report-name)
+)
+
+(defrule mongodb-game-report-update-post-game-points
+" Specifically useful to update the points in POST_GAME.
+  Actually redundant given the report also saves on finalize,
+  but just to be sure also update ad-hoc.
+  This also hopefully avoids mistakes if the report is dumped before
+  the refbox is closed.
+"
+	(declare (salience ?*PRIORITY_HIGHER*))
+	(time $?now)
+	(gamestate
+	     (teams $?teams&:(neq ?teams (create$ "" "")))
+	     (start-time $?stime) (end-time $?etime)
+	     (points $?points))
+	?gr <- (mongodb-game-report (points $?gr-points) (name ?report-name)
+	     (last-updated $?last-updated&:(neq $?points $?gr-points)))
 	=>
 	(modify ?gr (points $?points) (last-updated $?now))
 	(mongodb-write-game-report (mongodb-create-game-report ?teams ?stime ?etime ?report-name) ?stime ?report-name)

--- a/src/games/rcll/orders.clp
+++ b/src/games/rcll/orders.clp
@@ -173,7 +173,7 @@
 
 (defrule order-delivery-confirmation-referee-confirmed-simulate-tracking
   ?gf <- (gamestate (phase PRODUCTION|POST_GAME))
-  ?rf <- (referee-confirmation (process-id ?id) (state CONFIRMED))
+  (referee-confirmation (process-id ?id) (state CONFIRMED))
   ?pf <- (product-processed (id ?id) (team ?team) (order ?order) (confirmed FALSE)
                             (workpiece 0) (game-time ?delivery-time))
   ?of <- (order (id ?order) (active TRUE))
@@ -182,7 +182,17 @@
   =>
   (bind ?wp-id (workpiece-simulate-tracking ?order ?team ?delivery-time))
   (modify ?pf (workpiece ?wp-id) (confirmed TRUE))
-  (retract ?rf)
+)
+
+(defrule order-delivery-confirmation-referee-confirmed-points-done
+  (declare (salience ?*PRIORITY_HIGHER*))
+  (gamestate (phase PRODUCTION|POST_GAME))
+  ?rc <- (referee-confirmation (process-id ?id) (state CONFIRMED))
+  (product-processed (id ?id) (team ?team) (order ?order) (confirmed TRUE))
+  ?of <- (order (id ?order) (active TRUE))
+  (not (product-processed (order ?order) (confirmed TRUE) (scored FALSE)))
+  =>
+  (retract ?rc)
 )
 
 (defrule order-delivery-confirmation-referee-confirmed-DS-read-fail-recovery


### PR DESCRIPTION
Fixes https://github.com/robocup-logistics/rcll-refbox/issues/156.

The frontend already handles points correctly, but there were indeed some issues regarding mongodb, especially while the refbox was still in POST-GAME, the report was not updated.
Reports were updated only properly once the refbox actually closed, this is now handled better.