### PR TITLE
improve machine active flag handling

### DIFF
--- a/src/games/rcll/challenges.clp
+++ b/src/games/rcll/challenges.clp
@@ -10,13 +10,6 @@
 ;---------------------------------------------------------------------------
 
 (defglobal
-	?*BASE-STATION* = 1
-	?*CAP1-STATION* = 2
-	?*CAP2-STATION* = 3
-	?*RING1-STATION* = 4
-	?*RING2-STATION* = 5
-	?*STORAGE-STATION* = 6
-	?*DELIVERY-STATION* = 7
 	?*PRIORITY_CHALLENGE-OVERRIDE* = 100
 	?*FIELD-WIDTH*  = (config-get-int "/llsfrb/challenges/field/width")
 	?*FIELD-HEIGHT* = (config-get-int "/llsfrb/challenges/field/height")
@@ -96,21 +89,6 @@
 		)
 	)
 	(assert (challenges-field (free-zones ?free) (occupied-zones ?occupied)))
-)
-
-(deffunction machine-to-id (?mps)
-	(switch ?mps
-		(case BS then (return ?*BASE-STATION*))
-		(case CS1 then (return ?*CAP1-STATION*))
-		(case CS2 then (return ?*CAP2-STATION*))
-		(case RS1 then (return ?*RING1-STATION*))
-		(case RS2 then (return ?*RING2-STATION*))
-		(case SS then (return ?*STORAGE-STATION*))
-		(case DS then (return ?*DELIVERY-STATION*))
-	)
-	(printout error "machine-to-id: unsupported machine: "
-	  ?mps " Expected BS|CS1|CS2|RS1|RS2|SS|DS" crlf)
-	(return 0)
 )
 
 (defrule challenges-create-routes

--- a/src/games/rcll/globals.clp
+++ b/src/games/rcll/globals.clp
@@ -182,4 +182,13 @@
   ?*AGENT-TASK-ROUTER*  = debug
 
   ?*MOCKUP-READY-AT-OUTPUT-TIMEOUT* = 15
+
+  ; index notation for mps generation
+  ?*BASE-STATION* = 1
+  ?*CAP1-STATION* = 2
+  ?*CAP2-STATION* = 3
+  ?*RING1-STATION* = 4
+  ?*RING2-STATION* = 5
+  ?*STORAGE-STATION* = 6
+  ?*DELIVERY-STATION* = 7
 )

--- a/src/games/rcll/machines.clp
+++ b/src/games/rcll/machines.clp
@@ -285,3 +285,29 @@
   )
   (retract ?cmd)
 )
+
+(defrule machine-remove-machine-from-game
+(declare (salience ?*PRIORITY_FIRST*))
+  ?m <- (machine (name ?name) (mtype ?t))
+  (confval (path ?p&:(eq ?p (str-cat "/llsfrb/mps/stations/" ?name "/active"))) (type BOOL) (value FALSE))
+  =>
+  (retract ?m)
+  (mps-generator-remove-machine (machine-to-id ?t))
+)
+
+(defrule machine-add-machine-to-game
+(declare (salience ?*PRIORITY_FIRST*))
+  (confval (path ?p) (type BOOL) (value TRUE))
+  (not (machine (name ?name&:(not (str-index ?name ?p)))))
+  =>
+  (bind ?end-index (- (str-index "/active" ?p) 1))
+  (bind ?start-index (+ (str-index "stations/" ?p) 9))
+  (bind ?m-name (sym-cat (sub-string ?start-index ?end-index ?p)))
+  (bind ?color-index (sub-string 1 1 ?m-name))
+  (bind ?type (sym-cat (sub-string 3 (str-length ?m-name) ?m-name)))
+
+  (bind ?team CYAN)
+  (if (eq ?color-index "M") then (bind ?team MAGENTA))
+  (assert (machine (name ?m-name) (team ?team) (mtype ?type)))
+  (mps-generator-add-machine (machine-to-id ?type))
+)

--- a/src/games/rcll/utils.clp
+++ b/src/games/rcll/utils.clp
@@ -517,3 +517,18 @@
   (if (eq ?machine-name M-SS) then (return (create$ 242 241)))
   (return FALSE)
 )
+
+(deffunction machine-to-id (?mps)
+	(switch ?mps
+		(case BS then (return ?*BASE-STATION*))
+		(case CS1 then (return ?*CAP1-STATION*))
+		(case CS2 then (return ?*CAP2-STATION*))
+		(case RS1 then (return ?*RING1-STATION*))
+		(case RS2 then (return ?*RING2-STATION*))
+		(case SS then (return ?*STORAGE-STATION*))
+		(case DS then (return ?*DELIVERY-STATION*))
+	)
+	(printout error "machine-to-id: unsupported machine: "
+	  ?mps " Expected BS|CS1|CS2|RS1|RS2|SS|DS" crlf)
+	(return 0)
+)

--- a/src/refbox/refbox.cpp
+++ b/src/refbox/refbox.cpp
@@ -196,7 +196,7 @@ LLSFRefBox::LLSFRefBox(int argc, char **argv)
 	std::stringstream refbox_call;
 	for (int i = 0; i < argc; ++i)
 		refbox_call << " " << argv[i];
-	logger_->log_info("RefBox", "%s", refbox_call.str().c_str());
+	logger_->log_info("RefBox", "%s (%i args)", refbox_call.str().c_str(), argc);
 
 	setup_protobuf_comm();
 


### PR DESCRIPTION
Previously, inactive machines were treated inconsistantly. The C++ objects were not created, but CLIPS treated the machines normally.
Instead, remove machines from generation and delete them from the WM if needed.
NOTE: Since the generation does not distinguish between CYAN and MAGENTA machines, this means setting a machine of either side to inactive effectively disables the machine of the other team as well.
Similarly, toggling back from inactive state only makes sense if the respective machine from the other team is also toggled back to active.